### PR TITLE
Fix typo in selector.md example

### DIFF
--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -127,7 +127,7 @@ const tempCelcius = selector({
   set: ({set}, newValue) =>
     set(
       tempFahrenheit,
-      neValue instanceof DefaultValue ? newValue : (newValue * 9) / 5 + 32
+      newValue instanceof DefaultValue ? newValue : (newValue * 9) / 5 + 32
     ),
 });
 


### PR DESCRIPTION
As I was reading through the documentation, I noticed a small one letter typo on the asynchronous example of the `api-reference/core/selectors()`. 

The small typo was `neValue` in line 136.

Hope this helps, I really didn't see an issue for it, but if there are any other steps I need to take to submit a PR please let me know :)

<img width="770" alt="Screen Shot 2020-06-17 at 4 19 45 PM" src="https://user-images.githubusercontent.com/28843542/84946329-829bb380-b0b6-11ea-8040-cf1a4cb77434.png">
