### PR TITLE
Update useRecoilCallback() to use Snapshot

### DIFF
--- a/src/components/Recoil_RecoilRoot.react.js
+++ b/src/components/Recoil_RecoilRoot.react.js
@@ -11,13 +11,7 @@
 'use strict';
 
 import type {RecoilValue} from '../core/Recoil_RecoilValue';
-import type {
-  NodeKey,
-  Store,
-  StoreRef,
-  StoreState,
-  TreeState,
-} from '../core/Recoil_State';
+import type {NodeKey, Store, StoreRef, StoreState} from '../core/Recoil_State';
 
 const React = require('React');
 const {useContext, useEffect, useRef, useState} = require('React');
@@ -28,6 +22,7 @@ const {
   setNodeValue,
   setUnvalidatedAtomValue,
 } = require('../core/Recoil_FunctionalCore');
+const {makeEmptyStoreState} = require('../core/Recoil_State');
 const nullthrows = require('../util/Recoil_nullthrows');
 
 type Props = {
@@ -124,29 +119,6 @@ if (__DEV__) {
   if (typeof window !== 'undefined' && !window.$recoilDebugStates) {
     window.$recoilDebugStates = [];
   }
-}
-
-function makeEmptyTreeState(): TreeState {
-  return {
-    isSnapshot: false,
-    transactionMetadata: {},
-    atomValues: new Map(),
-    nonvalidatedAtoms: new Map(),
-    dirtyAtoms: new Set(),
-    nodeDeps: new Map(),
-    nodeToNodeSubscriptions: new Map(),
-    nodeToComponentSubscriptions: new Map(),
-  };
-}
-
-function makeEmptyStoreState(): StoreState {
-  return {
-    currentTree: makeEmptyTreeState(),
-    nextTree: null,
-    transactionSubscriptions: new Map(),
-    queuedComponentCallbacks: [],
-    suspendedComponentResolvers: new Set(),
-  };
 }
 
 function initialStoreState(store, initializeState) {

--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -25,8 +25,8 @@ const {
   mapByUpdatingInMap,
   setByAddingToSet,
 } = require('../util/Recoil_CopyOnWrite');
-const {getNode} = require('./Recoil_Node');
 const Tracing = require('../util/Recoil_Tracing');
+const {getNode} = require('./Recoil_Node');
 
 // flowlint-next-line unclear-type:off
 const emptyMap: $ReadOnlyMap<any, any> = Object.freeze(new Map());
@@ -174,7 +174,7 @@ function fireNodeSubscriptions(
 
   for (const key of dependentNodes) {
     (state.nodeToComponentSubscriptions.get(key) ?? []).forEach(
-      ([debugName, cb]) => {
+      ([_debugName, cb]) => {
         when === 'enqueue'
           ? store.getState().queuedComponentCallbacks.push(cb)
           : cb(state);

--- a/src/core/Recoil_RecoilValue.js
+++ b/src/core/Recoil_RecoilValue.js
@@ -14,7 +14,7 @@ import type {Loadable} from '../adt/Recoil_Loadable';
 import type {DefaultValue} from './Recoil_Node';
 import type {RecoilValue} from './Recoil_RecoilValueClasses';
 export type {RecoilValue} from './Recoil_RecoilValueClasses';
-import type {NodeKey, Store, TreeState} from './Recoil_State';
+import type {Store, TreeState} from './Recoil_State';
 
 const Tracing = require('../util/Recoil_Tracing');
 const {

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+obviz
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {Loadable} from '../adt/Recoil_Loadable';
+import type {RecoilValue} from './Recoil_RecoilValue';
+import type {Store} from './Recoil_State';
+
+const {getRecoilValueAsLoadable} = require('./Recoil_RecoilValue');
+const {makeEmptyStoreState} = require('./Recoil_State');
+const gkx = require('gkx');
+
+function makeStore(): Store {
+  const storeState = makeEmptyStoreState();
+  const store = {
+    getState: () => storeState,
+    replaceState: replacer => {
+      storeState.currentTree = replacer(storeState.currentTree); // no batching so nextTree is never active
+    },
+    subscribeToTransactions: () => {
+      throw new Error('Cannot subscribe to Snapshots');
+    },
+    addTransactionMetadata: () => {
+      throw new Error('Cannot subscribe to Snapshots');
+    },
+    fireNodeSubscriptions: () => {},
+  };
+  return store;
+}
+
+// A "Snapshot" is "read-only" and captures a specific set of values of atoms.
+// However, the data-flow-graph and selector values may evolve as selector
+// evaluation functions are executed and async selectors resolve.
+class Snapshot {
+  _store: Store;
+
+  constructor(store: Store) {
+    this._store = store;
+  }
+
+  getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
+    return getRecoilValueAsLoadable(this._store, recoilValue);
+  }
+
+  getPromise<T>(recoilValue: RecoilValue<T>): Promise<T> {
+    if (gkx('recoil_async_selector_refactor')) {
+      return this.getLoadable(recoilValue)
+        .toPromise()
+        .then(({value}) => value);
+    } else {
+      return (this.getLoadable(recoilValue).toPromise(): $FlowFixMe);
+    }
+  }
+}
+
+function makeSnapshot(): Snapshot {
+  return new Snapshot(makeStore());
+}
+
+module.exports = {
+  Snapshot,
+  makeSnapshot,
+};

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -94,9 +94,9 @@ function makeEmptyTreeState(): TreeState {
   };
 }
 
-function makeEmptyStoreState(): StoreState {
+function makeStoreState(treeState: TreeState): StoreState {
   return {
-    currentTree: makeEmptyTreeState(),
+    currentTree: treeState,
     nextTree: null,
     transactionSubscriptions: new Map(),
     queuedComponentCallbacks: [],
@@ -104,7 +104,12 @@ function makeEmptyStoreState(): StoreState {
   };
 }
 
+function makeEmptyStoreState(): StoreState {
+  return makeStoreState(makeEmptyTreeState());
+}
+
 module.exports = {
   makeEmptyTreeState,
   makeEmptyStoreState,
+  makeStoreState,
 };

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -22,7 +22,6 @@ type ComponentCallback = TreeState => void;
 
 export type TreeState = $ReadOnly<{
   // Information about the TreeState itself:
-  isSnapshot: boolean,
   transactionMetadata: {...},
   dirtyAtoms: Set<NodeKey>,
 
@@ -83,4 +82,29 @@ export type StoreRef = {
   current: Store,
 };
 
-module.exports = ({}: {...});
+function makeEmptyTreeState(): TreeState {
+  return {
+    transactionMetadata: {},
+    atomValues: new Map(),
+    nonvalidatedAtoms: new Map(),
+    dirtyAtoms: new Set(),
+    nodeDeps: new Map(),
+    nodeToNodeSubscriptions: new Map(),
+    nodeToComponentSubscriptions: new Map(),
+  };
+}
+
+function makeEmptyStoreState(): StoreState {
+  return {
+    currentTree: makeEmptyTreeState(),
+    nextTree: null,
+    transactionSubscriptions: new Map(),
+    queuedComponentCallbacks: [],
+    suspendedComponentResolvers: new Set(),
+  };
+}
+
+module.exports = {
+  makeEmptyTreeState,
+  makeEmptyStoreState,
+};

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -15,10 +15,10 @@ const {act} = require('ReactTestUtils');
 const atom = require('../../recoil_values/Recoil_atom');
 const constSelector = require('../../recoil_values/Recoil_const');
 const {asyncSelector} = require('../../testing/Recoil_TestingUtils');
-const {Snapshot, makeSnapshot} = require('../Recoil_Snapshot');
+const {Snapshot, freshSnapshot} = require('../Recoil_Snapshot');
 
 test('Read default loadable from snapshot', () => {
-  const snapshot: Snapshot = makeSnapshot();
+  const snapshot: Snapshot = freshSnapshot();
 
   const myAtom = atom({
     key: 'Snapshot Atom Default',
@@ -36,7 +36,7 @@ test('Read default loadable from snapshot', () => {
 });
 
 test('Read async selector from snapshot', async () => {
-  const snapshot = makeSnapshot();
+  const snapshot = freshSnapshot();
 
   const [asyncSel, resolve] = asyncSelector();
   const nestSel = constSelector(asyncSel);

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+obviz
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {act} = require('ReactTestUtils');
+
+const atom = require('../../recoil_values/Recoil_atom');
+const constSelector = require('../../recoil_values/Recoil_const');
+const {asyncSelector} = require('../../testing/Recoil_TestingUtils');
+const {Snapshot, makeSnapshot} = require('../Recoil_Snapshot');
+
+test('Read default loadable from snapshot', () => {
+  const snapshot: Snapshot = makeSnapshot();
+
+  const myAtom = atom({
+    key: 'Snapshot Atom Default',
+    default: 'DEFAULT',
+  });
+
+  const atomLoadable = snapshot.getLoadable(myAtom);
+  expect(atomLoadable.state).toEqual('hasValue');
+  expect(atomLoadable.contents).toEqual('DEFAULT');
+
+  const mySelector = constSelector(myAtom);
+  const selectorLoadable = snapshot.getLoadable(mySelector);
+  expect(selectorLoadable.state).toEqual('hasValue');
+  expect(selectorLoadable.contents).toEqual('DEFAULT');
+});
+
+test('Read async selector from snapshot', async () => {
+  const snapshot = makeSnapshot();
+
+  const [asyncSel, resolve] = asyncSelector();
+  const nestSel = constSelector(asyncSel);
+
+  expect(snapshot.getLoadable(asyncSel).state).toEqual('loading');
+  expect(snapshot.getLoadable(nestSel).state).toEqual('loading');
+
+  act(() => resolve('SET VALUE'));
+  await expect(snapshot.getPromise(asyncSel)).resolves.toEqual('SET VALUE');
+  await expect(snapshot.getPromise(nestSel)).resolves.toEqual('SET VALUE');
+});

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -550,7 +550,7 @@ class Sentinel {}
 const SENTINEL = new Sentinel();
 
 function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
-  fn: (CallbackInterface, ...Args) => Return,
+  fn: CallbackInterface => (...Args) => Return,
   deps?: $ReadOnlyArray<mixed>,
 ): (...Args) => Return {
   const storeRef = useStoreRef();
@@ -601,7 +601,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
       let ret = SENTINEL;
       ReactDOM.unstable_batchedUpdates(() => {
         // flowlint-next-line unclear-type:off
-        ret = (fn: any)({getPromise, getLoadable, set, reset}, ...args);
+        ret = (fn: any)({getPromise, getLoadable, set, reset})(...args);
       });
       invariant(
         !(ret instanceof Sentinel),

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -55,9 +55,8 @@ const mergeMaps = require('../util/Recoil_mergeMaps');
 const recoverableViolation = require('../util/Recoil_recoverableViolation');
 const Tracing = require('../util/Recoil_Tracing');
 
-function cloneState(state: TreeState, opts): TreeState {
+function cloneState(state: TreeState): TreeState {
   return {
-    isSnapshot: opts.isSnapshot,
     transactionMetadata: {...state.transactionMetadata},
     atomValues: new Map(state.atomValues),
     nonvalidatedAtoms: new Map(state.nonvalidatedAtoms),
@@ -369,9 +368,7 @@ function useTreeStateClone(): TreeState {
   const forceUpdate = useCallback(() => setState(x => x + 1), []);
   useTransactionSubscription(forceUpdate);
   const storeRef = useStoreRef();
-  return cloneState(storeRef.current.getState().currentTree, {
-    isSnapshot: true,
-  });
+  return cloneState(storeRef.current.getState().currentTree);
 }
 
 type UpdatedSnapshot = {
@@ -557,9 +554,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
 
   return useCallback(
     (...args) => {
-      let snapshot = cloneState(storeRef.current.getState().currentTree, {
-        isSnapshot: true,
-      });
+      let snapshot = cloneState(storeRef.current.getState().currentTree);
 
       function getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
         let result: Loadable<T>;

--- a/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -38,9 +38,9 @@ describe('useRecoilCallback', () => {
     let cb;
 
     function Component() {
-      cb = useRecoilCallback(({getPromise}) => () => {
+      cb = useRecoilCallback(({snapshot}) => () => {
         // eslint-disable-next-line jest/valid-expect
-        pTest = expect(getPromise(anAtom)).resolves.toBe('DEFAULT');
+        pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
       });
       return null;
     }
@@ -61,12 +61,12 @@ describe('useRecoilCallback', () => {
     let cb;
 
     function Component() {
-      cb = useRecoilCallback(({getLoadable}) => () => {
-        expect(getLoadable(anAtom)).toMatchObject({
+      cb = useRecoilCallback(({snapshot}) => () => {
+        expect(snapshot.getLoadable(anAtom)).toMatchObject({
           state: 'hasValue',
           contents: 123,
         });
-        expect(getLoadable(asyncSelector)).toMatchObject({
+        expect(snapshot.getLoadable(asyncSelector)).toMatchObject({
           state: 'loading',
         });
         didRun = true; // ensure these assertions do get made
@@ -85,10 +85,10 @@ describe('useRecoilCallback', () => {
     let pTest = Promise.reject(new Error("Callback didn't resolve"));
 
     function Component() {
-      cb = useRecoilCallback(({getPromise, set}) => value => {
+      cb = useRecoilCallback(({snapshot, set}) => value => {
         set(anAtom, value);
         // eslint-disable-next-line jest/valid-expect
-        pTest = expect(getPromise(anAtom)).resolves.toBe('DEFAULT');
+        pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
       });
       return null;
     }
@@ -136,11 +136,11 @@ describe('useRecoilCallback', () => {
     const pTest = [];
 
     function Component() {
-      cb = useRecoilCallback(({getPromise, set}) => async value => {
+      cb = useRecoilCallback(({snapshot, set}) => async value => {
         set(anAtom, value);
         pTest.push(
           // eslint-disable-next-line jest/valid-expect
-          expect(getPromise(anAtom)).resolves.toBe(
+          expect(snapshot.getPromise(anAtom)).resolves.toBe(
             value === 123 ? 'DEFAULT' : 123,
           ),
         );
@@ -179,9 +179,9 @@ describe('useRecoilCallback', () => {
 
     function Component() {
       setter = useSetRecoilState(anAtom);
-      cb = useRecoilCallback(({getPromise}) => async () => {
+      cb = useRecoilCallback(({snapshot}) => async () => {
         await delay();
-        seenValue = await getPromise(anAtom);
+        seenValue = await snapshot.getPromise(anAtom);
       });
       return null;
     }

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {RecoilState, RecoilValue} from 'Recoil_RecoilValue';
-import type {Store, StoreState, TreeState} from 'Recoil_State';
+import type {Store} from 'Recoil_State';
 
 const React = require('React');
 const ReactDOM = require('ReactDOM');
@@ -19,6 +19,7 @@ const {act} = require('ReactTestUtils');
 
 const {RecoilRoot} = require('../components/Recoil_RecoilRoot.react');
 const {fireNodeSubscriptions} = require('../core/Recoil_FunctionalCore');
+const {makeEmptyStoreState} = require('../core/Recoil_State');
 const {
   useRecoilValue,
   useResetRecoilState,
@@ -31,31 +32,9 @@ const stableStringify = require('../util/Recoil_stableStringify');
 // This isn't a test but is used in tests so Jest will be present:
 declare var jest: JestObjectType;
 
-function makeTreeState(): TreeState {
-  return {
-    isSnapshot: false,
-    atomValues: new Map(),
-    nonvalidatedAtoms: new Map(),
-    dirtyAtoms: new Set(),
-    nodeDeps: new Map(),
-    nodeToNodeSubscriptions: new Map(),
-    nodeToComponentSubscriptions: new Map(),
-    transactionMetadata: {},
-  };
-}
-
-function makeStoreState(): StoreState {
-  return {
-    currentTree: makeTreeState(),
-    nextTree: null,
-    transactionSubscriptions: new Map(),
-    queuedComponentCallbacks: [],
-    suspendedComponentResolvers: new Set(),
-  };
-}
-
+// TODO Use Snapshot for testing instead of this thunk?
 function makeStore(): Store {
-  const state = makeStoreState();
+  const state = makeEmptyStoreState();
   const store = {
     getState: () => state,
     replaceState: replacer => {
@@ -198,7 +177,6 @@ function flushPromisesAndTimers(): Promise<mixed> {
 }
 
 module.exports = {
-  makeTreeState,
   makeStore,
   renderElements,
   ReadsAtom,


### PR DESCRIPTION
Summary:
Update `useRecoilCallback()` to use the `Snapshot` interface based on the Snapshot proposal

```
type CallbackInterface = {
  set: <T>(RecoilState<T>, T | DefaultValue | (T) => T | DefaultValue) => void,
  reset: <T>(RecoilState<T>) => void,
  snapshot: Snapshot,
  gotoSnapsot: Snapshot => void  // TODO
};

function useRecoilCallback(
  CallbackInterface => Args => Return,
): Args => Return
```

Notice that this has a similar interface as the current `useRecoilCallback()` API (with the wrapped callback RFC proposal), but moves the snapshot accessors to use a `Snapshot` object instead.  The `set`/`reset` callbacks affect the current state, not the snapshot.

NOTE: This is a breaking change, but we are still on version `0.0.x` for semantic versioning.

Reviewed By: davidmccabe

Differential Revision: D21705808

