### PR TITLE
docs(Introduction) 📄 adds Motivation and Installation

### DIFF
--- a/docs/docs/docs_es/api-reference/core/RecoilRoot.md
+++ b/docs/docs/docs_es/api-reference/core/RecoilRoot.md
@@ -1,0 +1,30 @@
+---
+title: <RecoilRoot ...props />
+sidebar_label: <RecoilRoot />
+---
+
+Provides the context in which atoms have values. Must be an ancestor of any component that uses any Recoil hooks. Multiple roots may co-exist; atoms will have distinct values within each root. If they are nested, the innermost root will completely mask any outer roots.
+
+---
+
+- `props`
+  - `initializeState?`: `({set, setUnvalidatedAtomValues}) => void`.
+    - A function that will be called when RecoilStore is first rendered which can set initial values for atoms. It is provided with two arguments:
+      - `set`: `<T>(RecoilValue<T>, T) => void`
+        - Sets the initial value of a single atom to the provided value.
+      - `setUnvalidatedAtomValues`: `(Map<string, mixed>) => void`
+        - Sets the initial value for any number of atoms whose keys are the keys in the provided map. As with `useSetUnvalidatedAtomValues`, the validator for each atom will be called when it is next read, and setting an atom without a configured validator will result in an exception.
+
+### Example
+
+```javascript
+import {RecoilRoot} from 'recoil';
+
+function AppRoot() {
+  return (
+    <RecoilRoot>
+      <ComponentThatUsesRecoil />
+    </RecoilRoot>
+  );
+}
+```

--- a/docs/docs/docs_es/api-reference/core/atom.md
+++ b/docs/docs/docs_es/api-reference/core/atom.md
@@ -1,0 +1,44 @@
+---
+title: atom(options)
+sidebar_label: atom()
+---
+
+Returns writeable Recoil state.
+
+---
+
+- `options`
+  - `key`: A unique string used to identify the atom internally. This string should be unique with respect to other atoms and selectors in the entire application.
+  - `default`: The initial value of the atom.
+
+Most often, you'll use the following hooks to interact with atoms:
+
+- [`useRecoilState()`](/docs/api-reference/core/useRecoilState): use this hook when you intend on both reading and writing to the atom. This hook subscribes the component to the atom.
+- [`useRecoilValue()`](/docs/api-reference/core/useRecoilValue): use this hook when you intend on only reading the atom. This hook subscribes the component to the atom.
+- [`useSetRecoilState()`](/docs/api-reference/core/useRecoilState): use this hook when you intend on only writing to the atom.
+
+For rare cases where you need to read an atom's value without subscribing the component, see [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback).
+
+### Example
+
+```javascript
+import {atom, useRecoilState} from 'recoil';
+
+const counter = atom({
+  key: 'myCounter',
+  default: 0,
+});
+
+function Counter() {
+  const [count, setCount] = useRecoilState(counter);
+  const incrementByOne = () => setCount(count + 1);
+
+  return (
+    <div>
+      Count: {count}
+      <br />
+      <button onClick={incrementByOne}>Increment</button>
+    </div>
+  );
+}
+```

--- a/docs/docs/docs_es/api-reference/core/isRecoilValue.md
+++ b/docs/docs/docs_es/api-reference/core/isRecoilValue.md
@@ -1,0 +1,30 @@
+---
+title: isRecoilValue(value)
+sidebar_label: isRecoilValue()
+---
+
+Returns `true` if `value` is either an atom or selector and `false` otherwise.
+
+---
+
+### Example
+
+```javascript
+import {atom, isRecoilValue} from 'recoil';
+
+const counter = atom({
+  key: 'myCounter',
+  default: 0,
+});
+
+const strCounter = selector({
+  key: 'myCounterStr',
+  get: ({get}) => String(get(counter)),
+});
+
+isRecoilValue(counter); // true
+isRecoilValue(strCounter); // true
+
+isRecoilValue(5); // false
+isRecoilValue({}); // false
+```

--- a/docs/docs/docs_es/api-reference/core/selector.md
+++ b/docs/docs/docs_es/api-reference/core/selector.md
@@ -1,0 +1,57 @@
+---
+title: selector(options)
+sidebar_label: selector()
+---
+
+Returns writeable or read-only Recoil state, depending on the options passed to the function.
+
+Selectors represent **derived state**. You can think of derived state as the output of passing state to a pure function that modifies the given state in some way.
+
+---
+
+- `options`
+  - `key`: A unique string used to identify the atom internally. This string should be unique with respect to other atoms and selectors in the entire application.
+  - `get`: A function that is passed an object as the first parameter containing the following properties:
+    - `get`: a function used to retrieve values from other atoms/selectors. All atoms/selectors passed to this function will be implicitly added to a list of **dependencies** for the selector. If any of the selector's dependencies change, the selector will re-evaluate.
+  - `set?`: If this property is set, the selector will return **writeable** state. A function that is passed an object as the first parameter containing the following properties:
+    - `get`: a function used to retrieve values from other atoms/selectors. This function will not subscribe the selector to the given atoms/selectors.
+    - `set`: a function used to set the values of Recoil state. The first parameter is the Recoil state and the second parameter is the new value.
+
+### Example (Synchronous)
+
+```javascript
+import {atom, selector, useRecoilState} from 'recoil';
+
+const tempFahrenheit = atom({
+  key: 'tempFahrenheit',
+  default: 32,
+});
+
+const tempCelcius = selector({
+  key: 'tempCelcius',
+  get: ({get}) => ((get(tempFahrenheit) - 32) * 5) / 9,
+  set: ({set}, newValue) => set(tempFahrenheit, (newValue * 9) / 5 + 32),
+});
+
+function TempCelcius() {
+  const [tempF, setTempF] = useRecoilState(tempFahrenheit);
+  const [tempC, setTempC] = useRecoilState(tempCelcius);
+
+  const addTenCelcius = () => setTempC(tempC + 10);
+  const addTenFahrenheit = () => setTempF(tempF + 10);
+
+  return (
+    <div>
+      Temp (Celcius): {tempC}
+      <br />
+      Temp (Fahrenheit): {tempF}
+      <br />
+      <button onClick={addTenCelcius}>Add 10 Celcius</button>
+      <br />
+      <button onClick={addTenFahrenheit}>Add 10 Fahrenheit</button>
+    </div>
+  );
+}
+```
+
+### Example (Asynchronous)

--- a/docs/docs/docs_es/api-reference/core/useRecoilCallback.md
+++ b/docs/docs/docs_es/api-reference/core/useRecoilCallback.md
@@ -1,0 +1,28 @@
+---
+title: useRecoilCallback()
+---
+
+### Example
+
+```javascript
+import {atom, useRecoilCallback} from 'recoil';
+
+const itemsInCart = atom({
+  key: 'itemsInCart',
+  default: 0,
+});
+
+function CartInfoDebug() {
+  const logCartItems = useRecoilCallback(async ({getPromise}) => {
+    const numItemsInCart = await getPromise(itemsInCart);
+
+    console.log('Items in cart: ', numItemsInCart);
+  });
+
+  return (
+    <div>
+      <button onClick={logCartItems}>Log Cart Items</button>
+    </div>
+  );
+}
+```

