### PR TITLE
fix: Use Object.prototype.hasOwnProperty.call instead of direct method calling.

### DIFF
--- a/src/util/Recoil_deepFreezeValue.js
+++ b/src/util/Recoil_deepFreezeValue.js
@@ -64,7 +64,7 @@ function deepFreezeValue(value: mixed) {
 
   Object.freeze(value); // Make all properties read-only
   for (const key in value) {
-    if (value.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
       const prop = value[key];
       // Prevent infinite recurssion for circular references.
       if (typeof prop === 'object' && prop != null && !Object.isFrozen(prop)) {


### PR DESCRIPTION
I encountered an error while trying to use with latest twilio javascript sdk:
https://media.twiliocdn.com/sdk/js/chat/v3.3/twilio-chat.min.js

error :
```
Uncaught (in promise) TypeError: t.hasOwnProperty is not a function
    at e (recoil.js:122)
    at e (recoil.js:122)
    at e (recoil.js:122)
    at e (recoil.js:122)
    at Object.set (recoil.js:626)
    at setNodeValue (recoil.js:379)
    at recoil.js:526
    at Object.replaceState (recoil.js:746)
    at recoil.js:525
    at Object.trace (recoil.js:337)
```

My Code Snippets:

```ts
const [client, setClient] = useRecoilState(twilioClientState);
...
twilio.Chat.Client.create(token).then((client) => {
        setClient(client); // <- this raise an error.
});
```

And it seems that an error occurred while trying to deep freeze object.
Because some object that not inherit `Object` prototype pass thorough `typeof` checking.

Minimal reproducible example:

```js
const nonObject = Object.create(null);
nonObject["hello"] = "world";
nonObject.hello
=> "world"
typeof nonObject
=> "object"
nonObject === null
=> false
nonObject.hasOwnProperty
=> undefined
Object.prototype.hasOwnProperty.call(mapLike, 'hello')
=> true
```