### PR TITLE
Fix cannot destructure property error of undefined

### DIFF
--- a/src/util/Recoil_recoverableViolation.js
+++ b/src/util/Recoil_recoverableViolation.js
@@ -17,7 +17,7 @@
 function recoverableViolation( // @oss-only
   message: string, // @oss-only
   projectName: 'recoil', // @oss-only
-  {error}: {|error?: Error|}, // @oss-only
+  {error}: {|error?: Error|} = {}, // @oss-only
 ): null { // @oss-only
   if (__DEV__) { // @oss-only
     console.error(message, error); // @oss-only


### PR DESCRIPTION
Adds a default value `{}` to the 3rd argument of `recoverableViolation` so that it has something to try and destructure `error` from when nothing is passed at call-sites.

Note: the third argument isn't currently used anywhere in this codebase

