### PR TITLE
Add eslint command on lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,md,json}": "prettier --write"
+    "*.{js,md,json}": "prettier --write",
+    "*.{js}": "eslint --fix"
   }
 }


### PR DESCRIPTION
I think, we need `eslint --fix` after `prettier --write` in `lint-staged`