--- a/docs/docs/docs_es/api-reference/core/useRecoilState.md
+++ b/docs/docs/docs_es/api-reference/core/useRecoilState.md
@@ -1,0 +1,51 @@
+---
+title: useRecoilState()
+sidebar_label: useRecoilState()
+---
+
+Returns a tuple where the first element is the value of state and the second element is a setter function that will update the value of the given state when called.
+
+This hook will implicitly subscribe the component to the given state.
+
+---
+
+- `state`: an [`atom`](/docs/api-reference/core/atom) or a _writeable_ [`selector`](/docs/api-reference/core/selector). Writeable selectors are selectors that were have both a `get` and `set` in their definition while read-only selectors only have a `get`.
+
+This is the recommended hook to use when a component intends to read and write state.
+
+### Example
+
+```javascript
+import {atom, selector, useRecoilState} from 'recoil';
+
+const tempFahrenheit = atom({
+  key: 'tempFahrenheit',
+  default: 32,
+});
+
+const tempCelcius = selector({
+  key: 'tempCelcius',
+  get: ({get}) => ((get(tempFahrenheit) - 32) * 5) / 9,
+  set: ({set}, newValue) => set(tempFahrenheit, (newValue * 9) / 5 + 32),
+});
+
+function TempCelcius() {
+  const [tempF, setTempF] = useRecoilState(tempFahrenheit);
+  const [tempC, setTempC] = useRecoilState(tempCelcius);
+
+  const addTenCelcius = () => setTempC(tempC + 10);
+  const addTenFahrenheit = () => setTempF(tempF + 10);
+
+  return (
+    <div>
+      Temp (Celcius): {tempC}
+      <br />
+      Temp (Fahrenheit): {tempF}
+      <br />
+      <button onClick={addTenCelcius}>Add 10 Celcius</button>
+      <br />
+      <button onClick={addTenFahrenheit}>Add 10 Fahrenheit</button>
+    </div>
+  );
+}
+```

--- a/docs/docs/docs_es/api-reference/core/useRecoilStateLoadable.md
+++ b/docs/docs/docs_es/api-reference/core/useRecoilStateLoadable.md
@@ -1,0 +1,3 @@
+---
+title: useRecoilStateLoadable()
+---

--- a/docs/docs/docs_es/api-reference/core/useRecoilValue.md
+++ b/docs/docs/docs_es/api-reference/core/useRecoilValue.md
@@ -1,0 +1,43 @@
+---
+title: useRecoilValue()
+sidebar_label: useRecoilValue()
+---
+
+Returns the value of the given Recoil state.
+
+This hook will implicitly subscribe the component to the given state.
+
+---
+
+- `state`: an [`atom`](/docs/api-reference/core/atom) or [`selector`](/docs/api-reference/core/selector)
+
+This is the recommended hook to use when a component intends to read state without writing to it as this hook works with both **read-only state** and **writeable state**. Atoms are writeable state while selectors may be either read-only or writeable. See [`selector()`](/docs/api-reference/core/selector) for more info.
+
+### Example
+
+```javascript
+import {atom, selector, useRecoilValue} from 'recoil';
+
+const namesState = atom({
+  key: 'namesState',
+  default: ['', 'Ella', 'Chris', '', 'Paul'],
+});
+
+const filteredNamesState = selector({
+  key: 'filteredNamesState',
+  get: ({get}) => get(namesState).filter((str) => str !== ''),
+});
+
+function NameDisplay() {
+  const names = useRecoilValue(namesState);
+  const filteredNames = useRecoilValue(filteredNamesState);
+
+  return (
+    <>
+      Original names: {names.join(',')}
+      <br />
+      Filtered names: {filteredNames.join(',')}
+    </>
+  );
+}
+```

--- a/docs/docs/docs_es/api-reference/core/useRecoilValueLoadable.md
+++ b/docs/docs/docs_es/api-reference/core/useRecoilValueLoadable.md
@@ -1,0 +1,23 @@
+---
+title: useRecoilValueLoadable()
+sidebar_label: useRecoilValueLoadable()
+---
+
+Returns a `Loadable`.
+
+This hook is intended to be used for reading the value of asynchronous selectors. This hook will implicitly subscribe the component to the given state.
+
+Unlike `useRecoilValue()`, this hook will not throw a `Promise` when reading from a pending asynchronous selector (for the purpose of working alongside Suspense). Instead, this hook returns a `Loadable`, which is an object with the following interface:
+
+- `state`: indicates the status of the selector. Possible values are `'hasValue'`, `'hasError'`, `'loading'`.
+- `getValue()`: if there is an error, this function throws the error. If selector is still loading, it throws a Promise. Otherwise it returns the value that the selector resolved to.
+- `toPromise()`: returns a `Promise` that will resolve when the selector has resolved. If the selector is synchronous or has already resolved, it returns a `Promise` that resolves immediately.
+
+---
+
+- `state`: a [`selector`](/docs/api-reference/core/selector) that _may_ have some asynchronous operations. The status of the returned loadable will depend on the status of the given selector.
+
+### Example
+
+```jsx
+```

--- a/docs/docs/docs_es/api-reference/core/useResetRecoilState.md
+++ b/docs/docs/docs_es/api-reference/core/useResetRecoilState.md
@@ -1,0 +1,11 @@
+---
+title: useResetRecoilState()
+---
+
+Returns a function that will reset the value of the given state to its default value.
+
+---
+
+- `state`: a writeable Recoil state
+
+### Example

--- a/docs/docs/docs_es/api-reference/core/useSetRecoilState.md
+++ b/docs/docs/docs_es/api-reference/core/useSetRecoilState.md
@@ -1,0 +1,12 @@
+---
+title: useSetRecoilState()
+sidebar_label: useSetRecoilState()
+---
+
+Returns a setter function for updating the value of writeable Recoil state.
+
+---
+
+- `state`: writeable Recoil state.
+
+### Example

