### PR TITLE
Adds window object check in Recoil Root

### DIFF
--- a/src/components/Recoil_RecoilRoot.react.js
+++ b/src/components/Recoil_RecoilRoot.react.js
@@ -213,8 +213,10 @@ function RecoilRoot({initializeState, children}: Props): ReactElement {
       return;
     }
     // Save changes to nextTree and schedule a React update:
-    if (__DEV__ && typeof window !== 'undefined') {
-      window.$recoilDebugStates.push(replaced); // TODO this shouldn't happen here because it's not batched
+    if (__DEV__) {
+      if (typeof window !== 'undefined') {
+        window.$recoilDebugStates.push(replaced); // TODO this shouldn't happen here because it's not batched
+      }
     }
     storeState.nextTree = replaced;
     nullthrows(notifyBatcherOfChange.current)();

--- a/src/components/Recoil_RecoilRoot.react.js
+++ b/src/components/Recoil_RecoilRoot.react.js
@@ -120,7 +120,7 @@ function Batcher(props: {setNotifyBatcherOfChange: (() => void) => void}) {
 }
 
 if (__DEV__) {
-  if (!window.$recoilDebugStates) {
+  if (typeof window !== 'undefined' && !window.$recoilDebugStates) {
     window.$recoilDebugStates = [];
   }
 }
@@ -213,7 +213,7 @@ function RecoilRoot({initializeState, children}: Props): ReactElement {
       return;
     }
     // Save changes to nextTree and schedule a React update:
-    if (__DEV__) {
+    if (__DEV__ && typeof window !== 'undefined') {
       window.$recoilDebugStates.push(replaced); // TODO this shouldn't happen here because it's not batched
     }
     storeState.nextTree = replaced;


### PR DESCRIPTION
Should fix #215

In short, it checks if window is defined before using it in dev mode.

I don't think these minimal changes should brea but I haven't tested them.

This is the first non-UI library I've worked on and I don't know how to test my changes locally (other than seeing if build + tests pass or building and using it in an app).

If someone could let me know the preferred way to test that would be awesome!