### PR TITLE
[docs/example] Update selector.md async example

### DIFF
--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -164,7 +164,8 @@ import {selector, useRecoilValue} from 'recoil';
 const myQuery = selector({
   key: 'MyDBQuery',
   get: async () => {
-    return myDBQueryPromise();
+    const response = await fetch(getMyRequestUrl());
+    return response.json();
   },
 });
 


### PR DESCRIPTION
current example with async selector is not clear, since without inner await we could remove `async` prefix and directly return callback's result if the result is a promise
```
get: async () => {
    return myDBQueryPromise();
}
```

will be the same
```
get: () => myDBQueryPromise()
```

or to be sure to work with promises always simple wrap the result `get: () => Promise.resolve(myDBQueryPromise())`

to avoid possible misunderstanding I propose to add `await` in the callback's body to highlight `async` root of the get callback

The result:
```
get: async () => {
    const queryResults = await myDBQueryPromise();
    // other dependent operations
    
    return queryResults;
  }
```