--- a/docs/docs/docs_es/api-reference/utils/atomFamily.md
+++ b/docs/docs/docs_es/api-reference/utils/atomFamily.md
@@ -1,0 +1,78 @@
+---
+title: atomFamily()
+sidebar_label: atomFamily()
+---
+
+Returns a function that returns a writeable `RecoilState` atom.
+
+```js
+function atomFamily<T, Parameter>({
+  key: string,
+
+  default:
+    | RecoilValue<T>
+    | Promise<T>
+    | T
+    | (Parameter => T | RecoilValue<T> | Promise<T>),
+
+  dangerouslyAllowMutability?: boolean,
+}): RecoilState<T>
+```
+
+---
+
+- `options`
+  - `key`: A unique string used to identify the atom internally. This string should be unique with respect to other atoms and selectors in the entire application.
+  - `default`: The initial value of the atom. It may either be a value directly, a `RecoilValue` or `Promise` that represents the default value, or a function to get the default value. The callback function is passed a copy of the parameter used when the `atomFamily` function is called.
+
+An `atom` represents a piece of state with _Recoil_. An atom is created and registered per `<RecoilRoot>` by your app. But, what if your state isn’t global? What if your state is associated with a particular instance of a control, or with a particular element? For example, maybe your app is a UI prototyping tool where the user can dynamically add elements and each element has state, such as its position. Idealy, each element would get its own atom of state. You could implement this yourself via a memoization pattern. But, _Recoil_ provides this pattern for you with the `atomFamily` utility. An Atom Family represents a collection of atoms. When you call `atomFamily` it will return a function which provides the `RecoilState` atom based on the parameters you pass in.
+
+## Example
+
+```js
+const elementPositionStateFamily = atomFamily({
+  key: ElementPosition,
+  default: [0, 0],
+});
+
+function ElementListItem({elementID}) {
+  const position = useRecoilValue(elementPositionStateFamily(elementID));
+  return (
+    <div>
+      Element: {elementID}
+      Position: {position}
+    </div>
+  );
+}
+```
+
+An `atomFamily()` takes almost the same options as a simple `atom()`.  However, the default value can also be parameterized. That means you could provide a function which takes the parameter value and returns the actual default value.  For example:
+
+```js
+const myAtomFamily = atomFamily({
+  key: ‘MyAtom’,
+  default: param => defaultBasedOnParam(param),
+});
+```
+
+or using `selectorFamily` instead of `selector`, you can also access the parameter value in a `default` selector as well.
+
+```js
+const myAtomFamily = atomFamily({
+  key: ‘MyAtom’,
+  default: selectorFamily({
+    key: 'MyAtom/Default',
+    get: param => ({get}) => { ... },
+  }),
+});
+```
+
+## Subscriptions
+
+One advantage of using this pattern for separate atoms for each element over trying to store a single atom with a map of state for all elements is that they all maintain their own individual subscriptions. So, updating the value for one element will only cause React components that have subscribed to just that atom to update.
+
+## Persistence
+
+Persistence observers will persist the state for each parameter value as a distinct atom with a unique key based on serialization of the parameter value used. Therefore, it is important to only use parameters which are primitives or simple compound objects containing primitives. Custom classes or functions are not allowed.
+
+It is allowed to “upgrade” a simple `atom` to be an `atomFamily` in a newer version of your app, based on the same key. If you do this, then any persisted values with the old simple key can still be read and all parameter values of the new `atomFamily` will default to the persisted state of the simple atom. If you change the format of the parameter in an `atomFamily`, however, it will not automatically read the previous values that were persisted before the change. However, you can add logic in a default selector to lookup values based on previous parameter formats. We hope to help automate this pattern in the future.

--- a/docs/docs/docs_es/api-reference/utils/constSelector.md
+++ b/docs/docs/docs_es/api-reference/utils/constSelector.md
@@ -1,0 +1,3 @@
+---
+title: constSelector()
+---

--- a/docs/docs/docs_es/api-reference/utils/errorSelector.md
+++ b/docs/docs/docs_es/api-reference/utils/errorSelector.md
@@ -1,0 +1,3 @@
+---
+title: errorSelector()
+---

--- a/docs/docs/docs_es/api-reference/utils/noWait.md
+++ b/docs/docs/docs_es/api-reference/utils/noWait.md
@@ -1,0 +1,3 @@
+---
+title: noWait()
+---

--- a/docs/docs/docs_es/api-reference/utils/selectorFamily.md
+++ b/docs/docs/docs_es/api-reference/utils/selectorFamily.md
@@ -1,0 +1,110 @@
+---
+title: selectorFamily()
+sidebar_label: selectorFamily()
+---
+
+Returns a function that returns a read-only `RecoilValueReadOnly` or writeable `RecoilState` selector.
+
+A `selectorFamily` is a powerful pattern that is similar to a `selector`, but allows you to pass parameters to the `get` and `set` callbacks of a `selector`.
+
+```js
+function selectorFamily<T, Parameter>({
+  key: string,
+
+  get: Parameter => ({get: GetRecoilValue}) => Promise<T> | RecoilValue<T> | T,
+
+  dangerouslyAllowMutability?: boolean,
+}): RecoilValueReadOnly<T>
+```
+
+```js
+function selectorFamily<T, Parameter>({
+  key: string,
+
+  get: Parameter => ({get: GetRecoilValue}) => Promise<T> | RecoilValue<T> | T,
+
+  set: Parameter => (
+    {
+      get: GetRecoilValue,
+      set: SetRecoilValue,
+      reset: ResetRecoilValue,
+    },
+    newValue: T | DefaultValue,
+  ) => void,
+
+  dangerouslyAllowMutability?: boolean,
+}): RecoilState<T>
+```
+
+Where
+
+```js
+type GetRecoilValue = <T>(RecoilValue<T>) => T;
+type SetRecoilValue = <T>(
+  RecoilState<T>,
+  T | DefaultValue | ((prevValue: T) => T | DefaultValue),
+) => void;
+type ResetRecoilValue = <T>(RecoilState<T>) => void;
+```
+
+---
+
+The `selectorFamily()` utility returns a function which can be called with user-defined parameters and returns a selector. Each unique parameter value will return the same memoized selector instance.
+
+- `options`
+  - `key`: A unique string used to identify the atom internally. This string should be unique with respect to other atoms and selectors in the entire application.
+  - `get`: A function that is passed an object of named callbacks that returns the value of the selector, the same as the `selector()` interface. This is wrapped by a function which is passed the parameter from calling the selector family function.
+  - `set?`: An optional function that will produce writeable selectors when provided. It should be a function that takes an object of named callbacks, same as the `selector()` interface. This is again wrapped by another function with gets the parameters from calling the selector family function.
+
+## Example
+
+```js
+const myNumberState = atom({
+  key: 'MyNumber',
+  default: 2,
+});
+
+const myMultipliedState = selectorFamily({
+  key: 'MyMultipliedNumber',
+  get: (multiplier) => ({get}) => {
+    return get(myNumberState) * multiplier;
+  },
+
+  // optional set
+  set: (multiplier) => ({set}, newValue) => {
+    set(myNumberState, newValue / multiplier);
+  },
+});
+
+function MyComponent() {
+  // defaults to 2
+  const number = useRecoilValue(myNumberState);
+
+  // defaults to 200
+  const multipliedNumber = useRecoilValue(myMultipliedState(100));
+
+  return <div>...</div>;
+}
+```
+
+## Query Example
+
+Selector Families are also useful to use for passing parameters to queries:
+
+```js
+const myDataQuery = selectorFamily({
+  key: 'MyDataQuery',
+  get: (queryParameters) => async ({get}) => {
+    const response = await asyncDataRequest(queryParameters);
+    if (response.error) {
+      throw response.error;
+    }
+    return response.data;
+  },
+});
+
+function MyComponent() {
+  const data = useRecoilValue(myDataQuery({userID: 132}));
+  return <div>...</div>;
+}
+```

--- a/docs/docs/docs_es/api-reference/utils/waitForAll.md
+++ b/docs/docs/docs_es/api-reference/utils/waitForAll.md
@@ -1,0 +1,3 @@
+---
+title: waitForAll()
+---

--- a/docs/docs/docs_es/api-reference/utils/waitForAny.md
+++ b/docs/docs/docs_es/api-reference/utils/waitForAny.md
@@ -1,0 +1,3 @@
+---
+title: waitForAny()
+---

