### PR TITLE
Avoid update during atom state initialization

### DIFF
--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -233,7 +233,7 @@ function RecoilRoot({
     notifyBatcherOfChange.current = x;
   }
 
-  const store = {
+  const store: Store = {
     getState: () => storeState.current,
     replaceState,
     subscribeToTransactions,

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -20,9 +20,10 @@ import type {RecoilState, RecoilValue} from './Recoil_RecoilValue';
 import type {Store, TreeState} from './Recoil_State';
 
 const gkx = require('../util/Recoil_gkx');
+const mapIterable = require('../util/Recoil_mapIterable');
 const mapMap = require('../util/Recoil_mapMap');
 const nullthrows = require('../util/Recoil_nullthrows');
-const {DEFAULT_VALUE, recoilValues} = require('./Recoil_Node');
+const {DEFAULT_VALUE, nodes, recoilValues} = require('./Recoil_Node');
 const {
   getRecoilValueAsLoadable,
   setRecoilValue,
@@ -30,16 +31,15 @@ const {
 } = require('./Recoil_RecoilValueInterface');
 const {makeEmptyTreeState, makeStoreState} = require('./Recoil_State');
 
-function makeStore(treeState: TreeState): Store {
+// TODO Temporary until Snapshots only contain state
+function makeSnapshotStore(treeState: TreeState): Store {
   const storeState = makeStoreState(treeState);
-  const store = {
+  const store: Store = {
     getState: () => storeState,
     replaceState: replacer => {
       storeState.currentTree = replacer(storeState.currentTree); // no batching so nextTree is never active
     },
-    subscribeToTransactions: () => {
-      throw new Error('Cannot subscribe to Snapshots');
-    },
+    subscribeToTransactions: () => ({release: () => {}}),
     addTransactionMetadata: () => {
       throw new Error('Cannot subscribe to Snapshots');
     },
@@ -55,7 +55,7 @@ class Snapshot {
   _store: Store;
 
   constructor(treeState: TreeState) {
-    this._store = makeStore(treeState);
+    this._store = makeSnapshotStore(treeState);
   }
 
   getStore_INTERNAL(): Store {
@@ -79,24 +79,18 @@ class Snapshot {
   // eslint-disable-next-line fb-www/extra-arrow-initializer
   getNodes_UNSTABLE: (
     {
-      types?: $ReadOnlyArray<'atom' | 'selector'>,
       dirty?: boolean,
     } | void,
   ) => Iterable<RecoilValue<mixed>> = opt => {
-    const state = this._store.getState().currentTree;
-    const atoms = opt?.dirty === true ? state.dirtyAtoms : state.knownAtoms;
-    // TODO mark dirty selectors
-    const selectors = opt?.dirty === true ? new Set() : state.knownSelectors;
-    const types = opt?.types ?? ['atom', 'selector'];
+    // TODO Deal with modified selectors
+    if (opt?.dirty === true) {
+      const state = this._store.getState().currentTree;
+      return mapIterable(state.dirtyAtoms, key =>
+        nullthrows(recoilValues.get(key)),
+      );
+    }
 
-    return (function*() {
-      for (const type of types) {
-        const keys = {atom: atoms, selector: selectors}[type];
-        for (const key of keys) {
-          yield nullthrows(recoilValues.get(key));
-        }
-      }
-    })();
+    return recoilValues.values();
   };
 
   // eslint-disable-next-line fb-www/extra-arrow-initializer
@@ -140,11 +134,9 @@ class Snapshot {
 function cloneTreeState(treeState: TreeState): TreeState {
   return {
     transactionMetadata: {...treeState.transactionMetadata},
-    knownAtoms: new Set(treeState.knownAtoms),
     dirtyAtoms: new Set(treeState.dirtyAtoms),
     atomValues: new Map(treeState.atomValues),
     nonvalidatedAtoms: new Map(treeState.nonvalidatedAtoms),
-    knownSelectors: new Set(treeState.knownSelectors),
     nodeDeps: new Map(treeState.nodeDeps),
     nodeToNodeSubscriptions: mapMap(
       treeState.nodeToNodeSubscriptions,

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -24,13 +24,9 @@ export type TreeState = $ReadOnly<{
   transactionMetadata: {...},
 
   // ATOMS
-  knownAtoms: Set<NodeKey>,
   dirtyAtoms: Set<NodeKey>,
   atomValues: AtomValues,
   nonvalidatedAtoms: Map<NodeKey, mixed>,
-
-  // SELECTORS
-  knownSelectors: Set<NodeKey>,
 
   // NODE GRAPH
   // Upstream Node dependencies
@@ -57,6 +53,10 @@ export type StoreState = {
   // The TreeState that is written to when during the course of a transaction
   // (generally equal to a React batch) when atom values are updated.
   nextTree: null | TreeState,
+
+  // Node lifetimes
+  knownAtoms: Set<NodeKey>,
+  knownSelectors: Set<NodeKey>,
 
   // For observing transactions:
   +transactionSubscriptions: Map<number, (Store) => void>,
@@ -88,11 +88,9 @@ export type StoreRef = {
 function makeEmptyTreeState(): TreeState {
   return {
     transactionMetadata: {},
-    knownAtoms: new Set(),
     dirtyAtoms: new Set(),
     atomValues: new Map(),
     nonvalidatedAtoms: new Map(),
-    knownSelectors: new Set(),
     nodeDeps: new Map(),
     nodeToNodeSubscriptions: new Map(),
     nodeToComponentSubscriptions: new Map(),
@@ -103,6 +101,8 @@ function makeStoreState(treeState: TreeState): StoreState {
   return {
     currentTree: treeState,
     nextTree: null,
+    knownAtoms: new Set(),
+    knownSelectors: new Set(),
     transactionSubscriptions: new Map(),
     nodeTransactionSubscriptions: new Map(),
     queuedComponentCallbacks: [],

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -18,6 +18,60 @@ const selector = require('../../recoil_values/Recoil_selector');
 const {asyncSelector} = require('../../testing/Recoil_TestingUtils');
 const {Snapshot, freshSnapshot} = require('../Recoil_Snapshot');
 
+// Run test first since it is testing all registered atoms
+test('getNodes', () => {
+  const snapshot = freshSnapshot();
+  const {getNodes_UNSTABLE} = snapshot;
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
+
+  // Test atoms
+  const myAtom = atom({key: 'snapshot getNodes atom', default: 'DEFAULT'});
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(1);
+  expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
+  const nodesAfterGet = Array.from(getNodes_UNSTABLE());
+  expect(nodesAfterGet.length).toEqual(1);
+  expect(nodesAfterGet[0]).toBe(myAtom);
+  expect(snapshot.getLoadable(nodesAfterGet[0]).contents).toEqual('DEFAULT');
+
+  // Test selectors
+  const mySelector = selector({
+    key: 'snapshot getNodes selector',
+    get: ({get}) => get(myAtom) + '-SELECTOR',
+  });
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  expect(snapshot.getLoadable(mySelector).contents).toEqual('DEFAULT-SELECTOR');
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  // expect(Array.from(getNodes_UNSTABLE({types: ['atom']})).length).toEqual(1);
+  // const selectorNodes = Array.from(getNodes_UNSTABLE({types: ['selector']}));
+  // expect(selectorNodes.length).toEqual(1);
+  // expect(selectorNodes[0]).toBe(mySelector);
+
+  // Test dirty atoms
+  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
+    0,
+  );
+  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
+  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
+    0,
+  );
+  expect(
+    Array.from(updatedSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+  ).toEqual(1);
+  const dirtyAtom = Array.from(
+    updatedSnapshot.getNodes_UNSTABLE({dirty: true}),
+  )[0];
+  expect(snapshot.getLoadable(dirtyAtom).contents).toEqual('DEFAULT');
+  expect(updatedSnapshot.getLoadable(dirtyAtom).contents).toEqual('SET');
+
+  // Test reset
+  const resetSnapshot = updatedSnapshot.map(({reset}) => reset(myAtom));
+  expect(
+    Array.from(resetSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+  ).toEqual(1);
+
+  // TODO Test dirty selectors
+});
+
 test('Read default loadable from snapshot', () => {
   const snapshot: Snapshot = freshSnapshot();
 
@@ -121,64 +175,6 @@ test('Async map of snapshot', async () => {
   const newSnapshot = await newSnapshotPromise;
   const value = await newSnapshot.getPromise(myAtom);
   expect(value).toEqual('VALUE');
-});
-
-test('getNodes', () => {
-  const snapshot = freshSnapshot();
-  const {getNodes_UNSTABLE} = snapshot;
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(0);
-
-  // Test atoms
-  const myAtom = atom({key: 'snapshot getNodes atom', default: 'DEFAULT'});
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(0);
-  expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
-  const nodesAfterGet = Array.from(getNodes_UNSTABLE({}));
-  expect(nodesAfterGet.length).toEqual(1);
-  expect(nodesAfterGet[0]).toBe(myAtom);
-  expect(snapshot.getLoadable(nodesAfterGet[0]).contents).toEqual('DEFAULT');
-
-  // Test selectors
-  const mySelector = selector({
-    key: 'snapshot getNodes selector',
-    get: ({get}) => get(myAtom) + '-SELECTOR',
-  });
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(1);
-  expect(snapshot.getLoadable(mySelector).contents).toEqual('DEFAULT-SELECTOR');
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(2);
-  expect(Array.from(getNodes_UNSTABLE({types: ['atom']})).length).toEqual(1);
-  const selectorNodes = Array.from(getNodes_UNSTABLE({types: ['selector']}));
-  expect(selectorNodes.length).toEqual(1);
-  expect(selectorNodes[0]).toBe(mySelector);
-
-  // Test dirty atoms
-  expect(
-    Array.from(snapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}))
-      .length,
-  ).toEqual(0);
-  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
-  expect(
-    Array.from(snapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}))
-      .length,
-  ).toEqual(0);
-  expect(
-    Array.from(
-      updatedSnapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}),
-    ).length,
-  ).toEqual(1);
-  const dirtyAtom = Array.from(
-    updatedSnapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}),
-  )[0];
-  expect(snapshot.getLoadable(dirtyAtom).contents).toEqual('DEFAULT');
-  expect(updatedSnapshot.getLoadable(dirtyAtom).contents).toEqual('SET');
-
-  // Test reset
-  const resetSnapshot = updatedSnapshot.map(({reset}) => reset(myAtom));
-  expect(
-    Array.from(resetSnapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}))
-      .length,
-  ).toEqual(1);
-
-  // TODO Test dirty selectors
 });
 
 test('getDeps', () => {

--- a/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -11,12 +11,14 @@
 'use strict';
 
 const React = require('React');
+const {useState} = require('React');
 const {act} = require('ReactTestUtils');
 
 const {freshSnapshot} = require('../../core/Recoil_Snapshot');
 const {
   useGotoRecoilSnapshot,
   useRecoilCallback,
+  useRecoilValue,
 } = require('../../hooks/Recoil_Hooks');
 const atom = require('../../recoil_values/Recoil_atom');
 const constSelector = require('../../recoil_values/Recoil_constSelector');
@@ -191,4 +193,53 @@ test('Goto snapshot with async selector', async () => {
 
   act(() => gotoRecoilSnapshot(snapshot));
   expect(c.textContent).toEqual('"RESOLVE"');
+});
+
+// Test that going to a snapshot where an atom was not yet initialized will
+// cause the atom to be re-initialized when used again.
+test('Effects going to new snapshot', () => {
+  let init = 0;
+  const myAtom = atom({
+    key: 'gotoSnapshot effect',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [
+      () => {
+        init++;
+      },
+    ],
+  });
+
+  let forceUpdate;
+  function ReadAtom() {
+    const [_, setValue] = useState({});
+    forceUpdate = () => setValue({});
+    return useRecoilValue(myAtom);
+  }
+
+  let gotoRecoilSnapshot;
+  function GotoRecoilSnapshot() {
+    gotoRecoilSnapshot = useGotoRecoilSnapshot();
+    return null;
+  }
+
+  expect(init).toEqual(0);
+
+  renderElements(
+    <>
+      <ReadAtom />
+      <GotoRecoilSnapshot />
+    </>,
+  );
+
+  expect(init).toEqual(1);
+  act(forceUpdate);
+  expect(init).toEqual(1);
+
+  gotoRecoilSnapshot?.(freshSnapshot());
+  expect(init).toEqual(1);
+  act(forceUpdate);
+  expect(init).toEqual(2);
+
+  act(forceUpdate);
+  expect(init).toEqual(2);
 });

--- a/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -196,8 +196,8 @@ test('Goto snapshot with async selector', async () => {
 });
 
 // Test that going to a snapshot where an atom was not yet initialized will
-// cause the atom to be re-initialized when used again.
-test('Effects going to new snapshot', () => {
+// not cause the atom to be re-initialized when used again.
+test('Effects going to previous snapshot', () => {
   let init = 0;
   const myAtom = atom({
     key: 'gotoSnapshot effect',
@@ -238,8 +238,8 @@ test('Effects going to new snapshot', () => {
   gotoRecoilSnapshot?.(freshSnapshot());
   expect(init).toEqual(1);
   act(forceUpdate);
-  expect(init).toEqual(2);
+  expect(init).toEqual(1);
 
   act(forceUpdate);
-  expect(init).toEqual(2);
+  expect(init).toEqual(1);
 });

--- a/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
@@ -30,6 +30,85 @@ function TransactionObserver({callback}) {
   return null;
 }
 
+// Run test first since it deals with all registered atoms
+test('getNodes', () => {
+  let snapshot = freshSnapshot();
+  function UseRecoilTransactionObserver() {
+    useRecoilTransactionObserver(p => {
+      snapshot = p.snapshot;
+    });
+    return null;
+  }
+
+  const atoms = atomFamily<string, string>({
+    key: 'useRecoilTransactionObserver getNodes atom',
+    default: x => x,
+  });
+  const [ReadsAtomA, setAtomA, resetAtomA] = componentThatReadsAndWritesAtom(
+    atoms('A'),
+  );
+  const [ReadsAtomB, setAtomB] = componentThatReadsAndWritesAtom(atoms('B'));
+  const selectorA = selector({
+    key: 'useRecoilTransactionObserver getNodes selector',
+    get: ({get}) => get(atoms('A')) + '-SELECTOR',
+  });
+  const c = renderElements(
+    <>
+      <ReadsAtomA />
+      <ReadsAtomB />
+      <ReadsAtom atom={selectorA} />
+      <UseRecoilTransactionObserver />
+    </>,
+  );
+  expect(c.textContent).toEqual('"A""B""A-SELECTOR"');
+
+  expect(
+    Array.from(snapshot.getNodes_UNSTABLE()).length,
+  ).toBeGreaterThanOrEqual(2);
+  act(() => setAtomA('A'));
+  // Greater than 3 because we expect at least nodes for atom's A and B from
+  // the family and selectorA.  In reality we currenlty get 8 due to internal
+  // helper selectors and default fallback atoms.
+  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toBeGreaterThan(3);
+  const nodes = Array.from(snapshot.getNodes_UNSTABLE());
+  expect(nodes).toEqual(
+    expect.arrayContaining([atoms('A'), atoms('B'), selectorA]),
+  );
+
+  // Test atom A is set
+  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  expect(aDirty.length).toEqual(1);
+  expect(snapshot.getLoadable(aDirty[0]).contents).toEqual('A');
+
+  // Test atom B is set
+  act(() => setAtomB('B'));
+  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  expect(bDirty.length).toEqual(1);
+  expect(snapshot.getLoadable(bDirty[0]).contents).toEqual('B');
+
+  // // Test atoms
+  // const atomNodes = Array.from(snapshot.getNodes_UNSTABLE({types: ['atom']}));
+  // expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
+  //   expect.arrayContaining(['A', 'B']),
+  // );
+
+  // // Test selector
+  // const selectorNodes = Array.from(
+  //   snapshot.getNodes_UNSTABLE({types: ['selector']}),
+  // );
+  // expect(
+  //   selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
+  // ).toEqual(expect.arrayContaining(['A-SELECTOR']));
+
+  // Test Reset
+  act(resetAtomA);
+  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  expect(resetDirty.length).toEqual(1);
+  expect(resetDirty[0]).toBe(aDirty[0]);
+
+  // TODO Test dirty selectors
+});
+
 test('Can observe atom value', async () => {
   const atomA = atom({
     key: 'Observe Atom A',
@@ -182,80 +261,4 @@ test('Can observe async selector value', async () => {
   await expect(transactions[0].snapshot.getPromise(selectorA)).resolves.toEqual(
     'RESOLVE',
   );
-});
-
-test('getNodes', () => {
-  let snapshot = freshSnapshot();
-  function UseRecoilTransactionObserver() {
-    useRecoilTransactionObserver(p => {
-      snapshot = p.snapshot;
-    });
-    return null;
-  }
-
-  const atoms = atomFamily<string, string>({
-    key: 'useRecoilTransactionObserver getNodes atom',
-    default: x => x,
-  });
-  const [ReadsAtomA, setAtomA, resetAtomA] = componentThatReadsAndWritesAtom(
-    atoms('A'),
-  );
-  const [ReadsAtomB, setAtomB] = componentThatReadsAndWritesAtom(atoms('B'));
-  const selectorA = selector({
-    key: 'useRecoilTransactionObserver getNodes selector',
-    get: ({get}) => get(atoms('A')) + '-SELECTOR',
-  });
-  const c = renderElements(
-    <>
-      <ReadsAtomA />
-      <ReadsAtomB />
-      <ReadsAtom atom={selectorA} />
-      <UseRecoilTransactionObserver />
-    </>,
-  );
-  expect(c.textContent).toEqual('"A""B""A-SELECTOR"');
-
-  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toEqual(0);
-  act(() => setAtomA('A'));
-  // Greater than 3 because we expect at least nodes for atom's A and B from
-  // the family and selectorA.  In reality we currenlty get 8 due to internal
-  // helper selectors and default fallback atoms.
-  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toBeGreaterThan(3);
-  const nodes = Array.from(snapshot.getNodes_UNSTABLE());
-  expect(nodes).toEqual(
-    expect.arrayContaining([atoms('A'), atoms('B'), selectorA]),
-  );
-
-  // Test atom A is set
-  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
-  expect(aDirty.length).toEqual(1);
-  expect(snapshot.getLoadable(aDirty[0]).contents).toEqual('A');
-
-  // Test atom B is set
-  act(() => setAtomB('B'));
-  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
-  expect(bDirty.length).toEqual(1);
-  expect(snapshot.getLoadable(bDirty[0]).contents).toEqual('B');
-
-  // Test atoms
-  const atomNodes = Array.from(snapshot.getNodes_UNSTABLE({types: ['atom']}));
-  expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
-    expect.arrayContaining(['A', 'B']),
-  );
-
-  // Test selector
-  const selectorNodes = Array.from(
-    snapshot.getNodes_UNSTABLE({types: ['selector']}),
-  );
-  expect(
-    selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
-  ).toEqual(expect.arrayContaining(['A-SELECTOR']));
-
-  // Test Reset
-  act(resetAtomA);
-  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
-  expect(resetDirty.length).toEqual(1);
-  expect(resetDirty[0]).toBe(aDirty[0]);
-
-  // TODO Test dirty selectors
 });

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -140,9 +140,10 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     initState: TreeState,
     trigger: 'set' | 'get',
   ): TreeState {
-    if (initState.knownAtoms.has(key)) {
+    if (store.getState().knownAtoms.has(key)) {
       return initState;
     }
+    store.getState().knownAtoms.add(key);
 
     // Run Atom Effects
     let initValue: T | DefaultValue = DEFAULT_VALUE;
@@ -222,7 +223,6 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
 
     return {
       ...initState,
-      knownAtoms: setByAddingToSet(initState.knownAtoms, key),
       atomValues: !(initValue instanceof DefaultValue)
         ? mapBySettingInMap(
             initState.atomValues,

--- a/src/recoil_values/Recoil_selector_NEW.js
+++ b/src/recoil_values/Recoil_selector_NEW.js
@@ -213,15 +213,8 @@ function selector<T>(
 
   const executionInfo: ExecutionInfo<T> = getInitialExecutionInfo();
 
-  function initSelector(state: TreeState): TreeState {
-    if (state.knownSelectors.has(key)) {
-      return state;
-    }
-
-    return {
-      ...state,
-      knownSelectors: setByAddingToSet(state.knownSelectors, key),
-    };
+  function initSelector(store: Store) {
+    store.getState().knownSelectors.add(key);
   }
 
   /**
@@ -753,15 +746,16 @@ function selector<T>(
     cache = cache.set(key, val);
   }
 
-  function myGet(store: Store, initState: TreeState): [TreeState, Loadable<T>] {
-    const state = initSelector(initState);
+  function myGet(store: Store, state: TreeState): [TreeState, Loadable<T>] {
+    initSelector(store);
     // TODO memoize a value if no deps have changed to avoid a cache lookup
     return getSelectorResult(store, state);
   }
 
   if (set != null) {
-    function mySet(store, initState, newValue) {
-      let newState = initSelector(initState);
+    function mySet(store, state, newValue) {
+      initSelector(store);
+      let newState = state;
       const writtenNodes: Set<NodeKey> = new Set();
 
       function getRecoilValue<S>({key}: RecoilValue<S>): S {

--- a/src/recoil_values/Recoil_selector_OLD.js
+++ b/src/recoil_values/Recoil_selector_OLD.js
@@ -151,15 +151,8 @@ function selector<T>(
   let cache: CacheImplementation<Loadable<T>> =
     cacheImplementation ?? cacheWithReferenceEquality();
 
-  function initSelector(state: TreeState): TreeState {
-    if (state.knownSelectors.has(key)) {
-      return state;
-    }
-
-    return {
-      ...state,
-      knownSelectors: setByAddingToSet(state.knownSelectors, key),
-    };
+  function initSelector(store: Store) {
+    store.getState().knownSelectors.add(key);
   }
 
   function putIntoCache(
@@ -396,8 +389,8 @@ function selector<T>(
     return [newState, loadable, newDepValues];
   }
 
-  function myGet(store: Store, initState: TreeState): [TreeState, Loadable<T>] {
-    const state = initSelector(initState);
+  function myGet(store: Store, state: TreeState): [TreeState, Loadable<T>] {
+    initSelector(store);
 
     // TODO memoize a value if no deps have changed to avoid a cache lookup
     // Lookup the node value in the cache.  If not there, then compute
@@ -406,8 +399,9 @@ function selector<T>(
   }
 
   if (set != null) {
-    function mySet(store, initState, newValue) {
-      let newState = initSelector(initState);
+    function mySet(store, state, newValue) {
+      initSelector(store);
+      let newState = state;
       const writtenNodes: Set<NodeKey> = new Set();
 
       function getRecoilValue<S>({key}: RecoilValue<S>): S {


### PR DESCRIPTION
Summary: Avoid replacing state and initiating a render when initializing atom state with an effect.  No need to replace the state since we know there are no other subscribers to an atom if we are the ones initializing it on first use.

Differential Revision: D22223025

