### PR TITLE
Expose useRecoilInterface

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -46,6 +46,7 @@ const {
   useRecoilValueLoadable,
   useResetRecoilState,
   useSetRecoilState,
+  useRecoilInterface,
   useSetUnvalidatedAtomValues,
   useTransactionObservation_DEPRECATED,
 } = require('./hooks/Recoil_Hooks');
@@ -105,4 +106,5 @@ module.exports = {
 
   // Other functions
   isRecoilValue,
+  useRecoilInterface_LIBRARY_INTERFACE: useRecoilInterface,
 };


### PR DESCRIPTION
We've built a layer above recoil that changes the syntax and makes it a lot easier for us use/migrate to, but requires using `useRecoilInterface` so we can avoid having N hooks calls per component including a lot of weird logic around re-mounting if # of hooks calls change.

I understand this is private, so I've appended `_LIBRARY_INTERFACE`, though perhaps there could be a namespace `__INTERNAL` that has a group of things.