### PR TITLE
Restore sprintf() in expectationViolation()

### DIFF
--- a/src/util/Recoil_expectationViolation.js
+++ b/src/util/Recoil_expectationViolation.js
@@ -8,20 +8,36 @@
  * @flow strict-local
  * @format
  */
-
 'use strict';
 
 // @fb-only: const expectationViolation = require('expectationViolation');
 
-const sprintf = require('./Recoil_sprintf'); // @oss-only
+// The {} blocks are necessary to keep prettier off on internal repo
+/* eslint-disable no-lone-blocks */
+
 // prettier-ignore
+function sprintf(format: string, ...args: Array<mixed>): string { // @oss-only
+// @fb-only: {
+  let index = 0; // @oss-only
+  return format.replace(/%s/g, () => String(args[index++])); // @oss-only
+// @fb-only: }
+} // @oss-only
+
+// prettier-ignore
+const sprintf = require('./Recoil_sprintf'); // @oss-only
 function expectationViolation(format: string, ...args: $ReadOnlyArray<mixed>) { // @oss-only
+// @fb-only: {
   if (__DEV__) { // @oss-only
+  // @fb-only: {
     const message = sprintf.call(null, format, ...args); // @oss-only
     const error = new Error(message); // @oss-only
     error.name = 'Expectation Violation'; // @oss-only
     console.error(error); // @oss-only
+  // @fb-only: }
   } // @oss-only
+// @fb-only: }
 } // @oss-only
+
+/* eslint-enable no-lone-blocks */
 
 module.exports = expectationViolation;


### PR DESCRIPTION
Summary:
The `Recoil_sprintf.js` file was removed by the DeadJSCode reaper in D22184459 (https://github.com/facebookexperimental/recoil/commit/d4343b68eb06c6b58720adb5d0e2d3e4001921cb) since it was only referenced by `oss-only` code.  Solve that by just placing that function in `Recoil_expectationViolation.js`

mondaychen - How did you solve the problem with prettier un-indenting the lines?

Differential Revision: D22323789