--- a/docs/docs/docs_es/api-reference/utils/waitForNone.md
+++ b/docs/docs/docs_es/api-reference/utils/waitForNone.md
@@ -1,0 +1,3 @@
+---
+title: waitForNone()
+---

--- a/docs/docs/docs_es/basic-tutorial/atoms.mdx
+++ b/docs/docs/docs_es/basic-tutorial/atoms.mdx
@@ -1,0 +1,131 @@
+---
+title: Atoms
+---
+
+Atoms contain the source of truth for our application state. In our todo-list, the source of truth will be an array of objects, with each object representing a todo item.
+
+We'll call our list atom `todoListState` and create it using the `atom()` function:
+
+```javascript
+const todoListState = atom({
+  key: 'todoListState',
+  default: [],
+});
+```
+
+We give our atom a unique `key` and set the `default` value to an empty array. To read the contents of this atom, we can use the `useRecoilValue()` hook in our `TodoList` component:
+
+```jsx
+function TodoList() {
+  const todoList = useRecoilValue(todoListState);
+
+  return (
+    <>
+      {/* <TodoListStats /> */}
+      {/* <TodoListFilters /> */}
+      <TodoItemCreator />
+
+      {todoList.map((todoItem) => (
+        <TodoItem item={todoItem} />
+      ))}
+    </>
+  );
+}
+```
+
+The commented-out components will be implemented in the sections that follow.
+
+To create new todo items, we need to access a setter function that will update the contents of the `todoListState`. We can use the `useSetRecoilState()` hook to get a setter function in our `TodoItemCreator` component:
+
+```jsx
+function TodoItemCreator() {
+  const [inputValue, setInputValue] = useState('');
+  const setTodoList = useSetRecoilState(todoListState);
+
+  const addItem = () => {
+    setTodoList((oldTodoList) => [
+      ...oldTodoList,
+      {
+        id: getId(),
+        text: inputValue,
+        isComplete: false,
+      },
+    ]);
+    setInputValue('');
+  };
+
+  const onChange = ({target: {value}}) => {
+    setInputValue(value);
+  };
+
+  return (
+    <div>
+      <input type="text" value={inputValue} onChange={onChange} />
+      <button onClick={addItem}>Add</button>
+    </div>
+  );
+}
+
+// utility for creating unique Id
+let id = 0;
+function getId() {
+  return id++;
+}
+```
+
+Notice we use the **updater** form of the setter function so that we can create a new todo list based on the old todo list.
+
+The `TodoItem` component will display the value of the todo item while allowing you to change its text and delete the item. We use `useRecoilState()` to read `todoListState` and to get a setter function that we use to update the item text, mark it as completed, and delete it:
+
+```jsx
+function TodoItem({item}) {
+  const [todoList, setTodoList] = useRecoilState(todoListState);
+  const index = todoList.findIndex((listItem) => listItem === item);
+
+  const editItemText = ({target: {value}}) => {
+    const newList = replaceItemAtIndex(todoList, index, {
+      ...item,
+      text: value,
+    });
+
+    setTodoList(newList);
+  };
+
+  const toggleItemCompletion = () => {
+    const newList = replaceItemAtIndex(todoList, index, {
+      ...item,
+      isComplete: !item.isComplete,
+    });
+
+    setTodoList(newList);
+  };
+
+  const deleteItem = () => {
+    const newList = removeItemAtIndex(todoList, index);
+
+    setTodoList(newList);
+  };
+
+  return (
+    <div>
+      <input type="text" value={item.text} onChange={editItemText} />
+      <input
+        type="checkbox"
+        checked={item.isComplete}
+        onChange={toggleItemCompletion}
+      />
+      <button onClick={deleteItem}>X</button>
+    </div>
+  );
+}
+
+function replaceItemAtIndex(arr, index, newValue) {
+  return [...arr.slice(0, index), newValue, ...arr.slice(index + 1)];
+}
+
+function removeItemAtIndex(arr, index) {
+  return [...arr.slice(0, index), ...arr.slice(index + 1)];
+}
+```
+
+And with that we've got a fully functional todo list! In the next section we'll see how we can use selectors to take our list to the next level.

--- a/docs/docs/docs_es/basic-tutorial/demo.md
+++ b/docs/docs/docs_es/basic-tutorial/demo.md
@@ -1,0 +1,5 @@
+---
+title: Demo (Todo List)
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/basic-tutorial/intro.md
+++ b/docs/docs/docs_es/basic-tutorial/intro.md
@@ -1,0 +1,15 @@
+---
+title: Intro
+---
+
+This section assumes you have installed Recoil and React. See the [Getting Started](/docs/introduction/getting-started) page for how to get started with Recoil and React from scratch. Components in the following sections are assumed to have a `<RecoilRoot />` in the parent tree.
+
+In this tutorial, we'll be building a simple todo-list application. Our app will be able to do the following:
+
+- Add todo items
+- Edit todo items
+- Delete todo items
+- Filter todo items
+- Display useful stats
+
+Along the way, we'll cover atoms, selectors, atom families, and the hooks exposed by the Recoil API. We'll also cover optimization

