### PR TITLE
Remove duplicate flow-bin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^3.6.11",
-    "flow-bin": "^0.124.0",
     "eslint": "^7.2.0",
     "eslint-plugin-flowtype": "^5.1.3",
     "eslint-plugin-react": "^7.20.0",


### PR DESCRIPTION
There is a duplicate entry for `flow-bin` in the `package.json`. This PR removes it.