### PR TITLE
[docs] Use splice to make the docs more intuitive

### DIFF
--- a/docs/docs/basic-tutorial/atoms.mdx
+++ b/docs/docs/basic-tutorial/atoms.mdx
@@ -92,16 +92,15 @@ function TodoItem({item}) {
   };
 
   const toggleItemCompletion = () => {
-    const newList = replaceItemAtIndex(todoList, index, {
-      ...item,
-      isComplete: !item.isComplete,
-    });
+    const newList = todoList;
+    newList.splice(index, 1, {...item, isComplete: !item.isComplete});
 
     setTodoList(newList);
   };
 
   const deleteItem = () => {
-    const newList = removeItemAtIndex(todoList, index);
+    const newList = todoList;
+    newList.splice(index, 1);
 
     setTodoList(newList);
   };
@@ -117,14 +116,6 @@ function TodoItem({item}) {
       <button onClick={deleteItem}>X</button>
     </div>
   );
-}
-
-function replaceItemAtIndex(arr, index, newValue) {
-  return [...arr.slice(0, index), newValue, ...arr.slice(index + 1)];
-}
-
-function removeItemAtIndex(arr, index) {
-  return [...arr.slice(0, index), ...arr.slice(index + 1)];
 }
 ```
 

--- a/docs/docs/basic-tutorial/atoms.mdx
+++ b/docs/docs/basic-tutorial/atoms.mdx
@@ -92,14 +92,14 @@ function TodoItem({item}) {
   };
 
   const toggleItemCompletion = () => {
-    const newList = todoList;
+    const newList = [...todoList];
     newList.splice(index, 1, {...item, isComplete: !item.isComplete});
 
     setTodoList(newList);
   };
 
   const deleteItem = () => {
-    const newList = todoList;
+    const newList = [...todoList];
     newList.splice(index, 1);
 
     setTodoList(newList);


### PR DESCRIPTION
The atoms section in the basic tutorial currently uses explicitly defined functions to replace and delete values from an array, which is exactly what the native "splice" method is used to do. 
Changing the tutorial to use splice instead reduced the number of lines of code and would also make it more intuitive for a Javascript developer to understand.