### PR TITLE
Update Guides (Queries with Parameters)  use atomFamily instead of selectorFamily

### DIFF
--- a/docs/docs/guides/asynchronous-data-queries.md
+++ b/docs/docs/guides/asynchronous-data-queries.md
@@ -108,7 +108,7 @@ Sometimes you want to be able to query based on parameters that aren't just base
 ```js
 const userNameQuery = atomFamily({
   key: 'UserName',
-  get: async userID => {
+  default: async userID => {
     const response = await myDBQuery({userID});
     if (response.error) {
       throw response.error;

--- a/docs/docs/guides/asynchronous-data-queries.md
+++ b/docs/docs/guides/asynchronous-data-queries.md
@@ -104,11 +104,11 @@ function MyApp() {
 ```
 
 ## Queries with Parameters
-Sometimes you want to be able to query based on parameters that aren't just based on derived state.  For example, you may want to query based on the component props.  You can do that using the `selectorFamily` helper:
+Sometimes you want to be able to query based on parameters that aren't just based on derived state.  For example, you may want to query based on the component props.  You can do that using the `atomFamily` helper:
 ```js
-const userNameQuery = selectorFamily({
+const userNameQuery = atomFamily({
   key: 'UserName',
-  get: userID => async ({get}) => {
+  get: async userID => {
     const response = await myDBQuery({userID});
     if (response.error) {
       throw response.error;


### PR DESCRIPTION
I don't see the reason of using `selectorFamily` in this example.