### PR TITLE
Remove getSnapshot() from Atom Effects

### DIFF
--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -60,7 +60,6 @@
 // @fb-only: import type {ScopeRules} from 'Recoil_ScopedAtom';
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
-import type {Snapshot} from '../core/Recoil_Snapshot';
 import type {NodeKey, Store, TreeState} from '../core/Recoil_State';
 
 // @fb-only: const {scopedAtom} = require('Recoil_ScopedAtom');
@@ -73,7 +72,6 @@ const {
 } = require('../core/Recoil_Node');
 const {isRecoilValue} = require('../core/Recoil_RecoilValue');
 const {setRecoilValue} = require('../core/Recoil_RecoilValueInterface');
-const {cloneSnapshot} = require('../core/Recoil_Snapshot');
 const {
   mapByDeletingFromMap,
   mapBySettingInMap,
@@ -109,7 +107,6 @@ type AtomEffect<T> = ({
     T | DefaultValue | ((T | DefaultValue) => T | DefaultValue),
   ) => void,
   resetSelf: () => void,
-  getSnapshot: () => Snapshot,
 
   // Subscribe callbacks to events.
   // Atom effect observers are called before global transaction observers
@@ -150,14 +147,6 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     if (options.effects_UNSTABLE != null) {
       let duringInit = true;
 
-      function getSnapshot() {
-        return cloneSnapshot(
-          duringInit
-            ? initState
-            : store.getState().nextTree ?? store.getState().currentTree,
-        );
-      }
-
       function setSelf(
         valueOrUpdater: T | DefaultValue | (T => T | DefaultValue),
       ) {
@@ -192,7 +181,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       }
 
       for (const effect of options.effects_UNSTABLE ?? []) {
-        effect({node, trigger, setSelf, resetSelf, getSnapshot, onSet});
+        effect({node, trigger, setSelf, resetSelf, onSet});
       }
 
       duringInit = false;

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -12,7 +12,7 @@ import type {Store} from 'Recoil_State';
 const React = require('React');
 const {act} = require('ReactTestUtils');
 
-const {DEFAULT_VALUE, DefaultValue} = require('../../core/Recoil_Node');
+const {DEFAULT_VALUE} = require('../../core/Recoil_Node');
 const {
   getRecoilValueAsLoadable,
   setRecoilValue,
@@ -110,27 +110,27 @@ test("Updating with same value doesn't rerender", () => {
   expect(renders).toEqual(0);
   const c = renderElements(<AtomComponent />);
 
-  expect(renders).toEqual(3);
+  expect(renders).toEqual(2);
   expect(c.textContent).toEqual('DEFAULT');
 
   act(() => setAtom('SET'));
-  expect(renders).toEqual(4);
+  expect(renders).toEqual(3);
   expect(c.textContent).toEqual('SET');
 
   act(() => setAtom('SET'));
-  expect(renders).toEqual(4);
+  expect(renders).toEqual(3);
   expect(c.textContent).toEqual('SET');
 
   act(() => setAtom('CHANGE'));
-  expect(renders).toEqual(5);
+  expect(renders).toEqual(4);
   expect(c.textContent).toEqual('CHANGE');
 
   act(resetAtom);
-  expect(renders).toEqual(6);
+  expect(renders).toEqual(5);
   expect(c.textContent).toEqual('DEFAULT');
 
   act(resetAtom);
-  expect(renders).toEqual(6);
+  expect(renders).toEqual(5);
   expect(c.textContent).toEqual('DEFAULT');
 });
 
@@ -223,28 +223,6 @@ describe('Effects', () => {
     reset(myAtom);
     expect(get(myAtom)).toEqual('DEFAULT');
     expect(inited).toEqual(1);
-  });
-
-  test('init from other atom', () => {
-    const myAtom = atom({
-      key: 'atom effect - init from other atom',
-      default: 'DEFAULT',
-      effects_UNSTABLE: [
-        ({setSelf, getSnapshot}) => {
-          const snapshot = getSnapshot();
-          const otherValue = snapshot.getLoadable(otherAtom).contents;
-          expect(otherValue).toEqual('OTHER');
-          setSelf(otherValue);
-        },
-      ],
-    });
-
-    const otherAtom = atom({
-      key: 'atom effect - other atom',
-      default: 'OTHER',
-    });
-
-    expect(get(myAtom)).toEqual('OTHER');
   });
 
   test('async set', () => {
@@ -425,13 +403,9 @@ describe('Effects', () => {
   test('onSet History', () => {
     const history: Array<() => void> = []; // Array of undo functions
 
-    function historyEffect({node, setSelf, onSet, getSnapshot}) {
+    function historyEffect({setSelf, onSet}) {
       let ignore = false;
-      onSet((newValue, oldValue) => {
-        if (!(newValue instanceof DefaultValue)) {
-          const {getLoadable} = getSnapshot();
-          expect(newValue).toEqual(getLoadable(node).contents);
-        }
+      onSet((_, oldValue) => {
         if (ignore) {
           ignore = false;
           return;


### PR DESCRIPTION
Summary: Remove `getSnapshot()` from the Atom Effects API.  This simplifies the API.  The indented use of this callback is no longer needed as the URL persistence library will use the store of unvalidated key/values for upgrading legacy URLS with atom key changes or migrations from multiple atom keys.

Differential Revision: D22267539

