### PR TITLE
docs: fix typo

### DIFF
--- a/docs/docs/api-reference/core/useRecoilState.md
+++ b/docs/docs/api-reference/core/useRecoilState.md
@@ -25,7 +25,7 @@ const tempFahrenheit = atom({
 
 const tempCelcius = selector({
   key: 'tempCelcius',
-  get: ({get}) => ((get(temptempFahrenheit) - 32) * 5) / 9,
+  get: ({get}) => ((get(tempFahrenheit) - 32) * 5) / 9,
   set: ({set}, newValue) => set(tempFahrenheit, (newValue * 9) / 5 + 32),
 });
 


### PR DESCRIPTION
fixed a typo in docs for useRecoilState example