### PR TITLE
Fix recording node subscriptions

### DIFF
--- a/src/recoil_values/Recoil_selector_OLD.js
+++ b/src/recoil_values/Recoil_selector_OLD.js
@@ -267,7 +267,7 @@ function selector<T>(
 
     function getRecoilValue<S>({key}: RecoilValue<S>): S {
       let loadable: Loadable<S>;
-      [newState, loadable] = getNodeLoadable(store, state, key);
+      [newState, loadable] = getNodeLoadable(store, newState, key);
       depValues.set(key, loadable);
       if (loadable.state === 'hasValue') {
         return loadable.contents;


### PR DESCRIPTION
Summary: Fix recording selector subscriptions properly for selectors that were evaluated for the first time from a selector before evaluating other dependencies.

Reviewed By: davidmccabe

Differential Revision: D21969655