--- a/docs/docs/docs_es/basic-tutorial/performance.md
+++ b/docs/docs/docs_es/basic-tutorial/performance.md
@@ -1,0 +1,82 @@
+---
+title: 'Bonus: Performance'
+---
+
+Our existing implementation is perfectly valid, but there are some important performance implications to consider as our app evolves from being a small toy project to a million-line corporate program.
+
+Let's think about what will cause each of our components to re-render:
+
+### `<TodoList />`
+
+This component is subscribed to `filteredTodoListState`, which is a selector that has a dependency on `todoListState` and `todoListFilterState`. This means `TodoList` will re-render when the following state changes:
+
+- `todoListState`
+- `todoListFilterState`
+
+### `<TodoItem />`
+
+This component is subscribed to `todoListState`, so it will re-render whenever `todoListState` changes and whenever its parent component, `TodoList`, re-renders.
+
+### `<TodoItemCreator />`
+
+This component is not subscribed to Recoil state (`useSetRecoilState()` does not create a subscription), so it will only re-render when its parent component, `TodoList`, re-renders.
+
+### `<TodoListFilters />`
+
+This component is subcribed to `todoListFilterState`, so it will re-render when either that state changes or when its parent component, `TodoList`, re-renders.
+
+### `<TodoListStats />`
+
+This component is subscribed to `filteredTodoListState`, so it will re-render whenever that state changes or when its parent component, `TodoList`, re-renders.
+
+## Room for Improvement
+
+The existing implementation has a few drawbacks, mainly that fact that we are re-rendering the entire tree whenever we make any change to `todoListState` due to the fact that `<TodoList />` is the parent of all of our components, so when it re-renders so will all of its children.
+
+Ideally, components would re-render only when they absolutely have to (when the data that they display on the screen has changed).
+
+## Optimization #1: `React.memo()`
+
+To mitigate the issue of child components re-rendering unnecessarily, we can make use of [`React.memo()`](https://reactjs.org/docs/react-api.html#reactmemo), which memoizes a component based on the **props** passed to that component:
+
+```js
+const TodoItem = React.memo(({item}) => ...);
+
+const TodoItemCreator = React.memo(() => ...);
+
+const TodoListFilters = React.memo(() => ...);
+
+const TodoListStats = React.memo(() => ...);
+```
+
+That helps with the re-renders of `<TodoItemCreator />` and `<TodoListFilters />` as they no longer re-render in response to re-renders of their parent component, `<TodoList />`, but we still have the problem of `<TodoItem />` and `<TodoListStats />` re-rendering when individual todo items have their text changed as text changes will result in a new `todoListFilterState`, which both `<TodoItem />` and `<TodoListStats />` are subscribed to.
+
+## Optimization #2: `atomFamily()`
+
+### Rethinking State Shape
+
+Thinking of a todo list as an array of objects is problematic because it forms a tight coupling between each individual todo item and the list of all todo items.
+
+To fix this issue, we need to rethink our state shape by thinking about **normalized state**. In the context of our todo-list app, this means storing the **list** of item ids separately from the **data** for each invididual item.
+
+> For a more detailed discussion on how to think about normalized state, see [this page from the Redux documentation](https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape).
+
+This ultimately means that we will be splitting our `todoListState` into two:
+
+- An array of todo item IDs
+- A mapping of item ID to item data
+
+The array of todo item IDs can be implemented using an atom like so:
+
+```javascript
+const todoListItemIdsState = atom({
+  key: 'todoListItemIdsState',
+  default: [],
+});
+```
+
+For implementing a mapping of item ID to item data, Recoil provides a utility method that allows us to dynamically create a mapping from ID to atom. This utlity is [`atomFamily()`](/docs/api-reference/utils/atomFamily).
+
+### `atomFamily()`
+
+We use the `atomFamily()` function

--- a/docs/docs/docs_es/basic-tutorial/selectors.md
+++ b/docs/docs/docs_es/basic-tutorial/selectors.md
@@ -1,0 +1,151 @@
+---
+title: Selectors
+---
+
+A **selector** represents a piece of **derived state**. You can think of derived state as the output of passing state to a pure function that modifies the given state in some way.
+
+Derived state is a powerful concept because it lets us build dynamic data that depends on other data. In the context of our todo list application, the following are considered derived state:
+
+- **Filtered todo list**: derived from the complete todo list by creating a new list that has certain items filtered out based on some criteria (such as filtering out items that are already completed).
+- **Todo list statistics**: derived from the complete todo list by calculating useful attributes of the list, such as the total number of items in the list, the number of completed items, and the percentage of items that are completed.
+
+To implement a filtered todo list, we need to choose a set of filter criteria whose value can be saved in an atom. The filter options we'll use are: "Show All", "Show Completed", and "Show Uncompleted". The default value will be "Show All":
+
+```javascript
+const todoListFilterState = atom({
+  key: 'todoListFilterState',
+  default: 'Show All',
+});
+```
+
+Using `todoListFilterState` and `todoListState`, we can build a `filteredTodoListState` selector which derives a filtered list:
+
+```javascript
+const filteredTodoListState = selector({
+  key: 'filteredTodoListState',
+  get: ({get}) => {
+    const filter = get(todoListFilterState);
+    const list = get(todoListState);
+
+    switch (filter) {
+      case 'Show Completed':
+        return list.filter((item) => item.isComplete);
+      case 'Show Uncompleted':
+        return list.filter((item) => !item.isComplete);
+      default:
+        return list;
+    }
+  },
+});
+```
+
+The `filteredTodoListState` internally keeps track of two dependencies: `todoListFilterState` and `todoListState` so that it re-runs if either of those change.
+
+> From a component's point of view, selectors can be read using the same hooks that are used to read atoms. However it's important to note that certain hooks only work with **writable state** (i.e `useRecoilState()`). All atoms are writable state, but only some selectors are considered writable state (selectors that have both a `get` and `set` property). See the [Core Concepts](/docs/introduction/core-concepts) page for more information on this topic.
+
+Displaying our filtered todoList is as simple as changing one line in the `TodoList` component:
+
+```jsx
+function TodoList() {
+  // changed from todoListState to filteredTodoListState
+  const todoList = useRecoilValue(filteredTodoListState);
+
+  return (
+    <>
+      <TodoListStats />
+      <TodoListFilters />
+      <TodoItemCreator />
+
+      {todoList.map((todoItem) => (
+        <TodoItem item={todoItem} key={todoItem.id} />
+      ))}
+    </>
+  );
+}
+```
+
+Note the UI is the same as the `todoListFilterState` has a default of `"Show All"`. In order to change the filter, we need to implement the `TodoListFilters` component:
+
+```jsx
+function TodoListFilters() {
+  const [filter, setFilter] = useRecoilState(todoListFilterState);
+
+  const updateFilter = ({target: {value}}) => {
+    setFilter(value);
+  };
+
+  return (
+    <>
+      Filter:
+      <select value={filter} onChange={updateFilter}>
+        <option value="Show All">All</option>
+        <option value="Show Completed">Completed</option>
+        <option value="Show Uncompleted">Uncompleted</option>
+      </select>
+    </>
+  );
+}
+```
+
+With a few lines of code we've managed to implement filtering! We'll use the same concepts to implement the `TodoListStats` component.
+
+We want to display the following stats:
+
+- Total number of todo items
+- Total number of completed items
+- Total number of uncompleted items
+- Percentage of items completed
+
+While we could create a selector for each of the stats, an easier approach would be to create one selector that returns an object containing the data we need. We'll call this selector `todoListStatsState`:
+
+```javascript
+const todoListStatsState = selector({
+  key: 'todoListStatsState',
+  get: ({get}) => {
+    const todoList = get(filteredTodoListState);
+    const totalNum = todoList.length;
+    const totalCompletedNum = todoList.filter((item) => item.isComplete).length;
+    const totalUncompletedNum = totalNum - totalCompletedNum;
+    const percentCompleted = totalNum === 0 ? 0 : totalCompletedNum / totalNum;
+
+    return {
+      totalNum,
+      totalCompletedNum,
+      totalUncompletedNum,
+      percentCompleted,
+    };
+  },
+});
+```
+
+To read the value of `todoListStatsState`, we use `useRecoilValue()` once again:
+
+```jsx
+function TodoListStats() {
+  const {
+    totalNum,
+    totalCompletedNum,
+    totalUncompletedNum,
+    percentCompleted,
+  } = useRecoilValue(todoListStatsState);
+
+  const formattedPercentCompleted = Math.round(percentCompleted * 100);
+
+  return (
+    <ul>
+      <li>Total items: {totalNum}</li>
+      <li>Items completed: {totalCompletedNum}</li>
+      <li>Items not completed: {totalUncompletedNum}</li>
+      <li>Percent completed: {formattedPercentCompleted}</li>
+    </ul>
+  );
+}
+```
+
+To summarize, we've created a todo list app that meets all of our requirements:
+
+- Add todo items
+- Edit todo items
+- Delete todo items
+- Filter todo items
+- Display useful stats

--- a/docs/docs/docs_es/guides/asynchronous-data-queries.md
+++ b/docs/docs/docs_es/guides/asynchronous-data-queries.md
@@ -1,0 +1,251 @@
+---
+title: Asynchronous Data Queries
+sidebar_label: Asynchronous Data Queries
+---
+
+Recoil provides a way to map state and derived state to React components via a data flow graph. What's really powerful is that the functions in the graph can also be asynchronous. This makes it easy to use asynchronous functions in synchronous React component render functions. Recoil allows you to seemlessly mix synchronous and asynchronous functions in your data flow graph of selectors. Simply return a Promise to a value instead of the value itself from a selector `get` callback, the interface remains exactly the same. Because these are just selectors, other selectors can also depend on them to further transform the data.
+
+## Synchronous Example
+
+For example, here is a simple synchronous atom and selector to get a user name:
+
+```js
+const currentUserIDState = atom({
+  key: 'CurrentUserID',
+  default: 1,
+});
+
+const currentUserNameState = selector({
+  key: 'CurrentUserName',
+  get: ({get}) => {
+    return tableOfUsers[get(currentUserIDState)].name;
+  },
+});
+
+function CurrentUserInfo() {
+  const userName = useRecoilValue(currentUserNameState);
+  return <div>{userName}</div>;
+}
+
+function MyApp() {
+  return (
+    <RecoilRoot>
+      <CurrentUserInfo />
+    </RecoilRoot>
+  );
+}
+```
+
+## Asynchronous Example
+
+If the user names were stored on some database we need to query, all we need to do is return a `Promise` or use an `async` function. If any dependencies change, the selector will be re-evaluated and execute a new query. The results are cached, so the query will only execute once per unique input.
+
+```js
+const currentUserNameQuery = selector({
+  key: 'CurrentUserName',
+  get: async ({get}) => {
+    const response = await myDBQuery({
+      userID: get(currentUserIDState),
+    });
+    return response.name;
+  },
+});
+
+function CurrentUserInfo() {
+  const userName = useRecoilValue(currentUserNameQuery);
+  return <div>{userName}</div>;
+}
+```
+
+The interface of the selector is the same, so the component using this selector doesn't need to care if it was backed with synchronous atom state, derived selector state, or asynchronous queries!
+
+But, since React is synchronous, what will it render before the promise resolves? Recoil is designed to work with React Suspense to handle pending data. Wrapping your component with a Suspense boundary will catch any descendents that are still pending and render a fallback UI:
+
+```js
+function MyApp() {
+  return (
+    <RecoilRoot>
+      <React.Suspense fallback={<div>Loading...</div>}>
+        <CurrentUserInfo />
+      </React.Suspense>
+    </RecoilRoot>
+  );
+}
+```
+
+## Error Handling
+
+But what if the request has an error? Recoil selectors can also throw errors which will then be thrown if a component tries to use that value. This can be caught with a React `<ErrorBoundary>`. For example:
+
+```js
+const currentUserNameQuery = selector({
+  key: 'CurrentUserName',
+  get: async ({get}) => {
+    const response = await myDBQuery({
+      userID: get(currentUserIDState),
+    });
+    if (response.error) {
+      throw response.error;
+    }
+    return response.name;
+  },
+});
+
+function CurrentUserInfo() {
+  const userName = useRecoilValue(currentUserNameQuery);
+  return <div>{userName}</div>;
+}
+
+function MyApp() {
+  return (
+    <RecoilRoot>
+      <ErrorBoundary>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <CurrentUserInfo />
+        </React.Suspense>
+      </ErrorBoundary>
+    </RecoilRoot>
+  );
+}
+```
+
+## Queries with Parameters
+
+Sometimes you want to be able to query based on parameters that aren't just based on derived state. For example, you may want to query based on the component props. You can do that using the `selectorFamily` helper:
+
+```js
+const userNameQuery = selectorFamily({
+  key: 'UserName',
+  get: (userID) => async ({get}) => {
+    const response = await myDBQuery({userID});
+    if (response.error) {
+      throw response.error;
+    }
+    return response.name;
+  },
+});
+
+function UserInfo({userID}) {
+  const userName = useRecoilValue(userNameQuery(userID));
+  return <div>{userName}</div>;
+}
+
+function MyApp() {
+  return (
+    <RecoilRoot>
+      <ErrorBoundary>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <UserInfo userID={1}/>
+          <UserInfo userID={2}/>
+          <UserInfo userID={3}/>
+        </React.Suspense>
+      </ErrorBoundary>
+    </RecoilRoot>
+  );
+}
+```
+
+## Data Flow Graph
+
+Remember, by modeling queries as selectors, we can build a data flow graph mixing state, derived state, and queries!  This graph will automatically update and re-render React components as state is updated.
+
+```js
+const currentUserIDState = atom({
+  key: 'CurrentUserID',
+  default: 1,
+});
+
+const userInfoQuery = selectorFamily({
+  key: 'UserInfoQuery',
+  get: userID => async ({get}) => {
+    const response = await myDBQuery({userID});
+    if (response.error) {
+      throw response.error;
+    }
+    return response;
+  },
+});
+
+const currentUserInfoQuery = selector({
+  key: 'CurrentUserInfoQuery',
+  get: ({get}) => get(userInfoQuery(get(currentUserIDState)),
+});
+
+const friendsInfoQuery = selector({
+  key: 'FriendsInfoQuery',
+  get: userID => ({get}) => {
+    const {friendList} = get(currentUserInfoQuery);
+    const friends = [];
+    for (const friendID of friendList) {
+      const friendInfo = get(userInfoQuery(friendID));
+      friends.push(friendInfo);
+    }
+    return friends;
+  },
+});
+
+function CurrentUserInfo() {
+  const currentUser = useRecoilValue(currentUserInfoQuery);
+  const friends = useRecoilValue(friendsInfoQuery);
+  const setCurrentUserID = useSetRecoilState(currentUserIDState);
+  return (
+    <div>
+      <h1>{currentUser.name}</h1>
+      <ul>
+        {friends.map(friend =>
+          <li key={friend.id} onClick={() => setCurrentUserID(friend.id)}>
+            {friend.name}
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function MyApp() {
+  return (
+    <RecoilRoot>
+      <ErrorBoundary>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <CurrentUserInfo />
+        </React.Suspense>
+      </ErrorBoundary>
+    </RecoilRoot>
+  );
+}
+```
+
+## Concurrent Requests
+
+If you notice in the above example, the `friendsInfoQuery` uses a query to get the info for each friend.  But, by doing this in a loop they are essentially serialized.  If the lookup is fast, maybe that's ok.  If it's expensive, you can use a concurrency helper such as `waitForAll`, `waitForNone`, or `waitForAny` to run them in parallel.  They accept both arrays and named objects of dependencies.
+
+```js
+const friendsInfoQuery = selector({
+  key: 'FriendsInfoQuery',
+  get: userID => ({get}) => {
+    const {friendList} = get(currentUserInfoQuery);
+    const friends = get(waitForAll(
+      friendList.map(friendID => userInfoQuery(friendID))
+    ));
+    return friends;
+  },
+});
+```
+
+## Without React Suspense
+
+It is not necessary to use React Suspense for handling pending asynchronous selectors. You can also use the `useRecoilValueLoadable()` hook to determine the status during rendering:
+
+```js
+function UserInfo({userID}) {
+  const userNameLoadable = useRecoilValueLoadable(userNameQuery(userID));
+  switch (userNameLoadable.status) {
+    case 'hasValue':
+      return <div>{userNameLoadable.contents}</div>;
+    case 'loading':
+      return <div>Loading...</div>;
+    case 'hasError':
+      throw userNameLoadable.contents;
+  }
+}
+```

--- a/docs/docs/docs_es/guides/code-splitting.md
+++ b/docs/docs/docs_es/guides/code-splitting.md
@@ -1,0 +1,5 @@
+---
+title: Code Splitting
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/guides/migrating/from-mobx.md
+++ b/docs/docs/docs_es/guides/migrating/from-mobx.md
@@ -1,0 +1,5 @@
+---
+title: From MobX
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/guides/migrating/from-react-state.md
+++ b/docs/docs/docs_es/guides/migrating/from-react-state.md
@@ -1,0 +1,5 @@
+---
+title: From React State
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/guides/migrating/from-redux.md
+++ b/docs/docs/docs_es/guides/migrating/from-redux.md
@@ -1,0 +1,5 @@
+---
+title: From Redux
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/guides/persistence.md
+++ b/docs/docs/docs_es/guides/persistence.md
@@ -1,0 +1,4 @@
+---
+title: State Persistence
+sidebar_label: State Persistence
+---

--- a/docs/docs/docs_es/guides/usage-flow.md
+++ b/docs/docs/docs_es/guides/usage-flow.md
@@ -1,0 +1,5 @@
+---
+title: Usage with Flow
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/guides/usage-typescript.md
+++ b/docs/docs/docs_es/guides/usage-typescript.md
@@ -1,0 +1,5 @@
+---
+title: Usage with TypeScript
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/guides/writing-test.md
+++ b/docs/docs/docs_es/guides/writing-test.md
@@ -1,0 +1,5 @@
+---
+title: Writing Tests
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).

