### PR TITLE
[docs] use full todoList for stats, not filteredTodoList.

### DIFF
--- a/docs/docs/basic-tutorial/selectors.md
+++ b/docs/docs/basic-tutorial/selectors.md
@@ -102,7 +102,7 @@ While we could create a selector for each of the stats, an easier approach would
 const todoListStatsState = selector({
   key: 'todoListStatsState',
   get: ({get}) => {
-    const todoList = get(filteredTodoListState);
+    const todoList = get(todoListState);
     const totalNum = todoList.length;
     const totalCompletedNum = todoList.filter((item) => item.isComplete).length;
     const totalUncompletedNum = totalNum - totalCompletedNum;


### PR DESCRIPTION
seems like we'd want the stats on the full todoList, not on the filtered list.
otherwise you click on "unfinished" and the stats say that you're 0% complete, then you click on "finished" and the stats say 100% complete.