### PR TITLE
useGotoRecoilSnapshot() hook

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -41,13 +41,13 @@ const {
   useRecoilCallback,
   useRecoilState,
   useRecoilStateLoadable,
+  useRecoilTransactionObserver,
   useRecoilValue,
   useRecoilValueLoadable,
   useResetRecoilState,
   useSetRecoilState,
   useSetUnvalidatedAtomValues,
-  useTransactionObservation,
-  useTransactionSubscription,
+  useTransactionObservation_DEPRECATED,
 } = require('./hooks/Recoil_Hooks');
 const atom = require('./recoil_values/Recoil_atom');
 const atomFamily = require('./recoil_values/Recoil_atomFamily');
@@ -93,8 +93,8 @@ module.exports = {
   useRecoilCallback,
 
   // Hooks for Persistence/Debugging
-  useTransactionObservation_UNSTABLE: useTransactionObservation,
-  useTransactionSubscription_UNSTABLE: useTransactionSubscription,
+  useRecoilTransactionObserver,
+  useTransactionObservation_UNSTABLE: useTransactionObservation_DEPRECATED,
   useSetUnvalidatedAtomValues_UNSTABLE: useSetUnvalidatedAtomValues,
 
   // Concurrency Helpers

--- a/src/components/Recoil_Link.react.js
+++ b/src/components/Recoil_Link.react.js
@@ -40,8 +40,9 @@
 import type {RecoilState} from '../core/Recoil_RecoilValue';
 
 const React = require('React');
+
 const {
-  useGoToSnapshot,
+  useGoToSnapshot_DEPRECATED,
   useSnapshotWithStateChange,
 } = require('../hooks/Recoil_Hooks');
 
@@ -62,7 +63,7 @@ function Link({
   target,
   ...rest
 }: Props): React.Element<'a'> {
-  const goToSnapshot = useGoToSnapshot();
+  const goToSnapshot = useGoToSnapshot_DEPRECATED();
   const snapshot = useSnapshotWithStateChange(update => stateChange(update));
 
   function myOnClick(event) {

--- a/src/components/Recoil_RecoilRoot.react.js
+++ b/src/components/Recoil_RecoilRoot.react.js
@@ -11,13 +11,7 @@
 'use strict';
 
 import type {RecoilValue} from '../core/Recoil_RecoilValue';
-import type {
-  NodeKey,
-  Store,
-  StoreRef,
-  StoreState,
-  TreeState,
-} from '../core/Recoil_State';
+import type {NodeKey, Store, StoreRef, StoreState} from '../core/Recoil_State';
 
 const React = require('React');
 const {useContext, useEffect, useRef, useState} = require('React');
@@ -28,6 +22,7 @@ const {
   setNodeValue,
   setUnvalidatedAtomValue,
 } = require('../core/Recoil_FunctionalCore');
+const {makeEmptyStoreState} = require('../core/Recoil_State');
 const nullthrows = require('../util/Recoil_nullthrows');
 
 type Props = {
@@ -124,29 +119,6 @@ if (__DEV__) {
   if (typeof window !== 'undefined' && !window.$recoilDebugStates) {
     window.$recoilDebugStates = [];
   }
-}
-
-function makeEmptyTreeState(): TreeState {
-  return {
-    isSnapshot: false,
-    transactionMetadata: {},
-    atomValues: new Map(),
-    nonvalidatedAtoms: new Map(),
-    dirtyAtoms: new Set(),
-    nodeDeps: new Map(),
-    nodeToNodeSubscriptions: new Map(),
-    nodeToComponentSubscriptions: new Map(),
-  };
-}
-
-function makeEmptyStoreState(): StoreState {
-  return {
-    currentTree: makeEmptyTreeState(),
-    nextTree: null,
-    transactionSubscriptions: new Map(),
-    queuedComponentCallbacks: [],
-    suspendedComponentResolvers: new Set(),
-  };
 }
 
 function initialStoreState(store, initializeState) {

--- a/src/components/Recoil_RecoilRoot.react.js
+++ b/src/components/Recoil_RecoilRoot.react.js
@@ -78,7 +78,7 @@ function Batcher(props: {setNotifyBatcherOfChange: (() => void) => void}) {
     // call useEffect in an unpredictable order sometimes.
     Queue.enqueueExecution('Batcher', () => {
       const storeState = storeRef.current.getState();
-      const {currentTree, nextTree} = storeState;
+      const {nextTree} = storeState;
 
       // Ignore commits that are not because of Recoil transactions -- namely,
       // because something above RecoilRoot re-rendered:
@@ -89,11 +89,8 @@ function Batcher(props: {setNotifyBatcherOfChange: (() => void) => void}) {
       // Inform transaction subscribers of the transaction:
       const dirtyAtoms = nextTree.dirtyAtoms;
       if (dirtyAtoms.size) {
-        // NOTE that this passes the committed (current, aka previous) tree,
-        // whereas the nextTree is retrieved from storeRef by the transaction subscriber.
-        // (This interface can be cleaned up, TODO)
         storeState.transactionSubscriptions.forEach(sub =>
-          sub(storeRef.current, currentTree),
+          sub(storeRef.current),
         );
       }
 

--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -25,8 +25,8 @@ const {
   mapByUpdatingInMap,
   setByAddingToSet,
 } = require('../util/Recoil_CopyOnWrite');
-const {getNode} = require('./Recoil_Node');
 const Tracing = require('../util/Recoil_Tracing');
+const {getNode} = require('./Recoil_Node');
 
 // flowlint-next-line unclear-type:off
 const emptyMap: $ReadOnlyMap<any, any> = Object.freeze(new Map());
@@ -174,7 +174,7 @@ function fireNodeSubscriptions(
 
   for (const key of dependentNodes) {
     (state.nodeToComponentSubscriptions.get(key) ?? []).forEach(
-      ([debugName, cb]) => {
+      ([_debugName, cb]) => {
         when === 'enqueue'
           ? store.getState().queuedComponentCallbacks.push(cb)
           : cb(state);

--- a/src/core/Recoil_RecoilValue.js
+++ b/src/core/Recoil_RecoilValue.js
@@ -14,7 +14,7 @@ import type {Loadable} from '../adt/Recoil_Loadable';
 import type {DefaultValue} from './Recoil_Node';
 import type {RecoilValue} from './Recoil_RecoilValueClasses';
 export type {RecoilValue} from './Recoil_RecoilValueClasses';
-import type {NodeKey, Store, TreeState} from './Recoil_State';
+import type {Store, TreeState} from './Recoil_State';
 
 const Tracing = require('../util/Recoil_Tracing');
 const {

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+obviz
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {Loadable} from '../adt/Recoil_Loadable';
+import type {RecoilValue} from './Recoil_RecoilValue';
+import type {Store} from './Recoil_State';
+
+const {getRecoilValueAsLoadable} = require('./Recoil_RecoilValue');
+const {makeEmptyStoreState} = require('./Recoil_State');
+const gkx = require('gkx');
+
+function makeStore(): Store {
+  const storeState = makeEmptyStoreState();
+  const store = {
+    getState: () => storeState,
+    replaceState: replacer => {
+      storeState.currentTree = replacer(storeState.currentTree); // no batching so nextTree is never active
+    },
+    subscribeToTransactions: () => {
+      throw new Error('Cannot subscribe to Snapshots');
+    },
+    addTransactionMetadata: () => {
+      throw new Error('Cannot subscribe to Snapshots');
+    },
+    fireNodeSubscriptions: () => {},
+  };
+  return store;
+}
+
+// A "Snapshot" is "read-only" and captures a specific set of values of atoms.
+// However, the data-flow-graph and selector values may evolve as selector
+// evaluation functions are executed and async selectors resolve.
+class Snapshot {
+  _store: Store;
+
+  constructor(store: Store) {
+    this._store = store;
+  }
+
+  getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
+    return getRecoilValueAsLoadable(this._store, recoilValue);
+  }
+
+  getPromise<T>(recoilValue: RecoilValue<T>): Promise<T> {
+    if (gkx('recoil_async_selector_refactor')) {
+      return this.getLoadable(recoilValue)
+        .toPromise()
+        .then(({value}) => value);
+    } else {
+      return (this.getLoadable(recoilValue).toPromise(): $FlowFixMe);
+    }
+  }
+}
+
+function makeSnapshot(): Snapshot {
+  return new Snapshot(makeStore());
+}
+
+module.exports = {
+  Snapshot,
+  makeSnapshot,
+};

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -84,6 +84,18 @@ class Snapshot {
     const newState = mutableSnapshot.getStore_INTERNAL().getState().currentTree;
     return cloneSnapshot(newState);
   };
+
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  asyncMap: (
+    (MutableSnapshot) => Promise<void>,
+  ) => Promise<Snapshot> = async mapper => {
+    const mutableSnapshot = new MutableSnapshot(
+      this._store.getState().currentTree,
+    );
+    await mapper(mutableSnapshot);
+    const newState = mutableSnapshot.getStore_INTERNAL().getState().currentTree;
+    return cloneSnapshot(newState);
+  };
 }
 
 function cloneTreeState(treeState: TreeState): TreeState {

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -11,11 +11,21 @@
 'use strict';
 
 import type {Loadable} from '../adt/Recoil_Loadable';
-import type {RecoilValue} from './Recoil_RecoilValue';
+import type {
+  ResetRecoilState,
+  SetRecoilState,
+  ValueOrUpdater,
+} from '../recoil_values/Recoil_selector';
+import type {RecoilState, RecoilValue} from './Recoil_RecoilValue';
 import type {Store, TreeState} from './Recoil_State';
 
 const mapMap = require('../util/Recoil_mapMap');
-const {getRecoilValueAsLoadable} = require('./Recoil_RecoilValue');
+const {DEFAULT_VALUE} = require('./Recoil_Node');
+const {
+  getRecoilValueAsLoadable,
+  setRecoilValue,
+  valueFromValueOrUpdater,
+} = require('./Recoil_RecoilValue');
 const {makeEmptyTreeState, makeStoreState} = require('./Recoil_State');
 const gkx = require('gkx');
 
@@ -47,6 +57,10 @@ class Snapshot {
     this._store = makeStore(treeState);
   }
 
+  getStore_INTERNAL(): Store {
+    return this._store;
+  }
+
   getLoadable: <T>(RecoilValue<T>) => Loadable<T> = <T>(
     recoilValue: RecoilValue<T>,
   ) => getRecoilValueAsLoadable(this._store, recoilValue);
@@ -59,16 +73,21 @@ class Snapshot {
           .toPromise()
           .then(({value}) => value)
       : (this.getLoadable(recoilValue).toPromise(): $FlowFixMe);
+
+  // We want to allow the methods to be destructured and used as accessors
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  map: ((MutableSnapshot) => void) => Snapshot = mapper => {
+    const mutableSnapshot = new MutableSnapshot(
+      this._store.getState().currentTree,
+    );
+    mapper(mutableSnapshot);
+    const newState = mutableSnapshot.getStore_INTERNAL().getState().currentTree;
+    return cloneSnapshot(newState);
+  };
 }
 
-// Factory to build a fresh snapshot
-function freshSnapshot(): Snapshot {
-  return new Snapshot(makeEmptyTreeState());
-}
-
-// Factory to clone a snapahot state
-function cloneSnapshot(treeState: TreeState): Snapshot {
-  return new Snapshot({
+function cloneTreeState(treeState: TreeState): TreeState {
+  return {
     transactionMetadata: {...treeState.transactionMetadata},
     atomValues: new Map(treeState.atomValues),
     nonvalidatedAtoms: new Map(treeState.nonvalidatedAtoms),
@@ -79,7 +98,41 @@ function cloneSnapshot(treeState: TreeState): Snapshot {
       keys => new Set(keys),
     ),
     nodeToComponentSubscriptions: new Map(),
-  });
+  };
+}
+
+// Factory to build a fresh snapshot
+function freshSnapshot(): Snapshot {
+  return new Snapshot(makeEmptyTreeState());
+}
+
+// Factory to clone a snapahot state
+function cloneSnapshot(treeState: TreeState): Snapshot {
+  return new Snapshot(cloneTreeState(treeState));
+}
+
+class MutableSnapshot extends Snapshot {
+  constructor(treeState: TreeState) {
+    super(cloneTreeState(treeState));
+  }
+
+  // We want to allow the methods to be destructured and used as accessors
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  set: SetRecoilState = <T>(
+    recoilState: RecoilState<T>,
+    newValueOrUpdater: ValueOrUpdater<T>,
+  ) => {
+    const store = this.getStore_INTERNAL();
+    const newValue = valueFromValueOrUpdater(
+      store,
+      recoilState,
+      newValueOrUpdater,
+    );
+    setRecoilValue(store, recoilState, newValue);
+  };
+
+  reset: ResetRecoilState = recoilState =>
+    setRecoilValue(this.getStore_INTERNAL(), recoilState, DEFAULT_VALUE);
 }
 
 module.exports = {

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -29,11 +29,12 @@ export type TreeState = $ReadOnly<{
   atomValues: AtomValues,
   nonvalidatedAtoms: Map<NodeKey, mixed>,
 
-  // NODE GRAPH -- will soon move to StoreState
+  // NODE GRAPH
   // Upstream Node dependencies
   nodeDeps: Map<NodeKey, Set<NodeKey>>,
   // Downstream Node subscriptions
   nodeToNodeSubscriptions: Map<NodeKey, Set<NodeKey>>,
+  // TODO -- will soon move to StoreState
   nodeToComponentSubscriptions: Map<
     NodeKey,
     Map<number, [string, ComponentCallback]>,

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -94,9 +94,9 @@ function makeEmptyTreeState(): TreeState {
   };
 }
 
-function makeEmptyStoreState(): StoreState {
+function makeStoreState(treeState: TreeState): StoreState {
   return {
-    currentTree: makeEmptyTreeState(),
+    currentTree: treeState,
     nextTree: null,
     transactionSubscriptions: new Map(),
     queuedComponentCallbacks: [],
@@ -104,7 +104,12 @@ function makeEmptyStoreState(): StoreState {
   };
 }
 
+function makeEmptyStoreState(): StoreState {
+  return makeStoreState(makeEmptyTreeState());
+}
+
 module.exports = {
   makeEmptyTreeState,
   makeEmptyStoreState,
+  makeStoreState,
 };

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -55,7 +55,7 @@ export type StoreState = {
   nextTree: null | TreeState,
 
   // For observing transactions:
-  +transactionSubscriptions: Map<number, (Store, previous: TreeState) => void>,
+  +transactionSubscriptions: Map<number, (Store) => void>,
 
   // Callbacks to render external components that are subscribed to nodes
   // These are executed at the end of the transaction or asynchronously.
@@ -68,9 +68,7 @@ export type StoreState = {
 export type Store = $ReadOnly<{
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
-  subscribeToTransactions: (
-    (Store, previous: TreeState) => void,
-  ) => {release: () => void, ...},
+  subscribeToTransactions: ((Store) => void) => {release: () => void},
   addTransactionMetadata: ({...}) => void,
   fireNodeSubscriptions: (
     updatedNodes: $ReadOnlySet<NodeKey>,

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -22,7 +22,6 @@ type ComponentCallback = TreeState => void;
 
 export type TreeState = $ReadOnly<{
   // Information about the TreeState itself:
-  isSnapshot: boolean,
   transactionMetadata: {...},
   dirtyAtoms: Set<NodeKey>,
 
@@ -83,4 +82,29 @@ export type StoreRef = {
   current: Store,
 };
 
-module.exports = ({}: {...});
+function makeEmptyTreeState(): TreeState {
+  return {
+    transactionMetadata: {},
+    atomValues: new Map(),
+    nonvalidatedAtoms: new Map(),
+    dirtyAtoms: new Set(),
+    nodeDeps: new Map(),
+    nodeToNodeSubscriptions: new Map(),
+    nodeToComponentSubscriptions: new Map(),
+  };
+}
+
+function makeEmptyStoreState(): StoreState {
+  return {
+    currentTree: makeEmptyTreeState(),
+    nextTree: null,
+    transactionSubscriptions: new Map(),
+    queuedComponentCallbacks: [],
+    suspendedComponentResolvers: new Set(),
+  };
+}
+
+module.exports = {
+  makeEmptyTreeState,
+  makeEmptyStoreState,
+};

--- a/src/core/__tests__/Recoil_RecoilValueInterface-test.js
+++ b/src/core/__tests__/Recoil_RecoilValueInterface-test.js
@@ -11,14 +11,13 @@
 'use strict';
 
 const atom = require('../../recoil_values/Recoil_atom');
+const selector = require('../../recoil_values/Recoil_selector');
+const {makeStore} = require('../../testing/Recoil_TestingUtils');
 const {
   getRecoilValueAsLoadable,
-  peekRecoilValueAsLoadable,
   setRecoilValue,
   subscribeToRecoilValue,
 } = require('../Recoil_RecoilValue');
-const selector = require('../../recoil_values/Recoil_selector');
-const {makeStore} = require('../../testing/Recoil_TestingUtils');
 
 const a = atom<number>({key: 'a', default: 0});
 const dependsOnAFn = jest.fn(x => x + 1);
@@ -33,7 +32,7 @@ const dependsOnDependsOnA = selector({
 
 test('read default value', () => {
   const store = makeStore();
-  expect(peekRecoilValueAsLoadable(store, a)).toMatchObject({
+  expect(getRecoilValueAsLoadable(store, a)).toMatchObject({
     state: 'hasValue',
     contents: 0,
   });
@@ -42,7 +41,7 @@ test('read default value', () => {
 test('read written value, visited contains written value', () => {
   const store = makeStore();
   setRecoilValue(store, a, 1);
-  expect(peekRecoilValueAsLoadable(store, a)).toMatchObject({
+  expect(getRecoilValueAsLoadable(store, a)).toMatchObject({
     state: 'hasValue',
     contents: 1,
   });
@@ -50,13 +49,13 @@ test('read written value, visited contains written value', () => {
 
 test('read selector based on default upstream', () => {
   const store = makeStore();
-  expect(peekRecoilValueAsLoadable(store, dependsOnA).contents).toEqual(1);
+  expect(getRecoilValueAsLoadable(store, dependsOnA).contents).toEqual(1);
 });
 
 test('read selector based on written upstream', () => {
   const store = makeStore();
   setRecoilValue(store, a, 1);
-  expect(peekRecoilValueAsLoadable(store, dependsOnA).contents).toEqual(2);
+  expect(getRecoilValueAsLoadable(store, dependsOnA).contents).toEqual(2);
 });
 
 test('selector subscriber is called when upstream changes', () => {

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -15,10 +15,10 @@ const {act} = require('ReactTestUtils');
 const atom = require('../../recoil_values/Recoil_atom');
 const constSelector = require('../../recoil_values/Recoil_const');
 const {asyncSelector} = require('../../testing/Recoil_TestingUtils');
-const {Snapshot, makeSnapshot} = require('../Recoil_Snapshot');
+const {Snapshot, freshSnapshot} = require('../Recoil_Snapshot');
 
 test('Read default loadable from snapshot', () => {
-  const snapshot: Snapshot = makeSnapshot();
+  const snapshot: Snapshot = freshSnapshot();
 
   const myAtom = atom({
     key: 'Snapshot Atom Default',
@@ -36,7 +36,7 @@ test('Read default loadable from snapshot', () => {
 });
 
 test('Read async selector from snapshot', async () => {
-  const snapshot = makeSnapshot();
+  const snapshot = freshSnapshot();
 
   const [asyncSel, resolve] = asyncSelector();
   const nestSel = constSelector(asyncSel);

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -37,14 +37,62 @@ test('Read default loadable from snapshot', () => {
 
 test('Read async selector from snapshot', async () => {
   const snapshot = freshSnapshot();
+  const otherA = freshSnapshot();
+  const otherB = freshSnapshot();
 
   const [asyncSel, resolve] = asyncSelector();
   const nestSel = constSelector(asyncSel);
 
   expect(snapshot.getLoadable(asyncSel).state).toEqual('loading');
   expect(snapshot.getLoadable(nestSel).state).toEqual('loading');
+  expect(otherA.getLoadable(nestSel).state).toEqual('loading');
+  const otherC = snapshot.map(() => {});
+
+  // eslint-disable-next-line jest/valid-expect
+  const ptest = expect(snapshot.getPromise(asyncSel)).resolves.toEqual(
+    'SET VALUE',
+  );
 
   act(() => resolve('SET VALUE'));
+  await ptest;
   await expect(snapshot.getPromise(asyncSel)).resolves.toEqual('SET VALUE');
+  expect(snapshot.getLoadable(asyncSel).contents).toEqual('SET VALUE');
   await expect(snapshot.getPromise(nestSel)).resolves.toEqual('SET VALUE');
+  await expect(otherA.getPromise(nestSel)).resolves.toEqual('SET VALUE');
+  await expect(otherB.getPromise(nestSel)).resolves.toEqual('SET VALUE');
+  await expect(otherC.getPromise(nestSel)).resolves.toEqual('SET VALUE');
+});
+
+test('Sync map of snapshot', () => {
+  const snapshot = freshSnapshot();
+
+  const myAtom = atom({
+    key: 'Snapshot Map Sync',
+    default: 'DEFAULT',
+  });
+
+  const atomLoadable = snapshot.getLoadable(myAtom);
+  expect(atomLoadable.state).toEqual('hasValue');
+  expect(atomLoadable.contents).toEqual('DEFAULT');
+
+  const setSnapshot = snapshot.map(({set}) => {
+    set(myAtom, 'SET');
+  });
+  const setLoadable = setSnapshot.getLoadable(myAtom);
+  expect(setLoadable.state).toEqual('hasValue');
+  expect(setLoadable.contents).toEqual('SET');
+
+  const updateSnapshot = setSnapshot.map(({set}) => {
+    set(myAtom, value => value + 'TER');
+  });
+  const updateLoadable = updateSnapshot.getLoadable(myAtom);
+  expect(updateLoadable.state).toEqual('hasValue');
+  expect(updateLoadable.contents).toEqual('SETTER');
+
+  const resetSnapshot = updateSnapshot.map(({reset}) => {
+    reset(myAtom);
+  });
+  const resetLoadable = resetSnapshot.getLoadable(myAtom);
+  expect(resetLoadable.state).toEqual('hasValue');
+  expect(resetLoadable.contents).toEqual('DEFAULT');
 });

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+obviz
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {act} = require('ReactTestUtils');
+
+const atom = require('../../recoil_values/Recoil_atom');
+const constSelector = require('../../recoil_values/Recoil_const');
+const {asyncSelector} = require('../../testing/Recoil_TestingUtils');
+const {Snapshot, makeSnapshot} = require('../Recoil_Snapshot');
+
+test('Read default loadable from snapshot', () => {
+  const snapshot: Snapshot = makeSnapshot();
+
+  const myAtom = atom({
+    key: 'Snapshot Atom Default',
+    default: 'DEFAULT',
+  });
+
+  const atomLoadable = snapshot.getLoadable(myAtom);
+  expect(atomLoadable.state).toEqual('hasValue');
+  expect(atomLoadable.contents).toEqual('DEFAULT');
+
+  const mySelector = constSelector(myAtom);
+  const selectorLoadable = snapshot.getLoadable(mySelector);
+  expect(selectorLoadable.state).toEqual('hasValue');
+  expect(selectorLoadable.contents).toEqual('DEFAULT');
+});
+
+test('Read async selector from snapshot', async () => {
+  const snapshot = makeSnapshot();
+
+  const [asyncSel, resolve] = asyncSelector();
+  const nestSel = constSelector(asyncSel);
+
+  expect(snapshot.getLoadable(asyncSel).state).toEqual('loading');
+  expect(snapshot.getLoadable(nestSel).state).toEqual('loading');
+
+  act(() => resolve('SET VALUE'));
+  await expect(snapshot.getPromise(asyncSel)).resolves.toEqual('SET VALUE');
+  await expect(snapshot.getPromise(nestSel)).resolves.toEqual('SET VALUE');
+});

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -70,29 +70,54 @@ test('Sync map of snapshot', () => {
     key: 'Snapshot Map Sync',
     default: 'DEFAULT',
   });
+  const mySelector = constSelector(myAtom);
 
   const atomLoadable = snapshot.getLoadable(myAtom);
   expect(atomLoadable.state).toEqual('hasValue');
   expect(atomLoadable.contents).toEqual('DEFAULT');
+  const selectorLoadable = snapshot.getLoadable(mySelector);
+  expect(selectorLoadable.state).toEqual('hasValue');
+  expect(selectorLoadable.contents).toEqual('DEFAULT');
 
   const setSnapshot = snapshot.map(({set}) => {
     set(myAtom, 'SET');
   });
-  const setLoadable = setSnapshot.getLoadable(myAtom);
-  expect(setLoadable.state).toEqual('hasValue');
-  expect(setLoadable.contents).toEqual('SET');
+  const setAtomLoadable = setSnapshot.getLoadable(myAtom);
+  expect(setAtomLoadable.state).toEqual('hasValue');
+  expect(setAtomLoadable.contents).toEqual('SET');
+  const setSelectorLoadable = setSnapshot.getLoadable(myAtom);
+  expect(setSelectorLoadable.state).toEqual('hasValue');
+  expect(setSelectorLoadable.contents).toEqual('SET');
 
-  const updateSnapshot = setSnapshot.map(({set}) => {
-    set(myAtom, value => value + 'TER');
-  });
-  const updateLoadable = updateSnapshot.getLoadable(myAtom);
-  expect(updateLoadable.state).toEqual('hasValue');
-  expect(updateLoadable.contents).toEqual('SETTER');
-
-  const resetSnapshot = updateSnapshot.map(({reset}) => {
+  const resetSnapshot = snapshot.map(({reset}) => {
     reset(myAtom);
   });
-  const resetLoadable = resetSnapshot.getLoadable(myAtom);
-  expect(resetLoadable.state).toEqual('hasValue');
-  expect(resetLoadable.contents).toEqual('DEFAULT');
+  const resetAtomLoadable = resetSnapshot.getLoadable(myAtom);
+  expect(resetAtomLoadable.state).toEqual('hasValue');
+  expect(resetAtomLoadable.contents).toEqual('DEFAULT');
+  const resetSelectorLoadable = resetSnapshot.getLoadable(myAtom);
+  expect(resetSelectorLoadable.state).toEqual('hasValue');
+  expect(resetSelectorLoadable.contents).toEqual('DEFAULT');
+});
+
+test('Async map of snapshot', async () => {
+  const snapshot = freshSnapshot();
+
+  const myAtom = atom({
+    key: 'Snapshot Map Async',
+    default: 'DEFAULT',
+  });
+  const [asyncSel, resolve] = asyncSelector();
+
+  const newSnapshotPromise = snapshot.asyncMap(async ({getPromise, set}) => {
+    const value = await getPromise(asyncSel);
+    expect(value).toEqual('VALUE');
+    set(myAtom, value);
+  });
+
+  act(() => resolve('VALUE'));
+
+  const newSnapshot = await newSnapshotPromise;
+  const value = await newSnapshot.getPromise(myAtom);
+  expect(value).toEqual('VALUE');
 });

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -28,12 +28,7 @@ const {
   peekNodeLoadable,
   setNodeValue,
 } = require('../core/Recoil_FunctionalCore');
-const {
-  DEFAULT_VALUE,
-  RecoilValueNotReady,
-  getNode,
-  nodes,
-} = require('../core/Recoil_Node');
+const {DEFAULT_VALUE, getNode, nodes} = require('../core/Recoil_Node');
 const {
   AbstractRecoilValue,
   getRecoilValueAsLoadable,
@@ -41,6 +36,7 @@ const {
   setRecoilValue,
   setUnvalidatedRecoilValue,
   subscribeToRecoilValue,
+  valueFromValueOrUpdater,
 } = require('../core/Recoil_RecoilValue');
 const {Snapshot, cloneSnapshot} = require('../core/Recoil_Snapshot');
 const {setByAddingToSet} = require('../util/Recoil_CopyOnWrite');
@@ -87,26 +83,6 @@ function handleLoadable<T>(loadable: Loadable<T>, atom, storeRef): T {
     throw loadable.contents;
   } else {
     throw new Error(`Invalid value of loadable atom "${atom.key}"`);
-  }
-}
-
-function valueFromValueOrUpdater(store, recoilValue, valueOrUpdater) {
-  if (typeof valueOrUpdater === 'function') {
-    // Updater form: pass in the current value. Throw if the current value
-    // is unavailable (namely when updating an async selector that's
-    // pending or errored):
-    const storeState = store.getState();
-    const state = storeState.nextTree ?? storeState.currentTree;
-    const current = peekNodeLoadable(store, state, recoilValue.key);
-    if (current.state === 'loading') {
-      throw new RecoilValueNotReady(recoilValue.key);
-    } else if (current.state === 'hasError') {
-      throw current.contents;
-    }
-    // T itself may be a function, so our refinement is not sufficient:
-    return (valueOrUpdater: any)(current.contents); // flowlint-line unclear-type:off
-  } else {
-    return valueOrUpdater;
   }
 }
 

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -550,7 +550,7 @@ class Sentinel {}
 const SENTINEL = new Sentinel();
 
 function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
-  fn: (CallbackInterface, ...Args) => Return,
+  fn: CallbackInterface => (...Args) => Return,
   deps?: $ReadOnlyArray<mixed>,
 ): (...Args) => Return {
   const storeRef = useStoreRef();
@@ -601,7 +601,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
       let ret = SENTINEL;
       ReactDOM.unstable_batchedUpdates(() => {
         // flowlint-next-line unclear-type:off
-        ret = (fn: any)({getPromise, getLoadable, set, reset}, ...args);
+        ret = (fn: any)({getPromise, getLoadable, set, reset})(...args);
       });
       invariant(
         !(ret instanceof Sentinel),

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -329,7 +329,7 @@ function useRecoilStateLoadable<T>(
   return [value, setValue];
 }
 
-function useTransactionSubscription(callback: (Store, TreeState) => void) {
+function useTransactionSubscription(callback: Store => void) {
   const storeRef = useStoreRef();
   useEffect(() => {
     const sub = storeRef.current.subscribeToTransactions(callback);
@@ -433,7 +433,7 @@ type ExternallyVisibleAtomInfo = {
           useSetUnvalidatedAtomValues hook. Useful for ignoring the useSetUnvalidatedAtomValues
           transaction, to avoid loops.
 */
-function useTransactionObservation(
+function useTransactionObservation_DEPRECATED(
   callback: ({
     atomValues: Map<NodeKey, mixed>,
     previousAtomValues: Map<NodeKey, mixed>,
@@ -444,16 +444,18 @@ function useTransactionObservation(
 ) {
   useTransactionSubscription(
     useCallback(
-      (store, previousState) => {
-        let nextTree = store.getState().nextTree;
-        if (!nextTree) {
+      store => {
+        const previousState = store.getState().currentTree;
+        let nextState = store.getState().nextTree;
+        if (!nextState) {
           recoverableViolation(
             'Transaction subscribers notified without a next tree being present -- this is a bug in Recoil',
             'recoil',
           );
-          nextTree = store.getState().currentTree; // attempt to trundle on
+          nextState = store.getState().currentTree; // attempt to trundle on
         }
-        const atomValues = externallyVisibleAtomValuesInState(nextTree);
+
+        const atomValues = externallyVisibleAtomValuesInState(nextState);
         const previousAtomValues = externallyVisibleAtomValuesInState(
           previousState,
         );
@@ -463,13 +465,43 @@ function useTransactionObservation(
             backButton: node.options?.persistence_UNSTABLE?.backButton ?? false,
           },
         }));
-        const modifiedAtoms = new Set(nextTree.dirtyAtoms);
+        const modifiedAtoms = new Set(nextState.dirtyAtoms);
+
         callback({
           atomValues,
           previousAtomValues,
           atomInfo,
           modifiedAtoms,
-          transactionMetadata: {...nextTree.transactionMetadata},
+          transactionMetadata: {...nextState.transactionMetadata},
+        });
+      },
+      [callback],
+    ),
+  );
+}
+
+function useRecoilTransactionObserver(
+  callback: ({
+    snapshot: Snapshot,
+    previousSnapshot: Snapshot,
+  }) => void,
+) {
+  useTransactionSubscription(
+    useCallback(
+      store => {
+        const previousState = store.getState().currentTree;
+        let nextState = store.getState().nextTree;
+        if (!nextState) {
+          recoverableViolation(
+            'Transaction subscribers notified without a next tree being present -- this is a bug in Recoil',
+            'recoil',
+          );
+          nextState = previousState; // attempt to trundle on
+        }
+
+        callback({
+          snapshot: cloneSnapshot(nextState),
+          previousSnapshot: cloneSnapshot(previousState),
         });
       },
       [callback],
@@ -571,9 +603,10 @@ module.exports = {
   useSetRecoilState,
   useResetRecoilState,
   useRecoilInterface: useInterface,
-  useTransactionSubscription,
   useSnapshotWithStateChange,
-  useTransactionObservation,
+  useTransactionSubscription_DEPRECATED: useTransactionSubscription,
+  useTransactionObservation_DEPRECATED,
+  useRecoilTransactionObserver,
   useGoToSnapshot,
   useSetUnvalidatedAtomValues,
 };

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -509,7 +509,7 @@ function useRecoilTransactionObserver(
   );
 }
 
-function useGoToSnapshot(): UpdatedSnapshot => void {
+function useGoToSnapshot_DEPRECATED(): UpdatedSnapshot => void {
   const storeRef = useStoreRef();
   return (snapshot: UpdatedSnapshot) => {
     ReactDOM.unstable_batchedUpdates(() => {
@@ -522,6 +522,44 @@ function useGoToSnapshot(): UpdatedSnapshot => void {
       });
     });
   };
+}
+
+function useGotoRecoilSnapshot(): Snapshot => void {
+  const storeRef = useStoreRef();
+  return useCallback(
+    (snapshot: Snapshot) => {
+      ReactDOM.unstable_batchedUpdates(() => {
+        storeRef.current.replaceState(prevState => {
+          const nextState = snapshot.getStore_INTERNAL().getState().currentTree;
+
+          // Fire subscriptions for any atoms that changed values
+          const updatedKeys = new Set();
+          // Going through both seems to be more efficient than constructing a union set of keys
+          for (const keys of [
+            prevState.atomValues.keys(),
+            nextState.atomValues.keys(),
+          ]) {
+            for (const key of keys) {
+              if (
+                prevState.atomValues.get(key)?.contents !==
+                nextState.atomValues.get(key)?.contents
+              ) {
+                updatedKeys.add(key);
+              }
+            }
+          }
+          storeRef.current.fireNodeSubscriptions(updatedKeys, 'enqueue');
+
+          return {
+            ...nextState,
+            nodeToComponentSubscriptions:
+              prevState.nodeToComponentSubscriptions,
+          };
+        });
+      });
+    },
+    [storeRef],
+  );
 }
 
 function useSetUnvalidatedAtomValues(): (
@@ -547,6 +585,7 @@ type CallbackInterface = $ReadOnly<{
   set: <T>(RecoilState<T>, (T => T) | T) => void,
   reset: <T>(RecoilState<T>) => void,
   snapshot: Snapshot,
+  gotoSnapshot: Snapshot => void,
 }>;
 
 class Sentinel {}
@@ -557,6 +596,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
   deps?: $ReadOnlyArray<mixed>,
 ): (...Args) => Return {
   const storeRef = useStoreRef();
+  const gotoSnapshot = useGotoRecoilSnapshot();
 
   return useCallback(
     (...args): Return => {
@@ -582,7 +622,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
       let ret = SENTINEL;
       ReactDOM.unstable_batchedUpdates(() => {
         // flowlint-next-line unclear-type:off
-        ret = (fn: any)({set, reset, snapshot})(...args);
+        ret = (fn: any)({set, reset, snapshot, gotoSnapshot})(...args);
       });
       invariant(
         !(ret instanceof Sentinel),
@@ -607,6 +647,7 @@ module.exports = {
   useTransactionSubscription_DEPRECATED: useTransactionSubscription,
   useTransactionObservation_DEPRECATED,
   useRecoilTransactionObserver,
-  useGoToSnapshot,
+  useGoToSnapshot_DEPRECATED,
+  useGotoRecoilSnapshot,
   useSetUnvalidatedAtomValues,
 };

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -55,9 +55,8 @@ const mergeMaps = require('../util/Recoil_mergeMaps');
 const recoverableViolation = require('../util/Recoil_recoverableViolation');
 const Tracing = require('../util/Recoil_Tracing');
 
-function cloneState(state: TreeState, opts): TreeState {
+function cloneState(state: TreeState): TreeState {
   return {
-    isSnapshot: opts.isSnapshot,
     transactionMetadata: {...state.transactionMetadata},
     atomValues: new Map(state.atomValues),
     nonvalidatedAtoms: new Map(state.nonvalidatedAtoms),
@@ -369,9 +368,7 @@ function useTreeStateClone(): TreeState {
   const forceUpdate = useCallback(() => setState(x => x + 1), []);
   useTransactionSubscription(forceUpdate);
   const storeRef = useStoreRef();
-  return cloneState(storeRef.current.getState().currentTree, {
-    isSnapshot: true,
-  });
+  return cloneState(storeRef.current.getState().currentTree);
 }
 
 type UpdatedSnapshot = {
@@ -557,9 +554,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
 
   return useCallback(
     (...args) => {
-      let snapshot = cloneState(storeRef.current.getState().currentTree, {
-        isSnapshot: true,
-      });
+      let snapshot = cloneState(storeRef.current.getState().currentTree);
 
       function getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
         let result: Loadable<T>;

--- a/src/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/src/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -42,7 +42,7 @@ const {
   useRecoilValueLoadable,
   useSetRecoilState,
   useSetUnvalidatedAtomValues,
-  useTransactionObservation,
+  useTransactionObservation_DEPRECATED,
 } = require('../Recoil_Hooks');
 
 gkx.setPass('recoil_async_selector_refactor');
@@ -170,7 +170,7 @@ function componentThatToggles(a, b) {
 }
 
 function ObservesTransactions({fn}) {
-  useTransactionObservation(fn);
+  useTransactionObservation_DEPRECATED(fn);
   return null;
 }
 

--- a/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+obviz
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const React = require('React');
+const {act} = require('ReactTestUtils');
+
+const {freshSnapshot} = require('../../core/Recoil_Snapshot');
+const {
+  useGotoRecoilSnapshot,
+  useRecoilCallback,
+} = require('../../hooks/Recoil_Hooks');
+const atom = require('../../recoil_values/Recoil_atom');
+const constSelector = require('../../recoil_values/Recoil_const');
+const selector = require('../../recoil_values/Recoil_selector');
+const {
+  ReadsAtom,
+  asyncSelector,
+  componentThatReadsAndWritesAtom,
+  flushPromisesAndTimers,
+  renderElements,
+} = require('../../testing/Recoil_TestingUtils');
+
+test('Goto mapped snapshot', async () => {
+  const snapshot = freshSnapshot();
+
+  const myAtom = atom({
+    key: 'Goto Snapshot Atom',
+    default: 'DEFAULT',
+  });
+  const [ReadsAndWritesAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);
+
+  const mySelector = constSelector(myAtom);
+
+  const updatedSnapshot = snapshot.map(({set}) => {
+    set(myAtom, 'SET IN SNAPSHOT');
+  });
+
+  let gotoRecoilSnapshot;
+  function GotoRecoilSnapshot() {
+    gotoRecoilSnapshot = useGotoRecoilSnapshot();
+    return null;
+  }
+
+  const c = renderElements(
+    <>
+      <ReadsAndWritesAtom />
+      <ReadsAtom atom={mySelector} />
+      <GotoRecoilSnapshot />
+    </>,
+  );
+
+  expect(c.textContent).toEqual('"DEFAULT""DEFAULT"');
+
+  act(() => setAtom('SET IN CURRENT'));
+  expect(c.textContent).toEqual('"SET IN CURRENT""SET IN CURRENT"');
+
+  await expect(updatedSnapshot.getPromise(myAtom)).resolves.toEqual(
+    'SET IN SNAPSHOT',
+  );
+  act(() => gotoRecoilSnapshot(updatedSnapshot));
+  expect(c.textContent).toEqual('"SET IN SNAPSHOT""SET IN SNAPSHOT"');
+
+  act(() => setAtom('SET AGAIN IN CURRENT'));
+  expect(c.textContent).toEqual('"SET AGAIN IN CURRENT""SET AGAIN IN CURRENT"');
+
+  // Test that atoms set after snapshot were created are reset
+  act(() => gotoRecoilSnapshot(snapshot));
+  expect(c.textContent).toEqual('"DEFAULT""DEFAULT"');
+});
+
+test('Goto callback snapshot', () => {
+  const myAtom = atom({
+    key: 'Goto Snapshot From Callback',
+    default: 'DEFAULT',
+  });
+  const [ReadsAndWritesAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);
+
+  const mySelector = constSelector(myAtom);
+
+  let cb;
+  function RecoilCallback() {
+    const gotoSnapshot = useGotoRecoilSnapshot();
+    cb = useRecoilCallback(({snapshot}) => () => {
+      const updatedSnapshot = snapshot.map(({set}) => {
+        set(myAtom, 'SET IN SNAPSHOT');
+      });
+      gotoSnapshot(updatedSnapshot);
+    });
+    return null;
+  }
+
+  const c = renderElements(
+    <>
+      <ReadsAndWritesAtom />
+      <ReadsAtom atom={mySelector} />
+      <RecoilCallback />
+    </>,
+  );
+
+  expect(c.textContent).toEqual('"DEFAULT""DEFAULT"');
+
+  act(() => setAtom('SET IN CURRENT'));
+  expect(c.textContent).toEqual('"SET IN CURRENT""SET IN CURRENT"');
+
+  act(cb);
+  expect(c.textContent).toEqual('"SET IN SNAPSHOT""SET IN SNAPSHOT"');
+});
+
+test('Goto snapshot with dependent async selector', async () => {
+  const snapshot = freshSnapshot();
+
+  const myAtom = atom({
+    key: 'atom for dep async snapshot',
+    default: 'DEFAULT',
+  });
+  const [ReadsAndWritesAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);
+  const mySelector = selector({
+    key: 'selector for async snapshot',
+    get: ({get}) => {
+      const dep = get(myAtom);
+      return Promise.resolve(dep);
+    },
+  });
+
+  const updatedSnapshot = snapshot.map(({set}) => {
+    set(myAtom, 'SET IN SNAPSHOT');
+  });
+
+  let gotoRecoilSnapshot;
+  function GotoRecoilSnapshot() {
+    gotoRecoilSnapshot = useGotoRecoilSnapshot();
+    return null;
+  }
+
+  const c = renderElements(
+    <>
+      <ReadsAndWritesAtom />
+      <ReadsAtom atom={mySelector} />
+      <GotoRecoilSnapshot />
+    </>,
+  );
+
+  expect(c.textContent).toEqual('loading');
+  await flushPromisesAndTimers();
+  expect(c.textContent).toEqual('"DEFAULT""DEFAULT"');
+
+  act(() => setAtom('SET IN CURRENT'));
+  await flushPromisesAndTimers();
+  expect(c.textContent).toEqual('"SET IN CURRENT""SET IN CURRENT"');
+
+  await expect(updatedSnapshot.getPromise(myAtom)).resolves.toEqual(
+    'SET IN SNAPSHOT',
+  );
+  act(() => gotoRecoilSnapshot(updatedSnapshot));
+  await flushPromisesAndTimers();
+  expect(c.textContent).toEqual('"SET IN SNAPSHOT""SET IN SNAPSHOT"');
+});
+
+test('Goto snapshot with async selector', async () => {
+  const snapshot = freshSnapshot();
+
+  const [mySelector, resolve] = asyncSelector();
+
+  let gotoRecoilSnapshot;
+  function GotoRecoilSnapshot() {
+    gotoRecoilSnapshot = useGotoRecoilSnapshot();
+    return null;
+  }
+
+  const c = renderElements(
+    <>
+      <ReadsAtom atom={mySelector} />
+      <GotoRecoilSnapshot />
+    </>,
+  );
+
+  expect(c.textContent).toEqual('loading');
+
+  act(() => resolve('RESOLVE'));
+  await flushPromisesAndTimers();
+  expect(c.textContent).toEqual('"RESOLVE"');
+
+  act(() => gotoRecoilSnapshot(snapshot));
+  expect(c.textContent).toEqual('"RESOLVE"');
+});

--- a/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -203,6 +203,37 @@ describe('useRecoilCallback', () => {
     await flushPromisesAndTimers();
     expect(seenValue).toBe(345);
   });
+
+  it('goes to snapshot', async () => {
+    const myAtom = atom({
+      key: 'Goto Snapshot From Callback',
+      default: 'DEFAULT',
+    });
+
+    let cb;
+    function RecoilCallback() {
+      cb = useRecoilCallback(({snapshot, gotoSnapshot}) => () => {
+        const updatedSnapshot = snapshot.map(({set}) => {
+          set(myAtom, 'SET IN SNAPSHOT');
+        });
+        gotoSnapshot(updatedSnapshot);
+      });
+      return null;
+    }
+
+    const c = renderElements(
+      <>
+        <ReadsAtom atom={myAtom} />
+        <RecoilCallback />
+      </>,
+    );
+
+    expect(c.textContent).toEqual('"DEFAULT"');
+
+    act(cb);
+    await flushPromisesAndTimers();
+    expect(c.textContent).toEqual('"SET IN SNAPSHOT"');
+  });
 });
 
 // Test that we always get a consistent instance of the callback function

--- a/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -38,9 +38,9 @@ describe('useRecoilCallback', () => {
     let cb;
 
     function Component() {
-      cb = useRecoilCallback(({getPromise}) => () => {
+      cb = useRecoilCallback(({snapshot}) => () => {
         // eslint-disable-next-line jest/valid-expect
-        pTest = expect(getPromise(anAtom)).resolves.toBe('DEFAULT');
+        pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
       });
       return null;
     }
@@ -61,12 +61,12 @@ describe('useRecoilCallback', () => {
     let cb;
 
     function Component() {
-      cb = useRecoilCallback(({getLoadable}) => () => {
-        expect(getLoadable(anAtom)).toMatchObject({
+      cb = useRecoilCallback(({snapshot}) => () => {
+        expect(snapshot.getLoadable(anAtom)).toMatchObject({
           state: 'hasValue',
           contents: 123,
         });
-        expect(getLoadable(asyncSelector)).toMatchObject({
+        expect(snapshot.getLoadable(asyncSelector)).toMatchObject({
           state: 'loading',
         });
         didRun = true; // ensure these assertions do get made
@@ -75,7 +75,6 @@ describe('useRecoilCallback', () => {
     }
     renderElements(<Component />);
     act(cb);
-    await flushPromisesAndTimers();
     expect(didRun).toBe(true);
   });
 
@@ -85,10 +84,10 @@ describe('useRecoilCallback', () => {
     let pTest = Promise.reject(new Error("Callback didn't resolve"));
 
     function Component() {
-      cb = useRecoilCallback(({getPromise, set}) => value => {
+      cb = useRecoilCallback(({snapshot, set}) => value => {
         set(anAtom, value);
         // eslint-disable-next-line jest/valid-expect
-        pTest = expect(getPromise(anAtom)).resolves.toBe('DEFAULT');
+        pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
       });
       return null;
     }
@@ -101,7 +100,6 @@ describe('useRecoilCallback', () => {
     );
     expect(container.textContent).toBe('"DEFAULT"');
     act(() => cb(123));
-    await flushPromisesAndTimers();
     expect(container.textContent).toBe('123');
     await pTest;
   });
@@ -136,11 +134,11 @@ describe('useRecoilCallback', () => {
     const pTest = [];
 
     function Component() {
-      cb = useRecoilCallback(({getPromise, set}) => async value => {
+      cb = useRecoilCallback(({snapshot, set}) => async value => {
         set(anAtom, value);
         pTest.push(
           // eslint-disable-next-line jest/valid-expect
-          expect(getPromise(anAtom)).resolves.toBe(
+          expect(snapshot.getPromise(anAtom)).resolves.toBe(
             value === 123 ? 'DEFAULT' : 123,
           ),
         );
@@ -159,10 +157,8 @@ describe('useRecoilCallback', () => {
     expect(container.textContent).toBe('"DEFAULT"');
     act(() => cb(123));
     act(kick);
-    await flushPromisesAndTimers();
     expect(container.textContent).toBe('123');
     act(() => cb(456));
-    await flushPromisesAndTimers();
     expect(container.textContent).toBe('456');
     for (const aTest of pTest) {
       await aTest;
@@ -179,9 +175,9 @@ describe('useRecoilCallback', () => {
 
     function Component() {
       setter = useSetRecoilState(anAtom);
-      cb = useRecoilCallback(({getPromise}) => async () => {
+      cb = useRecoilCallback(({snapshot}) => async () => {
         await delay();
-        seenValue = await getPromise(anAtom);
+        seenValue = await snapshot.getPromise(anAtom);
       });
       return null;
     }
@@ -203,7 +199,6 @@ describe('useRecoilCallback', () => {
     };
     act(cb);
     act(() => setter(678));
-    await flushPromisesAndTimers();
     resumeCallback();
     await flushPromisesAndTimers();
     expect(seenValue).toBe(345);

--- a/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+perf_viz
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const React = require('React');
+const {act} = require('ReactTestUtils');
+
+const atom = require('../../recoil_values/Recoil_atom');
+const selector = require('../../recoil_values/Recoil_selector');
+const {
+  asyncSelector,
+  componentThatReadsAndWritesAtom,
+  renderElements,
+} = require('../../testing/Recoil_TestingUtils');
+const {useRecoilTransactionObserver} = require('../Recoil_Hooks');
+
+function TransactionObserver({callback}) {
+  useRecoilTransactionObserver(callback);
+  return null;
+}
+
+test('Can observe atom value', async () => {
+  const atomA = atom({
+    key: 'Observe Atom A',
+    default: 'DEFAULT A',
+  });
+
+  const atomB = atom({
+    key: 'Observe Atom B',
+    default: 'DEFAULT B',
+  });
+
+  const [WriteAtomA, setAtomA, resetA] = componentThatReadsAndWritesAtom(atomA);
+  const [WriteAtomB, setAtomB] = componentThatReadsAndWritesAtom(atomB);
+
+  const transactions = [];
+  renderElements(
+    <>
+      <TransactionObserver
+        callback={({snapshot, previousSnapshot}) => {
+          transactions.push({snapshot, previousSnapshot});
+        }}
+      />
+      <WriteAtomA />
+      <WriteAtomB />
+    </>,
+  );
+
+  act(() => setAtomB('SET B'));
+
+  expect(transactions.length).toEqual(1);
+  await expect(transactions[0].snapshot.getPromise(atomA)).resolves.toEqual(
+    'DEFAULT A',
+  );
+  await expect(
+    transactions[0].previousSnapshot.getPromise(atomA),
+  ).resolves.toEqual('DEFAULT A');
+  await expect(transactions[0].snapshot.getPromise(atomB)).resolves.toEqual(
+    'SET B',
+  );
+  await expect(
+    transactions[0].previousSnapshot.getPromise(atomB),
+  ).resolves.toEqual('DEFAULT B');
+
+  act(() => setAtomA('SET A'));
+
+  expect(transactions.length).toEqual(2);
+  await expect(transactions[1].snapshot.getPromise(atomA)).resolves.toEqual(
+    'SET A',
+  );
+  await expect(
+    transactions[1].previousSnapshot.getPromise(atomA),
+  ).resolves.toEqual('DEFAULT A');
+  await expect(transactions[1].snapshot.getPromise(atomB)).resolves.toEqual(
+    'SET B',
+  );
+  await expect(
+    transactions[1].previousSnapshot.getPromise(atomB),
+  ).resolves.toEqual('SET B');
+
+  act(() => resetA());
+
+  expect(transactions.length).toEqual(3);
+  await expect(transactions[2].snapshot.getPromise(atomA)).resolves.toEqual(
+    'DEFAULT A',
+  );
+  await expect(
+    transactions[2].previousSnapshot.getPromise(atomA),
+  ).resolves.toEqual('SET A');
+  await expect(transactions[2].snapshot.getPromise(atomB)).resolves.toEqual(
+    'SET B',
+  );
+  await expect(
+    transactions[2].previousSnapshot.getPromise(atomB),
+  ).resolves.toEqual('SET B');
+});
+
+test('Can observe selector value', async () => {
+  const atomA = atom({
+    key: 'Observe Atom for Selector',
+    default: 'DEFAULT',
+  });
+
+  const selectorA = selector({
+    key: 'Observer Selector As',
+    get: ({get}) => `SELECTOR ${get(atomA)}`,
+  });
+
+  const [WriteAtom, setAtom] = componentThatReadsAndWritesAtom(atomA);
+
+  const transactions = [];
+  renderElements(
+    <>
+      <TransactionObserver
+        callback={({snapshot, previousSnapshot}) => {
+          transactions.push({snapshot, previousSnapshot});
+        }}
+      />
+      <WriteAtom />
+    </>,
+  );
+
+  act(() => setAtom('SET'));
+
+  expect(transactions.length).toEqual(1);
+  await expect(transactions[0].snapshot.getPromise(atomA)).resolves.toEqual(
+    'SET',
+  );
+  await expect(
+    transactions[0].previousSnapshot.getPromise(atomA),
+  ).resolves.toEqual('DEFAULT');
+  await expect(transactions[0].snapshot.getPromise(selectorA)).resolves.toEqual(
+    'SELECTOR SET',
+  );
+  await expect(
+    transactions[0].previousSnapshot.getPromise(selectorA),
+  ).resolves.toEqual('SELECTOR DEFAULT');
+});
+
+test('Can observe async selector value', async () => {
+  const atomA = atom({
+    key: 'Observe Atom for Async Selector',
+    default: 'DEFAULT',
+  });
+  const [WriteAtom, setAtom] = componentThatReadsAndWritesAtom(atomA);
+
+  const [selectorA, resolveA] = asyncSelector();
+
+  const transactions = [];
+  renderElements(
+    <>
+      <TransactionObserver
+        callback={({snapshot, previousSnapshot}) => {
+          transactions.push({snapshot, previousSnapshot});
+        }}
+      />
+      <WriteAtom />
+    </>,
+  );
+
+  act(() => setAtom('SET'));
+
+  expect(transactions.length).toEqual(1);
+  expect(transactions[0].snapshot.getLoadable(selectorA).state).toEqual(
+    'loading',
+  );
+
+  act(() => resolveA('RESOLVE'));
+
+  expect(transactions.length).toEqual(1);
+  await expect(transactions[0].snapshot.getPromise(selectorA)).resolves.toEqual(
+    'RESOLVE',
+  );
+});

--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -53,10 +53,9 @@
  */
 'use strict';
 
+const gkx = require('../util/Recoil_gkx');
 const newSelector = require('./Recoil_selector_NEW');
 const oldSelector = require('./Recoil_selector_OLD');
-
-const gkx = require('../util/Recoil_gkx');
 
 export type * from './Recoil_selector_NEW';
 

--- a/src/recoil_values/Recoil_selector_NEW.js
+++ b/src/recoil_values/Recoil_selector_NEW.js
@@ -94,11 +94,12 @@ const nullthrows = require('../util/Recoil_nullthrows');
 const {startPerfBlock} = require('../util/Recoil_PerformanceTimings');
 const traverseDepGraph = require('../util/Recoil_traverseDepGraph');
 
+export type ValueOrUpdater<T> =
+  | T
+  | DefaultValue
+  | ((prevValue: T) => T | DefaultValue);
 export type GetRecoilValue = <T>(RecoilValue<T>) => T;
-export type SetRecoilState = <T>(
-  RecoilState<T>,
-  T | DefaultValue | ((prevValue: T) => T | DefaultValue),
-) => void;
+export type SetRecoilState = <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
 export type ResetRecoilState = <T>(RecoilState<T>) => void;
 
 type ReadOnlySelectorOptions<T> = $ReadOnly<{

--- a/src/recoil_values/Recoil_selector_OLD.js
+++ b/src/recoil_values/Recoil_selector_OLD.js
@@ -94,11 +94,12 @@ const equalsSet = require('../util/Recoil_equalsSet');
 const isPromise = require('../util/Recoil_isPromise');
 const nullthrows = require('../util/Recoil_nullthrows');
 
+export type ValueOrUpdater<T> =
+  | T
+  | DefaultValue
+  | ((prevValue: T) => T | DefaultValue);
 export type GetRecoilValue = <T>(RecoilValue<T>) => T;
-export type SetRecoilState = <T>(
-  RecoilState<T>,
-  T | DefaultValue | ((prevValue: T) => T | DefaultValue),
-) => void;
+export type SetRecoilState = <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
 export type ResetRecoilState = <T>(RecoilState<T>) => void;
 
 type ReadOnlySelectorOptions<T> = $ReadOnly<{

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {RecoilState, RecoilValue} from 'Recoil_RecoilValue';
-import type {Store, StoreState, TreeState} from 'Recoil_State';
+import type {Store} from 'Recoil_State';
 
 const React = require('React');
 const ReactDOM = require('ReactDOM');
@@ -19,6 +19,7 @@ const {act} = require('ReactTestUtils');
 
 const {RecoilRoot} = require('../components/Recoil_RecoilRoot.react');
 const {fireNodeSubscriptions} = require('../core/Recoil_FunctionalCore');
+const {makeEmptyStoreState} = require('../core/Recoil_State');
 const {
   useRecoilValue,
   useResetRecoilState,
@@ -31,31 +32,9 @@ const stableStringify = require('../util/Recoil_stableStringify');
 // This isn't a test but is used in tests so Jest will be present:
 declare var jest: JestObjectType;
 
-function makeTreeState(): TreeState {
-  return {
-    isSnapshot: false,
-    atomValues: new Map(),
-    nonvalidatedAtoms: new Map(),
-    dirtyAtoms: new Set(),
-    nodeDeps: new Map(),
-    nodeToNodeSubscriptions: new Map(),
-    nodeToComponentSubscriptions: new Map(),
-    transactionMetadata: {},
-  };
-}
-
-function makeStoreState(): StoreState {
-  return {
-    currentTree: makeTreeState(),
-    nextTree: null,
-    transactionSubscriptions: new Map(),
-    queuedComponentCallbacks: [],
-    suspendedComponentResolvers: new Set(),
-  };
-}
-
+// TODO Use Snapshot for testing instead of this thunk?
 function makeStore(): Store {
-  const state = makeStoreState();
+  const state = makeEmptyStoreState();
   const store = {
     getState: () => state,
     replaceState: replacer => {
@@ -198,7 +177,6 @@ function flushPromisesAndTimers(): Promise<mixed> {
 }
 
 module.exports = {
-  makeTreeState,
   makeStore,
   renderElements,
   ReadsAtom,


### PR DESCRIPTION
Summary:
Add `useGotoRecoilSnapshot()` hook as per [this proposal](https://fb.quip.com/UwKaAGjK0L0E)

```
function useGotoRecoilSnapshot(): Snapshot => void
```

Change current store to use the state in the provided `Snapshot`.  If any atom values changed, then fire subscriptions to update any currently subscribed components for only those updated atoms.

Note that `nodeToComponentSubscriptions` is maintained as the state is updated to match the `Snapshot`.  This won't be necessary to explicitly copy when that state is migrated from the `TreeState` to the `StoreState` for CM.

I think the old implementation had a bug where it would only change atom values that were explicitly "updated" in the snapshot, making it not really a snapshot but a queue of state changes.

Next we will migrate `<Link>` and remove the old deprecated version.

Reviewed By: csantos42

Differential Revision: D21739680

