### PR TITLE
use real timers in async test

### DIFF
--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -30,6 +30,7 @@ const {
   ReadsAtom,
   renderElements,
   resolvingAsyncSelector,
+  waitFor,
 } = require('../../testing/Recoil_TestingUtils');
 const {DefaultValue} = require('../../core/Recoil_Node');
 
@@ -115,12 +116,15 @@ test('selector reset', () => {
   expect(get(selectorRW)).toEqual('DEFAULT');
 });
 
-test('useRecoilState - resolved async selector', () => {
+test('useRecoilState - resolved async selector', async () => {
+  jest.useRealTimers();
   const resolvingSel = resolvingAsyncSelector('HELLO');
   const c = renderElements(<ReadsAtom atom={resolvingSel} />);
   expect(c.textContent).toEqual('loading');
-  act(() => jest.runAllTimers());
-  expect(c.textContent).toEqual('"HELLO"');
+  await waitFor(() => {
+    act(() => {});
+    return c.textContent === '"HELLO"';
+  });
 });
 
 test('selector - evaluate to RecoilValue', () => {

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -197,6 +197,31 @@ function flushPromisesAndTimers(): Promise<mixed> {
   });
 }
 
+// Async util function that calls predicate multiple times until it returns `true`
+// or throws if predicate never returned `true` and the function reached its timeout
+// Example:
+//    let x = 0;
+//    setTimeout(() => x = 1, 1000);
+//    await waitFor(() => x === 1);
+async function waitFor(
+  fn: () => boolean,
+  message?: string,
+  timeout: number = 1000,
+) {
+  const error = new Error(
+    message != null
+      ? message
+      : 'Expected the function to start returning "true" but it never did',
+  );
+  const startTime = Date.now();
+  while (!Boolean(fn())) {
+    if (Date.now() - startTime > timeout) {
+      throw error;
+    }
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+}
+
 module.exports = {
   makeTreeState,
   makeStore,
@@ -208,4 +233,5 @@ module.exports = {
   loadingAsyncSelector,
   asyncSelector,
   flushPromisesAndTimers,
+  waitFor,
 };


### PR DESCRIPTION
i was debugging these tests and got confused by fake timers. 
fake timers are always a huge pain to work with and debug and sometimes it's much easier just wait for the right value to appear in the datastructur we need it to be in, even though it will cause a slight slowdown in the test suite. (of course not all cases are that simple and some cases do require fake timers)

i added a `waitFor` function and fixed one test

cc @mondaychen 