### PR TITLE
Disable variable name mangling in terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "recoil",
   "version": "0.0.7",
   "description": "Recoil - A React state management library for complex UIs",
-  "main": "dist/recoil.js",
+  "main": "dist/index.js",
   "files": ["dist/recoil.js"],
   "repository": "https://github.com/facebookexperimental/recoil.git",
   "license": "MIT",
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c && node scripts/postbuild.js"
   },
   "peerDependencies": {
     "react": "^16.13.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,7 +37,7 @@ const config = (mode) => ({
     },
     nodeResolve(),
     commonjs(),
-    mode === 'development' ? undefined : terser(),
+    mode === 'development' ? undefined : terser({ mangle: false }),
   ],
 });
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,10 @@ import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from "rollup-plugin-terser";
 
-export default {
+const config = (mode) => ({
   input: 'src/Recoil.js',
   output: {
-    file: 'dist/recoil.js',
+    file: `dist/recoil.${mode}.js`,
     format: 'cjs',
     exports: 'named',
   },
@@ -37,6 +37,8 @@ export default {
     },
     nodeResolve(),
     commonjs(),
-    terser(),
+    mode === 'development' ? undefined : terser(),
   ],
-};
+});
+
+export default [config('development'), config('production')];

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,3 @@
+const fs = require('fs');
+
+fs.copyFileSync('./src/npm/index.js', './dist/index.js');

--- a/src/npm/index.js
+++ b/src/npm/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+    module.exports = require('./recoil.production.js');
+} else {
+    module.exports = require('./recoil.development.js');
+}


### PR DESCRIPTION
Based off of #67 to avoid conflicts.

This fixes an issue that was breaking a fresh create-react-app from working, due to CRA's own minification step running only in production mode.

Demo repo is [here](https://github.com/dustinsoftware/recoil-playground/tree/094862e722ec6ed016d4b723061df77c7db65fb3), run `yarn build && npx serve build` to see the isuse.

<img width="1533" alt="Screen Shot 2020-05-17 at 01 25 22" src="https://user-images.githubusercontent.com/942358/82136605-9c0ebe80-97dd-11ea-8963-01b04ecd6af0.png">
