### PR TITLE
Fix broken async related tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "jest-cli": "^26.0.1",
     "lint-staged": ">=10",
     "prettier": "^2.0.5",
+    "promise-polyfill": "^8.1.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "rollup": "^2.10.0",
@@ -53,7 +54,10 @@
     "timers": "fake",
     "globals": {
       "__DEV__": true
-    }
+    },
+    "setupFiles": [
+      "./setupJestMock.js"
+    ]
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "jest-cli": "^26.0.1",
     "lint-staged": ">=10",
     "prettier": "^2.0.5",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "rollup": "^2.10.0",
     "rollup-plugin-includepaths": "^0.2.3",
     "rollup-plugin-terser": "^5.3.0"

--- a/setupJestMock.js
+++ b/setupJestMock.js
@@ -1,0 +1,3 @@
+const Promise = require('promise-polyfill');
+
+global.Promise = Promise;

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -448,7 +448,7 @@ test('selector is able to track dependencies discovered asynchronously', async (
 
   expect(container.textContent).toEqual('loading');
 
-  await get(selectorWithAsyncDeps);
+  await act(() => get(selectorWithAsyncDeps));
   await flushPromisesAndTimers();
 
   expect(container.textContent).toEqual('Async Dep Value');
@@ -457,7 +457,7 @@ test('selector is able to track dependencies discovered asynchronously', async (
 
   expect(container.textContent).toEqual('loading');
 
-  await get(selectorWithAsyncDeps);
+  await act(() => get(selectorWithAsyncDeps));
   await flushPromisesAndTimers();
 
   expect(container.textContent).toEqual('CHANGED Async Dep');
@@ -504,7 +504,7 @@ test('selector should rerun entire selector when a dep changes', async () => {
 
   expect(container.textContent).toEqual('loading');
 
-  await get(selectorWithAsyncDeps);
+  await act(() => get(selectorWithAsyncDeps));
   act(() => jest.runAllTimers());
 
   expect(container.textContent).toEqual('6');
@@ -513,7 +513,7 @@ test('selector should rerun entire selector when a dep changes', async () => {
 
   expect(container.textContent).toEqual('loading');
 
-  await get(selectorWithAsyncDeps);
+  await act(() => get(selectorWithAsyncDeps));
   act(() => jest.runAllTimers());
 
   expect(container.textContent).toEqual('7');
@@ -616,7 +616,7 @@ test('selector - dynamic getRecoilValue()', async () => {
   const el = renderElements(<ReadsAtom atom={sel1} />);
   expect(el.textContent).toEqual('loading');
 
-  await get(sel1);
+  await act(() => get(sel1));
   act(() => jest.runAllTimers());
 
   expect(el.textContent).toEqual('"READY"');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,6 +3506,11 @@ pretty-format@^26.0.1:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
+
 prompts@^2.0.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2811,7 +2811,7 @@ jest-worker@^26.0.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3036,6 +3036,13 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+loose-envify@^1.1.0, loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
 magic-string@^0.25.2, magic-string@^0.25.5:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -3249,6 +3256,11 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -3502,6 +3514,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -3525,10 +3546,29 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-react-is@^16.12.0:
+react-dom@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
+react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -3763,6 +3803,14 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Current master:
Test Suites: 8 failed, 12 passed, 20 total
Tests:       42 failed, 113 passed, 155 total

This branch:
Test Suites: 4 failed, 16 passed, 20 total
Tests:       7 failed, 148 passed, 155 total

Two things this PR does:
- Adding 'promise-polyfill' as dev dependency use `setTimeout` based `Promise` instead of native to mock FB internal behavior. This will allow `jest.runAllTimers()` flush Promises as well. 
- Some manual fixes on Recoil_selector-test.js (additional `await` on async selectors)