### PR TITLE
Enable RSS & Atom feeds for blog

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -129,6 +129,10 @@ module.exports = {
           showReadingTime: true,
           editUrl:
             'https://github.com/facebookexperimental/Recoil/edit/docs/docs/blog/',
+           feedOptions: {
+            type: 'all',
+            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
According to the documentation (https://v2.docusaurus.io/docs/blog#feed) only a small config update is needed.