### PR TITLE
Export new snapshot hooks

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -38,7 +38,9 @@ const {DefaultValue} = require('./core/Recoil_Node');
 const {RecoilRoot} = require('./core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
 const {
+  useGotoRecoilSnapshot,
   useRecoilCallback,
+  useRecoilSnapshotAndSubscribe
   useRecoilState,
   useRecoilStateLoadable,
   useRecoilTransactionObserver,
@@ -96,6 +98,10 @@ module.exports = {
   useRecoilTransactionObserver,
   useTransactionObservation_UNSTABLE: useTransactionObservation_DEPRECATED,
   useSetUnvalidatedAtomValues_UNSTABLE: useSetUnvalidatedAtomValues,
+  
+  // Hooks for Snapshots
+  useGotoRecoilSnapshot,
+  useRecoilSnapshotAndSubscribe
 
   // Concurrency Helpers
   noWait,

--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -101,7 +101,7 @@ module.exports = {
   
   // Hooks for Snapshots
   useGotoRecoilSnapshot,
-  useRecoilSnapshotAndSubscribe
+  useRecoilSnapshotAndSubscribe,
 
   // Concurrency Helpers
   noWait,

--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -40,7 +40,7 @@ const {isRecoilValue} = require('./core/Recoil_RecoilValue');
 const {
   useGotoRecoilSnapshot,
   useRecoilCallback,
-  useRecoilSnapshotAndSubscribe
+  useRecoilSnapshotAndSubscribe,
   useRecoilState,
   useRecoilStateLoadable,
   useRecoilTransactionObserver,
@@ -98,7 +98,7 @@ module.exports = {
   useRecoilTransactionObserver,
   useTransactionObservation_UNSTABLE: useTransactionObservation_DEPRECATED,
   useSetUnvalidatedAtomValues_UNSTABLE: useSetUnvalidatedAtomValues,
-  
+
   // Hooks for Snapshots
   useGotoRecoilSnapshot,
   useRecoilSnapshotAndSubscribe,


### PR DESCRIPTION
Add `useRecoilSnapshotAndSubscribe` and `useGotoRecoilSnapshot` to exports.

Fixes #351 