### PR TITLE
Remove parameters from Hooks sidebar links

### DIFF
--- a/docs/docs/api-reference/core/useRecoilCallback.md
+++ b/docs/docs/api-reference/core/useRecoilCallback.md
@@ -1,5 +1,6 @@
 ---
 title: useRecoilCallback(callback)
+sidebar_label: useRecoilCallback()
 ---
 
 ***NOTE***: *Minor changes to this API are expected soon.*

--- a/docs/docs/api-reference/core/useRecoilStateLoadable.md
+++ b/docs/docs/api-reference/core/useRecoilStateLoadable.md
@@ -1,5 +1,6 @@
 ---
 title: useRecoilStateLoadable(state)
+sidebar_label: useRecoilStateLoadable()
 ---
 
 TODO Documentation

--- a/docs/docs/api-reference/core/useResetRecoilState.md
+++ b/docs/docs/api-reference/core/useResetRecoilState.md
@@ -1,5 +1,6 @@
 ---
 title: useResetRecoilState(state)
+sidebar_label: useResetRecoilState()
 ---
 
 Returns a function that will reset the value of the given state to its default value.


### PR DESCRIPTION
Only three of the seven sidebar links for the Hooks include their parameters.
To keep the sidebar readable--especially once you inevitably add a hook
with more than one parameter--omit all parameters.