### PR TITLE
[docs] Changed fieldname for useRecoilValueLoadable hook

### DIFF
--- a/docs/docs/guides/asynchronous-data-queries.md
+++ b/docs/docs/guides/asynchronous-data-queries.md
@@ -239,7 +239,7 @@ It is not necessary to use React Suspense for handling pending asynchronous sele
 ```jsx
 function UserInfo({userID}) {
   const userNameLoadable = useRecoilValueLoadable(userNameQuery(userID));
-  switch (userNameLoadable.status) {
+  switch (userNameLoadable.state) {
     case 'hasValue':
       return <div>{userNameLoadable.contents}</div>;
     case 'loading':


### PR DESCRIPTION
May be that it was status before but right now getting the current state of the useRecoilValueLoadable
is done via the `state` field instead of `status`