### PR TITLE
Fix selector() options "set: SetRecoilValue" type to "SetRecoilState"

### DIFF
--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -18,7 +18,7 @@ function selector<T>({
   set?: (
     {
       get: GetRecoilValue,
-      set: SetRecoilValue,
+      set: SetRecoilState,
       reest: ResetRecoilValue,
     },
     newValue: T | DefaultValue,


### PR DESCRIPTION
The setter function is defined as SetRecoilState, but the selector's
options.set type is SetRecoilValue which I do not see defined anywhere.

Note: I still feel SetRecoilValue is better as it matches what it does
and mirrors GetRecoilValue. Additionally, the useSetRecoilState() hook
should be renamed to useSetRecoilValue() to match useRecoilValue().

Given the typo this commit fixes, I am not alone. :)