### PR TITLE
Disable react/prop-types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     strict: 0,
     'jsx-a11y/href-no-hash': 'off',
     'react/jsx-key': 'off',
+    'react/prop-types': 'off',
   },
   settings: {
     react: {


### PR DESCRIPTION
Disable the `react/prop-types` ESLint rule. It is causing CI to fail because of recently added components in tests. I don't think this rule is needed since we can statically type component props with Flow.