### PR TITLE
Normalize handling updater form in setRecoilValue()

### DIFF
--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -233,7 +233,7 @@ function RecoilRoot({
     notifyBatcherOfChange.current = x;
   }
 
-  const store = {
+  const store: Store = {
     getState: () => storeState.current,
     replaceState,
     subscribeToTransactions,

--- a/src/core/Recoil_RecoilValueInterface.js
+++ b/src/core/Recoil_RecoilValueInterface.js
@@ -49,14 +49,46 @@ function getRecoilValueAsLoadable<T>(
   return (result: any); // flowlint-line unclear-type:off
 }
 
-function setRecoilValue<T>(
+function valueFromValueOrUpdater<T>(
   store: Store,
   {key}: AbstractRecoilValue<T>,
-  newValue: T | DefaultValue,
+  valueOrUpdater: ValueOrUpdater<T>,
+): T | DefaultValue {
+  if (typeof valueOrUpdater === 'function') {
+    // Updater form: pass in the current value. Throw if the current value
+    // is unavailable (namely when updating an async selector that's
+    // pending or errored):
+    const storeState = store.getState();
+    const state = storeState.nextTree ?? storeState.currentTree;
+    // NOTE: This will not update state with node subscriptions.
+    const current = peekNodeLoadable(store, state, key);
+    if (current.state === 'loading') {
+      throw new RecoilValueNotReady(key);
+    } else if (current.state === 'hasError') {
+      throw current.contents;
+    }
+    // T itself may be a function, so our refinement is not sufficient:
+    return (valueOrUpdater: any)(current.contents); // flowlint-line unclear-type:off
+  } else {
+    return valueOrUpdater;
+  }
+}
+
+function setRecoilValue<T>(
+  store: Store,
+  recoilValue: AbstractRecoilValue<T>,
+  valueOrUpdater: T | DefaultValue | (T => T | DefaultValue),
 ): void {
+  const {key} = recoilValue;
   Tracing.trace('set RecoilValue', key, () =>
     store.replaceState(
       Tracing.wrap(state => {
+        const newValue = valueFromValueOrUpdater(
+          store,
+          recoilValue,
+          valueOrUpdater,
+        );
+
         const [newState, writtenNodes] = setNodeValue(
           store,
           state,
@@ -86,31 +118,6 @@ function setUnvalidatedRecoilValue<T>(
   );
 }
 
-function valueFromValueOrUpdater<T>(
-  store: Store,
-  {key}: RecoilState<T>,
-  valueOrUpdater: ValueOrUpdater<T>,
-): T | DefaultValue {
-  if (typeof valueOrUpdater === 'function') {
-    // Updater form: pass in the current value. Throw if the current value
-    // is unavailable (namely when updating an async selector that's
-    // pending or errored):
-    const storeState = store.getState();
-    const state = storeState.nextTree ?? storeState.currentTree;
-    // NOTE: This will not update state with node subscriptions.
-    const current = peekNodeLoadable(store, state, key);
-    if (current.state === 'loading') {
-      throw new RecoilValueNotReady(key);
-    } else if (current.state === 'hasError') {
-      throw current.contents;
-    }
-    // T itself may be a function, so our refinement is not sufficient:
-    return (valueOrUpdater: any)(current.contents); // flowlint-line unclear-type:off
-  } else {
-    return valueOrUpdater;
-  }
-}
-
 export type ComponentSubscription = {release: Store => void};
 function subscribeToRecoilValue<T>(
   store: Store,
@@ -133,7 +140,6 @@ module.exports = {
   RecoilValueReadOnly,
   AbstractRecoilValue,
   RecoilState,
-  valueFromValueOrUpdater,
   getRecoilValueAsLoadable,
   setRecoilValue,
   setUnvalidatedRecoilValue,

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -27,7 +27,6 @@ const {DEFAULT_VALUE, recoilValues} = require('./Recoil_Node');
 const {
   getRecoilValueAsLoadable,
   setRecoilValue,
-  valueFromValueOrUpdater,
 } = require('./Recoil_RecoilValueInterface');
 const {makeEmptyTreeState, makeStoreState} = require('./Recoil_State');
 
@@ -168,12 +167,7 @@ class MutableSnapshot extends Snapshot {
     newValueOrUpdater: ValueOrUpdater<T>,
   ) => {
     const store = this.getStore_INTERNAL();
-    const newValue = valueFromValueOrUpdater(
-      store,
-      recoilState,
-      newValueOrUpdater,
-    );
-    setRecoilValue(store, recoilState, newValue);
+    setRecoilValue(store, recoilState, newValueOrUpdater);
   };
 
   reset: ResetRecoilState = recoilState =>

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -24,13 +24,9 @@ export type TreeState = $ReadOnly<{
   transactionMetadata: {...},
 
   // ATOMS
-  knownAtoms: Set<NodeKey>,
   dirtyAtoms: Set<NodeKey>,
   atomValues: AtomValues,
   nonvalidatedAtoms: Map<NodeKey, mixed>,
-
-  // SELECTORS
-  knownSelectors: Set<NodeKey>,
 
   // NODE GRAPH
   // Upstream Node dependencies
@@ -57,6 +53,10 @@ export type StoreState = {
   // The TreeState that is written to when during the course of a transaction
   // (generally equal to a React batch) when atom values are updated.
   nextTree: null | TreeState,
+
+  // Node lifetimes
+  knownAtoms: Set<NodeKey>,
+  knownSelectors: Set<NodeKey>,
 
   // For observing transactions:
   +transactionSubscriptions: Map<number, (Store) => void>,
@@ -88,11 +88,9 @@ export type StoreRef = {
 function makeEmptyTreeState(): TreeState {
   return {
     transactionMetadata: {},
-    knownAtoms: new Set(),
     dirtyAtoms: new Set(),
     atomValues: new Map(),
     nonvalidatedAtoms: new Map(),
-    knownSelectors: new Set(),
     nodeDeps: new Map(),
     nodeToNodeSubscriptions: new Map(),
     nodeToComponentSubscriptions: new Map(),
@@ -103,6 +101,8 @@ function makeStoreState(treeState: TreeState): StoreState {
   return {
     currentTree: treeState,
     nextTree: null,
+    knownAtoms: new Set(),
+    knownSelectors: new Set(),
     transactionSubscriptions: new Map(),
     nodeTransactionSubscriptions: new Map(),
     queuedComponentCallbacks: [],

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -18,6 +18,60 @@ const selector = require('../../recoil_values/Recoil_selector');
 const {asyncSelector} = require('../../testing/Recoil_TestingUtils');
 const {Snapshot, freshSnapshot} = require('../Recoil_Snapshot');
 
+// Run test first since it is testing all registered atoms
+test('getNodes', () => {
+  const snapshot = freshSnapshot();
+  const {getNodes_UNSTABLE} = snapshot;
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
+
+  // Test atoms
+  const myAtom = atom({key: 'snapshot getNodes atom', default: 'DEFAULT'});
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(1);
+  expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
+  const nodesAfterGet = Array.from(getNodes_UNSTABLE());
+  expect(nodesAfterGet.length).toEqual(1);
+  expect(nodesAfterGet[0]).toBe(myAtom);
+  expect(snapshot.getLoadable(nodesAfterGet[0]).contents).toEqual('DEFAULT');
+
+  // Test selectors
+  const mySelector = selector({
+    key: 'snapshot getNodes selector',
+    get: ({get}) => get(myAtom) + '-SELECTOR',
+  });
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  expect(snapshot.getLoadable(mySelector).contents).toEqual('DEFAULT-SELECTOR');
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  // expect(Array.from(getNodes_UNSTABLE({types: ['atom']})).length).toEqual(1);
+  // const selectorNodes = Array.from(getNodes_UNSTABLE({types: ['selector']}));
+  // expect(selectorNodes.length).toEqual(1);
+  // expect(selectorNodes[0]).toBe(mySelector);
+
+  // Test dirty atoms
+  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
+    0,
+  );
+  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
+  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
+    0,
+  );
+  expect(
+    Array.from(updatedSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+  ).toEqual(1);
+  const dirtyAtom = Array.from(
+    updatedSnapshot.getNodes_UNSTABLE({dirty: true}),
+  )[0];
+  expect(snapshot.getLoadable(dirtyAtom).contents).toEqual('DEFAULT');
+  expect(updatedSnapshot.getLoadable(dirtyAtom).contents).toEqual('SET');
+
+  // Test reset
+  const resetSnapshot = updatedSnapshot.map(({reset}) => reset(myAtom));
+  expect(
+    Array.from(resetSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+  ).toEqual(1);
+
+  // TODO Test dirty selectors
+});
+
 test('Read default loadable from snapshot', () => {
   const snapshot: Snapshot = freshSnapshot();
 
@@ -121,64 +175,6 @@ test('Async map of snapshot', async () => {
   const newSnapshot = await newSnapshotPromise;
   const value = await newSnapshot.getPromise(myAtom);
   expect(value).toEqual('VALUE');
-});
-
-test('getNodes', () => {
-  const snapshot = freshSnapshot();
-  const {getNodes_UNSTABLE} = snapshot;
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(0);
-
-  // Test atoms
-  const myAtom = atom({key: 'snapshot getNodes atom', default: 'DEFAULT'});
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(0);
-  expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
-  const nodesAfterGet = Array.from(getNodes_UNSTABLE({}));
-  expect(nodesAfterGet.length).toEqual(1);
-  expect(nodesAfterGet[0]).toBe(myAtom);
-  expect(snapshot.getLoadable(nodesAfterGet[0]).contents).toEqual('DEFAULT');
-
-  // Test selectors
-  const mySelector = selector({
-    key: 'snapshot getNodes selector',
-    get: ({get}) => get(myAtom) + '-SELECTOR',
-  });
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(1);
-  expect(snapshot.getLoadable(mySelector).contents).toEqual('DEFAULT-SELECTOR');
-  expect(Array.from(getNodes_UNSTABLE({})).length).toEqual(2);
-  expect(Array.from(getNodes_UNSTABLE({types: ['atom']})).length).toEqual(1);
-  const selectorNodes = Array.from(getNodes_UNSTABLE({types: ['selector']}));
-  expect(selectorNodes.length).toEqual(1);
-  expect(selectorNodes[0]).toBe(mySelector);
-
-  // Test dirty atoms
-  expect(
-    Array.from(snapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}))
-      .length,
-  ).toEqual(0);
-  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
-  expect(
-    Array.from(snapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}))
-      .length,
-  ).toEqual(0);
-  expect(
-    Array.from(
-      updatedSnapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}),
-    ).length,
-  ).toEqual(1);
-  const dirtyAtom = Array.from(
-    updatedSnapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}),
-  )[0];
-  expect(snapshot.getLoadable(dirtyAtom).contents).toEqual('DEFAULT');
-  expect(updatedSnapshot.getLoadable(dirtyAtom).contents).toEqual('SET');
-
-  // Test reset
-  const resetSnapshot = updatedSnapshot.map(({reset}) => reset(myAtom));
-  expect(
-    Array.from(resetSnapshot.getNodes_UNSTABLE({types: ['atom'], dirty: true}))
-      .length,
-  ).toEqual(1);
-
-  // TODO Test dirty selectors
 });
 
 test('getDeps', () => {

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -29,7 +29,6 @@ const {
   setRecoilValue,
   setUnvalidatedRecoilValue,
   subscribeToRecoilValue,
-  valueFromValueOrUpdater,
 } = require('../core/Recoil_RecoilValueInterface');
 const {Snapshot, cloneSnapshot} = require('../core/Recoil_Snapshot');
 const {setByAddingToSet} = require('../util/Recoil_CopyOnWrite');
@@ -160,12 +159,7 @@ function useInterface(): RecoilInterface {
       return (
         newValueOrUpdater: (T => T | DefaultValue) | T | DefaultValue,
       ) => {
-        const newValue = valueFromValueOrUpdater(
-          storeRef.current,
-          recoilState,
-          newValueOrUpdater,
-        );
-        setRecoilValue(storeRef.current, recoilState, newValue);
+        setRecoilValue(storeRef.current, recoilState, newValueOrUpdater);
       };
     }
 
@@ -544,12 +538,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
         recoilState: RecoilState<T>,
         newValueOrUpdater: (T => T) | T,
       ) {
-        const newValue = valueFromValueOrUpdater(
-          storeRef.current,
-          recoilState,
-          newValueOrUpdater,
-        );
-        setRecoilValue(storeRef.current, recoilState, newValue);
+        setRecoilValue(storeRef.current, recoilState, newValueOrUpdater);
       }
 
       function reset<T>(recoilState: RecoilState<T>) {

--- a/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -196,8 +196,8 @@ test('Goto snapshot with async selector', async () => {
 });
 
 // Test that going to a snapshot where an atom was not yet initialized will
-// cause the atom to be re-initialized when used again.
-test('Effects going to new snapshot', () => {
+// not cause the atom to be re-initialized when used again.
+test('Effects going to previous snapshot', () => {
   let init = 0;
   const myAtom = atom({
     key: 'gotoSnapshot effect',
@@ -238,8 +238,8 @@ test('Effects going to new snapshot', () => {
   gotoRecoilSnapshot?.(freshSnapshot());
   expect(init).toEqual(1);
   act(forceUpdate);
-  expect(init).toEqual(2);
+  expect(init).toEqual(1);
 
   act(forceUpdate);
-  expect(init).toEqual(2);
+  expect(init).toEqual(1);
 });

--- a/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
@@ -30,6 +30,85 @@ function TransactionObserver({callback}) {
   return null;
 }
 
+// Run test first since it deals with all registered atoms
+test('getNodes', () => {
+  let snapshot = freshSnapshot();
+  function UseRecoilTransactionObserver() {
+    useRecoilTransactionObserver(p => {
+      snapshot = p.snapshot;
+    });
+    return null;
+  }
+
+  const atoms = atomFamily<string, string>({
+    key: 'useRecoilTransactionObserver getNodes atom',
+    default: x => x,
+  });
+  const [ReadsAtomA, setAtomA, resetAtomA] = componentThatReadsAndWritesAtom(
+    atoms('A'),
+  );
+  const [ReadsAtomB, setAtomB] = componentThatReadsAndWritesAtom(atoms('B'));
+  const selectorA = selector({
+    key: 'useRecoilTransactionObserver getNodes selector',
+    get: ({get}) => get(atoms('A')) + '-SELECTOR',
+  });
+  const c = renderElements(
+    <>
+      <ReadsAtomA />
+      <ReadsAtomB />
+      <ReadsAtom atom={selectorA} />
+      <UseRecoilTransactionObserver />
+    </>,
+  );
+  expect(c.textContent).toEqual('"A""B""A-SELECTOR"');
+
+  expect(
+    Array.from(snapshot.getNodes_UNSTABLE()).length,
+  ).toBeGreaterThanOrEqual(2);
+  act(() => setAtomA('A'));
+  // Greater than 3 because we expect at least nodes for atom's A and B from
+  // the family and selectorA.  In reality we currenlty get 8 due to internal
+  // helper selectors and default fallback atoms.
+  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toBeGreaterThan(3);
+  const nodes = Array.from(snapshot.getNodes_UNSTABLE());
+  expect(nodes).toEqual(
+    expect.arrayContaining([atoms('A'), atoms('B'), selectorA]),
+  );
+
+  // Test atom A is set
+  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  expect(aDirty.length).toEqual(1);
+  expect(snapshot.getLoadable(aDirty[0]).contents).toEqual('A');
+
+  // Test atom B is set
+  act(() => setAtomB('B'));
+  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  expect(bDirty.length).toEqual(1);
+  expect(snapshot.getLoadable(bDirty[0]).contents).toEqual('B');
+
+  // // Test atoms
+  // const atomNodes = Array.from(snapshot.getNodes_UNSTABLE({types: ['atom']}));
+  // expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
+  //   expect.arrayContaining(['A', 'B']),
+  // );
+
+  // // Test selector
+  // const selectorNodes = Array.from(
+  //   snapshot.getNodes_UNSTABLE({types: ['selector']}),
+  // );
+  // expect(
+  //   selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
+  // ).toEqual(expect.arrayContaining(['A-SELECTOR']));
+
+  // Test Reset
+  act(resetAtomA);
+  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  expect(resetDirty.length).toEqual(1);
+  expect(resetDirty[0]).toBe(aDirty[0]);
+
+  // TODO Test dirty selectors
+});
+
 test('Can observe atom value', async () => {
   const atomA = atom({
     key: 'Observe Atom A',
@@ -182,80 +261,4 @@ test('Can observe async selector value', async () => {
   await expect(transactions[0].snapshot.getPromise(selectorA)).resolves.toEqual(
     'RESOLVE',
   );
-});
-
-test('getNodes', () => {
-  let snapshot = freshSnapshot();
-  function UseRecoilTransactionObserver() {
-    useRecoilTransactionObserver(p => {
-      snapshot = p.snapshot;
-    });
-    return null;
-  }
-
-  const atoms = atomFamily<string, string>({
-    key: 'useRecoilTransactionObserver getNodes atom',
-    default: x => x,
-  });
-  const [ReadsAtomA, setAtomA, resetAtomA] = componentThatReadsAndWritesAtom(
-    atoms('A'),
-  );
-  const [ReadsAtomB, setAtomB] = componentThatReadsAndWritesAtom(atoms('B'));
-  const selectorA = selector({
-    key: 'useRecoilTransactionObserver getNodes selector',
-    get: ({get}) => get(atoms('A')) + '-SELECTOR',
-  });
-  const c = renderElements(
-    <>
-      <ReadsAtomA />
-      <ReadsAtomB />
-      <ReadsAtom atom={selectorA} />
-      <UseRecoilTransactionObserver />
-    </>,
-  );
-  expect(c.textContent).toEqual('"A""B""A-SELECTOR"');
-
-  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toEqual(0);
-  act(() => setAtomA('A'));
-  // Greater than 3 because we expect at least nodes for atom's A and B from
-  // the family and selectorA.  In reality we currenlty get 8 due to internal
-  // helper selectors and default fallback atoms.
-  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toBeGreaterThan(3);
-  const nodes = Array.from(snapshot.getNodes_UNSTABLE());
-  expect(nodes).toEqual(
-    expect.arrayContaining([atoms('A'), atoms('B'), selectorA]),
-  );
-
-  // Test atom A is set
-  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
-  expect(aDirty.length).toEqual(1);
-  expect(snapshot.getLoadable(aDirty[0]).contents).toEqual('A');
-
-  // Test atom B is set
-  act(() => setAtomB('B'));
-  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
-  expect(bDirty.length).toEqual(1);
-  expect(snapshot.getLoadable(bDirty[0]).contents).toEqual('B');
-
-  // Test atoms
-  const atomNodes = Array.from(snapshot.getNodes_UNSTABLE({types: ['atom']}));
-  expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
-    expect.arrayContaining(['A', 'B']),
-  );
-
-  // Test selector
-  const selectorNodes = Array.from(
-    snapshot.getNodes_UNSTABLE({types: ['selector']}),
-  );
-  expect(
-    selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
-  ).toEqual(expect.arrayContaining(['A-SELECTOR']));
-
-  // Test Reset
-  act(resetAtomA);
-  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
-  expect(resetDirty.length).toEqual(1);
-  expect(resetDirty[0]).toBe(aDirty[0]);
-
-  // TODO Test dirty selectors
 });

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -140,9 +140,10 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     initState: TreeState,
     trigger: 'set' | 'get',
   ): TreeState {
-    if (initState.knownAtoms.has(key)) {
+    if (store.getState().knownAtoms.has(key)) {
       return initState;
     }
+    store.getState().knownAtoms.add(key);
 
     // Run Atom Effects
     let initValue: T | DefaultValue = DEFAULT_VALUE;
@@ -222,7 +223,6 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
 
     return {
       ...initState,
-      knownAtoms: setByAddingToSet(initState.knownAtoms, key),
       atomValues: !(initValue instanceof DefaultValue)
         ? mapBySettingInMap(
             initState.atomValues,

--- a/src/recoil_values/Recoil_selector_NEW.js
+++ b/src/recoil_values/Recoil_selector_NEW.js
@@ -213,15 +213,8 @@ function selector<T>(
 
   const executionInfo: ExecutionInfo<T> = getInitialExecutionInfo();
 
-  function initSelector(state: TreeState): TreeState {
-    if (state.knownSelectors.has(key)) {
-      return state;
-    }
-
-    return {
-      ...state,
-      knownSelectors: setByAddingToSet(state.knownSelectors, key),
-    };
+  function initSelector(store: Store) {
+    store.getState().knownSelectors.add(key);
   }
 
   /**
@@ -753,15 +746,16 @@ function selector<T>(
     cache = cache.set(key, val);
   }
 
-  function myGet(store: Store, initState: TreeState): [TreeState, Loadable<T>] {
-    const state = initSelector(initState);
+  function myGet(store: Store, state: TreeState): [TreeState, Loadable<T>] {
+    initSelector(store);
     // TODO memoize a value if no deps have changed to avoid a cache lookup
     return getSelectorResult(store, state);
   }
 
   if (set != null) {
-    function mySet(store, initState, newValue) {
-      let newState = initSelector(initState);
+    function mySet(store, state, newValue) {
+      initSelector(store);
+      let newState = state;
       const writtenNodes: Set<NodeKey> = new Set();
 
       function getRecoilValue<S>({key}: RecoilValue<S>): S {

--- a/src/recoil_values/Recoil_selector_OLD.js
+++ b/src/recoil_values/Recoil_selector_OLD.js
@@ -151,15 +151,8 @@ function selector<T>(
   let cache: CacheImplementation<Loadable<T>> =
     cacheImplementation ?? cacheWithReferenceEquality();
 
-  function initSelector(state: TreeState): TreeState {
-    if (state.knownSelectors.has(key)) {
-      return state;
-    }
-
-    return {
-      ...state,
-      knownSelectors: setByAddingToSet(state.knownSelectors, key),
-    };
+  function initSelector(store: Store) {
+    store.getState().knownSelectors.add(key);
   }
 
   function putIntoCache(
@@ -396,8 +389,8 @@ function selector<T>(
     return [newState, loadable, newDepValues];
   }
 
-  function myGet(store: Store, initState: TreeState): [TreeState, Loadable<T>] {
-    const state = initSelector(initState);
+  function myGet(store: Store, state: TreeState): [TreeState, Loadable<T>] {
+    initSelector(store);
 
     // TODO memoize a value if no deps have changed to avoid a cache lookup
     // Lookup the node value in the cache.  If not there, then compute
@@ -406,8 +399,9 @@ function selector<T>(
   }
 
   if (set != null) {
-    function mySet(store, initState, newValue) {
-      let newState = initSelector(initState);
+    function mySet(store, state, newValue) {
+      initSelector(store);
+      let newState = state;
       const writtenNodes: Set<NodeKey> = new Set();
 
       function getRecoilValue<S>({key}: RecoilValue<S>): S {


### PR DESCRIPTION
Summary: Normalize updating recoil values with `setRecoilValue()` and handle the updater form of new values there instead of callers needing to use `valueFromValueOrUpdater()`

Reviewed By: davidmccabe

Differential Revision: D22224054

