### PR TITLE
Wrap useRecoilCallback function

### DIFF
--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -550,7 +550,7 @@ class Sentinel {}
 const SENTINEL = new Sentinel();
 
 function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
-  fn: (CallbackInterface, ...Args) => Return,
+  fn: CallbackInterface => (...Args) => Return,
   deps?: $ReadOnlyArray<mixed>,
 ): (...Args) => Return {
   const storeRef = useStoreRef();
@@ -601,7 +601,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
       let ret = SENTINEL;
       ReactDOM.unstable_batchedUpdates(() => {
         // flowlint-next-line unclear-type:off
-        ret = (fn: any)({getPromise, getLoadable, set, reset}, ...args);
+        ret = (fn: any)({getPromise, getLoadable, set, reset})(...args);
       });
       invariant(
         !(ret instanceof Sentinel),


### PR DESCRIPTION
Summary:
It was awkward combining the callback object and the rest of the callback arguments into the same set of arguments for the function passed to `useRecoilCallback`.  This proposal splits them out with a wrapper function.  This helps readability because the inner function matches the signature of the callback function that is returned by `useRecoilCallback`

There was also a problem with Flow in that it was not properly checking the argument types, such as the functions in the callback object, when the user used async functions.  This diff solves that problem.

Note that this is different from the wrapper function approach used with atom/selector families.  There we have a wrapper which adds parameterization, so the user parameters are in the outer function and the inner function has the object with named callbacks.  In this case, we are wrapping a user callback with the extra abstraction, so it is the outer function which has the object with named callbacks.

Examples:
```
useRecoilCallback(({set}) => value => {
  set(myAtom, value);
});

useRecoilCallback(({getPromise}) => async () => {
  const value = await getPromise(myAtom);
  alert(value);
});
```

Compare this as an extension to `useCallback()`:
```
useCallback(value => {
  alert(value);
});

useCallback(async () => {
  const value = await getValuePromise();
  alert(value);
});
```

NOTE: This is a breaking change, but we are still on version `0.0.x` for semantic versioning.

Reviewed By: davidmccabe

Differential Revision: D21443788