--- a/docs/docs/docs_es/introduction/core-concepts.md
+++ b/docs/docs/docs_es/introduction/core-concepts.md
@@ -1,0 +1,91 @@
+---
+title: Core Concepts
+---
+
+## Overview
+
+Recoil lets you create a data-flow graph that flows from _atoms_ (shared state) through _selectors_ (pure functions) and down into your React components. Atoms are units of state that components can subscribe to. Selectors transform this state either synchronously or asynchronously
+
+## Atoms
+
+Atoms are units of state. They're updateable and subscribeable: when an atom is updated, each subscribed component is re-rendered with the new value. They can be created at runtime, too. Atoms can be used in place of React local component state. If the same atom is used from multiple components, all those components share their state.
+
+Atoms are created using the `atom` function:
+
+```javascript
+const fontSizeState = atom({
+  key: 'fontSizeState',
+  default: 14,
+});
+```
+
+Atoms need a unique key, which is used for debugging, persistence, and for certain advanced APIs that let you see a map of all atoms. It is an error for two atoms to have the same key, so make sure they're globally unique. Like React component state, they also have a default value.
+
+To read and write an atom from a component, we use a hook called `useRecoilState`. It's just like React's `useState`, but now the state can be shared between components:
+
+```jsx
+function FontButton() {
+  const [fontSize, setFontSize] = useRecoilState(fontSizeState);
+  return (
+    <button onClick={() => setFontSize((size) => size + 1)} style={{fontSize}}>
+      Click to Enlarge
+    </button>
+  );
+}
+```
+
+Clicking on the button will increase the font size of the button by one. But now some other component can also use the same font size:
+
+```jsx
+function Text() {
+  const [fontSize, setFontSize] = useRecoilState(fontSizeState);
+  return <p style={{fontSize}}>This text will increase in size too.</p>;
+}
+```
+
+## Selectors
+
+A **selector** is a pure function that accepts atoms or other selectors as input. When these upstream atoms or selectors are updated, the selector function will be re-evaluated. Components can subscribe to selectors just like atoms, and will then be re-rendered when the selectors change.
+
+Selectors are used to calculate derived data that is based on state. This lets us avoid redundant state, usually obviating the need for reducers to keep state in sync and valid. Instead, a minimal set of state is stored in atoms, while everything else is efficiently computed as a function of that minimal state. Since selectors keep track of what components need them and what state they depend on, they make this functional approach more efficient.
+
+From the point of view of components, selectors and atoms have the same interface and can therefore be substituted for one another.
+
+Selectors are defined using the `selector` function:
+
+```javascript
+const fontSizeLabelState = selector({
+  key: 'fontSizeLabelState',
+  get: ({get}) => {
+    const fontSize = get(fontSizeState);
+    const unit = 'px';
+
+    return `${fontSize}${unit}`;
+  },
+});
+```
+
+The `get` property is the function that is to be computed. It can access the value of atoms and other selectors using the `get` argument passed to it. Whenever it accesses another atom or selector, a dependency relationship is created such that updating the other atom or selector will cause this one to be recomputed.
+
+In this `fontSizeLabelState` example, the selector has one dependency: the `fontSizeState` atom. Conceptually, the `fontSizeLabelState` selector behaves like a pure function that takes a `fontSizeState` as input and returns a formatted font size label as output.
+
+Selectors can be read using `useRecoilValue()`, which takes an atom or selector as an argument and returns the corresponding value. We don't use the `useRecoilState()` as the `fontSizeLabelState` selector is not writeable (see the [selector API reference](/docs/api-reference/core/selector) for more information on writeable selectors):
+
+```jsx
+function FontButton() {
+  const [fontSize, setFontSize] = useRecoilState(fontSizeState);
+  const fontSizeLabel = useRecoilValue(fontSizeLabelState);
+
+  return (
+    <>
+      <div>Current font size: ${fontSizeLabel}</div>
+
+      <button onClick={setFontSize(fontSize + 1)} style={{fontSize}}>
+        Click to Enlarge
+      </button>
+    </>
+  );
+}
+```
+
+Clicking on the button now does two things: it increases the font size of the button while also updating the font size label to reflect the current font size.

