### PR TITLE
fix: Cannot be used in the DEV environment of the SSR project

### DIFF
--- a/src/components/Recoil_RecoilRoot.react.js
+++ b/src/components/Recoil_RecoilRoot.react.js
@@ -120,7 +120,7 @@ function Batcher(props: {setNotifyBatcherOfChange: (() => void) => void}) {
 }
 
 if (__DEV__) {
-  if (!window.$recoilDebugStates) {
+  if (typeof window !== 'undefined' && !window.$recoilDebugStates) {
     window.$recoilDebugStates = [];
   }
 }


### PR DESCRIPTION
I got an error when I use Recoil in the development environment of next.js project，this error is "ReferenceError: window is not defined", so I want to fix this problem. 