### PR TITLE
Merge contents of RecoilUtils into index

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Recoil - A React state management library for complex UIs",
   "main": "dist/index.js",
   "files": [
-    "dist/recoil.js"
+    "dist"
   ],
   "repository": "https://github.com/facebookexperimental/recoil.git",
   "license": "MIT",

--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -29,6 +29,11 @@ export type {
   RecoilValueReadOnly,
 } from './core/Recoil_RecoilValue';
 
+export type {
+  Parameter,
+  SelectorFamilyOptions,
+} from './recoil_values/Recoil_selectorFamily';
+
 const atom = require('./recoil_values/Recoil_atom');
 const {
   useRecoilCallback,
@@ -47,6 +52,18 @@ const {RecoilRoot} = require('./components/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
 const selector = require('./recoil_values/Recoil_selector');
 
+const atomFamily = require('./recoil_values/Recoil_atomFamily');
+const constSelector = require('./recoil_values/Recoil_const');
+const errorSelector = require('./recoil_values/Recoil_error');
+const readOnlySelector = require('./recoil_values/Recoil_readOnlySelector');
+const selectorFamily = require('./recoil_values/Recoil_selectorFamily');
+const {
+  noWait,
+  waitForAll,
+  waitForAny,
+  waitForNone,
+} = require('./recoil_values/Recoil_WaitFor');
+
 module.exports = {
   // Types
   DefaultValue,
@@ -57,6 +74,13 @@ module.exports = {
   // RecoilValues
   atom,
   selector,
+
+  // Convenience RecoilValues
+  atomFamily,
+  selectorFamily,
+  constSelector,
+  errorSelector,
+  readOnlySelector,
 
   // Hooks that accept RecoilValues
   useRecoilValue,
@@ -73,6 +97,12 @@ module.exports = {
   useTransactionObservation_UNSTABLE: useTransactionObservation,
   useTransactionSubscription_UNSTABLE: useTransactionSubscription,
   useSetUnvalidatedAtomValues_UNSTABLE: useSetUnvalidatedAtomValues,
+
+  // Concurrency Helpers
+  noWait,
+  waitForNone,
+  waitForAny,
+  waitForAll,
 
   // Other functions
   isRecoilValue,


### PR DESCRIPTION
Per discussion of Recoil team, we will move everything in RecoilUtils into index, so people have easier access to them.

(RecoilUtils.js itself will be removed later along after some necessary internal changes)