--- a/docs/docs/docs_es/introduction/getting-started.mdx
+++ b/docs/docs/docs_es/introduction/getting-started.mdx
@@ -1,0 +1,127 @@
+---
+title: Getting Started
+---
+
+## Create React App
+
+Recoil is a state management library for React, so you need to have React installed and running to use Recoil. The easiest and recommended way for bootstrapping a React application is to use [Create React App](https://github.com/facebook/create-react-app#creating-an-app):
+
+```shell
+npx create-react-app my-app
+```
+
+> [`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) is a package runner tool that comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f).
+
+For more ways to install Create React App, see the [official documentation](https://github.com/facebook/create-react-app#creating-an-app).
+
+## Installation
+
+The Recoil package lives in <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>. To install the latest stable version, run the following command:
+
+```shell
+npm install recoil
+```
+
+Or if you're using <a href="https://classic.yarnpkg.com/en/docs/install/" target="_blank">yarn</a>:
+
+```shell
+yarn add recoil
+```
+
+## RecoilRoot
+
+Components that use recoil state need `RecoilRoot` to appear somewhere in the parent tree. A good place to put this is in your root component:
+
+```jsx
+import React from 'react';
+import {
+  RecoilRoot,
+  atom,
+  selector,
+  useRecoilState,
+  useRecoilValue,
+} from 'recoil';
+
+function App() {
+  return (
+    <RecoilRoot>
+      <CharacterCounter />
+    </RecoilRoot>
+  );
+}
+```
+
+We'll implement the `CharacterCounter` component in the following section.
+
+## Atom
+
+An **atom** represents a piece of **state**. Atoms can be read from and written to from any component. Components that read the value of an atom are implicitly **subscribed** to that atom, so any atom updates will result in a re-render of all components subscribed to that atom:
+
+```javascript
+const textState = atom({
+  key: 'textState', // unique ID (with respect to other atoms/selectors)
+  default: '', // default value (aka initial value)
+});
+```
+
+Components that need to read from _and_ write to an atom should use `useRecoilState()` as shown below:
+
+```jsx
+function CharacterCounter() {
+  return (
+    <div>
+      <TextInput />
+      <CharacterCount />
+    </div>
+  );
+}
+
+function TextInput() {
+  const [text, setText] = useRecoilState(textState);
+
+  const onChange = (event) => {
+    setText(event.target.value);
+  };
+
+  return (
+    <div>
+      <input type="text" value={text} onChange={onChange} />
+      <br />
+      Echo: {text}
+    </div>
+  );
+}
+```
+
+## Selector
+
+A **selector** represents a piece of **derived state**. Derived state is a **transformation** of state. You can think of derived state as the output of passing state to a pure function that modifies the given state in some way:
+
+```jsx
+const charCountState = selector({
+  key: 'charCountState', // unique ID (with respect to other atoms/selectors)
+  get: ({get}) => {
+    const text = get(textState);
+
+    return text.length;
+  },
+});
+```
+
+We can use the `useRecoilValue()` hook to read the value of `charCountState`:
+
+```jsx
+function CharacterCount() {
+  const count = useRecoilValue(charCountState);
+
+  return <>Character Count: {count}</>;
+}
+```
+
+## Demo
+
+Below is the finished product:
+
+import GettingStarted from '../../../src/components/introduction/GettingStarted';
+
+<GettingStarted />

--- a/docs/docs/docs_es/introduction/installation.md
+++ b/docs/docs/docs_es/introduction/installation.md
@@ -1,0 +1,15 @@
+---
+title: Instalación
+---
+
+Recoil está disponible a través de <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>. Para instalar la última versión estable ejecuta el siguiente comando:
+
+```shell
+npm install recoil
+```
+
+O si usas <a href="https://classic.yarnpkg.com/en/docs/install/" target="_blank">yarn</a>:
+
+```shell
+yarn add recoil
+```

--- a/docs/docs/docs_es/introduction/motivation.md
+++ b/docs/docs/docs_es/introduction/motivation.md
@@ -1,0 +1,22 @@
+---
+title: Motivación
+---
+
+Por razones de compatibilidad y simplicidad, es mejor usar las funciones nativas de React para el manejo de estados, en lugar de utilizar estados externos y globales. Pero React tiene algunas limitantes:
+
+- El estado de un componente solo puede ser compartido, si éste estado se mueve hacia el componente padre que se tiene en común, pero este implica tener un árbol de componentes mas grande que renderizar.
+- El contexto de React solo puede mantener un valor, y no un conjunto indefinido de valores con sus respectivos consumidores.
+- Por estas dos razones, es difícil dividir el código de la parte más alta del árbol de componentes (donde tenemos el estado), de las hojas del mismo árbol (donde el estado es usado).
+
+Queremos mejorar esto y al mismo tiempo seguir con la misma API, semántica y comportamiento de React como sea posible.
+
+Recoil define un grafo ortogonal directo pero también intrínseco a tu árbol de componentes de React. Los cambios de estado fluyen desde las raíces de este grafo (que llamamos átomos), pasan a través de funciones puras (que hemos llamado selectores) y finalmente llegan hasta los componentes.
+Con este enfoque:
+
+- Crear una API libre de código repetitivo, donde el estado ha compartir pueda utilizar la misma interfaz get/set, igual como lo hace el estado interno de React (Aunque también se puede encapsular con reductores de ser necesario).
+- Tenemos la posibilidad de ser compatibles con el Modo Concurrente y cualquier otra funcionalidad nueva de React que este disponible.
+- La definición del estado es incremental y distribuido, permitiendo así dividir el código.
+- El estado puede ser reemplazado con datos derivados sin tener que modificar el component que lo usa.
+- Los datos derivados pueden ser cambiados para ser asíncronos o síncronos, sin tener que modificar el component que lo usa.
+- Podemos usar la navegación como concepto de primera clase, incluso codificar el estado en hipervínculos.
+- Es fácil mantener todo el estado de la aplicación persistentemente y compatible con versiones anteriores, por lo tanto éste estado persistente puede sobrevivir cambios en la aplicación.

--- a/docs/docs/docs_es/mdx.md
+++ b/docs/docs/docs_es/mdx.md
@@ -1,0 +1,17 @@
+---
+id: mdx
+title: Powered by MDX
+---
+
+You can write JSX and use React components within your Markdown thanks to [MDX](https://mdxjs.com/).
+
+export const Highlight = ({children, color}) => ( <span style={{
+      backgroundColor: color,
+      borderRadius: '2px',
+      color: '#fff',
+      padding: '0.2rem',
+    }}> {children} </span> );
+
+<Highlight color="#25c2a0">Docusaurus green</Highlight> and <Highlight color="#1877F2">Facebook blue</Highlight> are my favorite colors.
+
+I can write **Markdown** alongside my _JSX_!


### PR DESCRIPTION
Starts the translation to Spanish. By now I am just adding this translation into the _docs/docs/docs_es/_ directory. This is the progress:

- [ ] docs
    - [ ] Introduction
        - [x] Motivation
        - [ ] Core Concepts
        - [x] Installation
        - [ ] Getting Started
    - [ ] Basic Tutorial
        - [ ] Intro
        - [ ] Atoms
        - [ ] Selectors
        - [ ] Bonus: Performance (Didn't release)
    - [ ] Guides
        - [ ] Asynchronous Data Queries
        - [ ] State Persistence
    - [ ] API Reference
        - [ ] Core
            - [ ] <RecoilRoot />
            - [ ] atom()
            - [ ] selector()
            - [ ] isRecoilValue()
            - [ ] Hooks
            - [ ] useRecoilState()
            - [ ] useRecoilValue()
            - [ ] useSetRecoilState()()
            - [ ] useResetRecoilState()()
            - [ ] useRecoilValueLoadable()()
            - [ ] useRecoilStateLoadable()()
            - [ ] useRecoilCallback()()
        - [ ] Utils
            - [ ] atomFamily()
            - [ ] selectorFamily()
            - [ ] constSelector()
            - [ ] errorSelector()
            - [ ] noWait()
            - [ ] waitForAll()
            - [ ] waitForAny()
            - [ ] waitForNone()

Question: Are we planning to follow the same reactjs.org Translation strategy?