### PR TITLE
Fixed typo in atomFamily.md

### DIFF
--- a/docs/docs/api-reference/utils/atomFamily.md
+++ b/docs/docs/api-reference/utils/atomFamily.md
@@ -45,7 +45,7 @@ function ElementListItem({elementID}) {
 };
 ```
 
-A `familyAtom()` takes almost the same options as a simple `atom()`.  However, the default value can also be parameterized. That means you could provide a function which takes the parameter value and returns the actual default value.  For example:
+A `atomFamily()` takes almost the same options as a simple `atom()`.  However, the default value can also be parameterized. That means you could provide a function which takes the parameter value and returns the actual default value.  For example:
 
 ```js
 const myAtomFamily = atomFamily({


### PR DESCRIPTION
Replaced "familyAtom()" with "atomFamily()".