### PR TITLE
Fix call stack size exceeded when set atom value with object that has circular reference

### DIFF
--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -56,7 +56,7 @@ test('atom can store null and undefined', () => {
   expect(get(myAtom)).toBe('VALUE');
 });
 
-test('atom can store a circular reference object ', () => {
+test('atom can store a circular reference object', () => {
   class Circular {
     constructor() {
       this.self = this;

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -55,3 +55,19 @@ test('atom can store null and undefined', () => {
   act(() => set(myAtom, 'VALUE'));
   expect(get(myAtom)).toBe('VALUE');
 });
+
+test('atom can store a circular reference object ', () => {
+  class Circular {
+    constructor() {
+      this.self = this;
+    }
+  }
+  const circular = new Circular();
+  const myAtom = atom<Circular>({
+    key: 'atom',
+    default: undefined,
+  });
+  expect(get(myAtom)).toBe(undefined);
+  act(() => set(myAtom, circular));
+  expect(get(myAtom)).toBe(circular);
+});

--- a/src/util/Recoil_deepFreezeValue.js
+++ b/src/util/Recoil_deepFreezeValue.js
@@ -64,7 +64,7 @@ function deepFreezeValue(value: mixed) {
 
   Object.freeze(value); // Make all properties read-only
   for (const prop in value) {
-    if (value.hasOwnProperty(prop)) {
+    if (value.hasOwnProperty(prop) && !Object.isFrozen(prop)) {
       deepFreezeValue(value[prop]);
     }
   }


### PR DESCRIPTION
## Background

fix #54

Set atom value with an object that has circular reference inside will cause an error

```
RangeError: Maximum call stack size exceeded
```


## What's changed

- In `deepFreezeValue`  Check if a property is already frozen 

