### PR TITLE
Remove scope rules from atomFamily for OSS build

### DIFF
--- a/src/recoil_values/Recoil_atomFamily.js
+++ b/src/recoil_values/Recoil_atomFamily.js
@@ -43,7 +43,8 @@ export type AtomFamilyOptions<T, P: Parameter> = $ReadOnly<{
     | Promise<T>
     | T
     | (P => T | RecoilValue<T> | Promise<T>),
-  scopeRules_APPEND_ONLY_READ_THE_DOCS?: ParameterizedScopeRules<P>,
+
+  // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS?: ParameterizedScopeRules<P>,
 }>;
 
 // Process scopeRules to handle any entries which are functions taking parameters


### PR DESCRIPTION
Summary: `scopeRules` should not be exported for the OSS build and is breaking oss `yarn flow`

Differential Revision: D22341651

