### PR TITLE
[docs/example] Update useSetRecoilState.md

### DIFF
--- a/docs/docs/api-reference/core/useSetRecoilState.md
+++ b/docs/docs/api-reference/core/useSetRecoilState.md
@@ -31,23 +31,20 @@ const namesState = atom({
   default: ['Ella', 'Chris', 'Paul'],
 });
 
-function NameInput() {
+function FormContent({setNamesState}) {
   const [name, setName] = useState('');
-  const setNamesState = useSetRecoilState(namesState);
-
-  const addName = () => {
-    setNamesState(existingNames => [...existingNames, name]);
-  };
-
-  const onChange = (e) => {
-    setName(e.target.value);
-  };
-
+  
   return (
     <>
-      <input type="text" value={name} onChange={onChange} />
-      <button onClick={addName}>Add Name</button>
+      <input type="text" value={name} onChange={(e) => onChange(e.target.value)} />
+      <button onClick={() => setNamesState(names => [...names, name])}>Add Name</button>
     </>
-  );
+)}
+
+// This component will be rendered once when mounting
+function Form() {
+  const setNamesState = useSetRecoilState(namesState);
+  
+  return <FormContent setNamesState={setNamesState} />;
 }
 ```

--- a/docs/docs/api-reference/core/useSetRecoilState.md
+++ b/docs/docs/api-reference/core/useSetRecoilState.md
@@ -36,7 +36,7 @@ function FormContent({setNamesState}) {
   
   return (
     <>
-      <input type="text" value={name} onChange={(e) => onChange(e.target.value)} />
+      <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
       <button onClick={() => setNamesState(names => [...names, name])}>Add Name</button>
     </>
 )}


### PR DESCRIPTION
Based on docs description component depends on `useSetRecoilState` will not be re-render on call of its setter

In the example was used only one component depends on `useState` hook and also will raise `onClick` what means the component renders happens each time on different triggers (click/change/call setters)

To clarify phrase `Using `useSetRecoilState()` allows a component to set the value without re-rendering when the value changes.` I propose to  move all dynamic part to the child component and pass to it recoil setter to split different re-rendering triggers to children and let root component depends only on the recoil setter.