### PR TITLE
fix: add window and dev check in stableStringify

### DIFF
--- a/src/util/Recoil_stableStringify.js
+++ b/src/util/Recoil_stableStringify.js
@@ -126,23 +126,29 @@ function stringify(x: mixed, opt: Options, key?: string): string {
 // * We could support BigInt, but Flow doesn't seem to like it.
 // See Recoil_stableStringify-test.js for examples
 function stableStringify(x: mixed, opt?: Options): string {
-  const startTime = window.performance ? window.performance.now() : 0;
-
-  const str = stringify(x, opt ?? {allowFunctions: undefined});
-
-  const endTime = window.performance ? window.performance.now() : 0;
   if (__DEV__) {
-    if (endTime - startTime > TIME_WARNING_THRESHOLD_MS) {
-      /* eslint-disable fb-www/no-console */
-      console.groupCollapsed(
-        `Recoil: Spent ${endTime - startTime}ms computing a cache key`,
-      );
-      console.warn(x, str);
-      console.groupEnd();
-      /* eslint-enable fb-www/no-console */
+    if (typeof window !== 'undefined') {
+      const startTime = window.performance ? window.performance.now() : 0;
+
+      const str = stringify(x, opt ?? {allowFunctions: undefined});
+
+      const endTime = window.performance ? window.performance.now() : 0;
+
+      if (endTime - startTime > TIME_WARNING_THRESHOLD_MS) {
+        /* eslint-disable fb-www/no-console */
+        console.groupCollapsed(
+          `Recoil: Spent ${endTime - startTime}ms computing a cache key`,
+        );
+        console.warn(x, str);
+        console.groupEnd();
+        /* eslint-enable fb-www/no-console */
+      }
+
+      return str;
     }
   }
-  return str;
+
+  return stringify(x, opt ?? {allowFunctions: undefined});
 }
 
 module.exports = stableStringify;


### PR DESCRIPTION
While playing around with Recoil this weekend, I tried to use `selectorFamily` but it seems to be using `stableStringify` which has an unchecked window call, and with something like next.js it was causing errors on the server. This fixes it!