### PR TITLE
Performance improvement

### DIFF
--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -128,7 +128,7 @@ function subscribeComponentToNode(
       state.nodeToComponentSubscriptions,
       key,
       subsForAtom =>
-        mapBySettingInMap(subsForAtom ?? emptyMap, subID, [
+        mapBySettingInMap(subsForAtom ?? new Map(emptyMap), subID, [
           'TODO debug name',
           callback,
         ]),

--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -107,7 +107,16 @@ function Batcher(props: {setNotifyBatcherOfChange: (() => void) => void}) {
 
       // nextTree is now committed -- note that copying and reset occurs when
       // a transaction begins, in startNextTreeIfNeeded:
-      storeState.currentTree = nextTree;
+      storeState.currentTree = {
+        ...nextTree,
+        atomValues: new Map(nextTree.atomValues),
+        nodeDeps: new Map(nextTree.nodeDeps),
+        nodeToNodeSubscriptions: new Map(nextTree.nodeToNodeSubscriptions),
+        nonvalidatedAtoms: new Map(nextTree.nonvalidatedAtoms),
+        nodeToComponentSubscriptions: new Map(
+          nextTree.nodeToComponentSubscriptions,
+        ),
+      };
       storeState.nextTree = null;
     });
   });

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -178,7 +178,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
             newValue instanceof DefaultValue
               ? mapByDeletingFromMap(state.atomValues, key)
               : mapBySettingInMap(
-                  state.atomValues,
+                  new Map(state.atomValues),
                   key,
                   loadableWithValue(newValue),
                 ),

--- a/src/util/Recoil_CopyOnWrite.js
+++ b/src/util/Recoil_CopyOnWrite.js
@@ -25,24 +25,18 @@ function setByDeletingFromSet<V>(set: $ReadOnlySet<V>, v: V): Set<V> {
   return next;
 }
 
-function mapBySettingInMap<K, V>(
-  map: $ReadOnlyMap<K, V>,
-  k: K,
-  v: V,
-): Map<K, V> {
-  const next = new Map(map);
-  next.set(k, v);
-  return next;
+function mapBySettingInMap<K, V>(map: Map<K, V>, k: K, v: V): Map<K, V> {
+  map.set(k, v);
+  return map;
 }
 
 function mapByUpdatingInMap<K, V>(
-  map: $ReadOnlyMap<K, V>,
+  map: Map<K, V>,
   k: K,
   updater: (V | void) => V,
 ): Map<K, V> {
-  const next = new Map(map);
-  next.set(k, updater(next.get(k)));
-  return next;
+  map.set(k, updater(map.get(k)));
+  return map;
 }
 
 function mapByDeletingFromMap<K, V>(map: $ReadOnlyMap<K, V>, k: K): Map<K, V> {


### PR DESCRIPTION
This PR relates to #228 

I [forked the code](https://codesandbox.io/s/d302y) from the original post, and changed the pixel count to 100 * 80 * 2, then use the Chrome Dev tool to profile the [page](https://d302y.csb.app/) performance, and you can see it spends long time on `mapByUpdatingInMap` and GC.

![image](https://user-images.githubusercontent.com/648674/84994412-4432e280-b110-11ea-8de1-b4a4b94ed8f2.png)

if we take a deep look with the function, the `new Map` takes time.

![image](https://user-images.githubusercontent.com/648674/84993971-9d4e4680-b10f-11ea-942d-75651fcc540c.png)

This PR is trying to reduce the `new Map`, and I tested it with this PR using the [same test code]  (https://codesandbox.io/s/xituo), and tested the [page](https://xituo.csb.app/) performance again, the performance got much better.
![image](https://user-images.githubusercontent.com/648674/84994602-88be7e00-b110-11ea-8704-9cbf2a13b8e4.png)

