### PR TITLE
[docs] Update useResetRecoilState.md

### DIFF
--- a/docs/docs/api-reference/core/useResetRecoilState.md
+++ b/docs/docs/api-reference/core/useResetRecoilState.md
@@ -5,6 +5,8 @@ sidebar_label: useResetRecoilState()
 
 Returns a function that will reset the value of the given state to its default value.
 
+Using **useResetRecoilState()** allows a component to reset the state to its default value without subscribing to re-render whenever the state changes.
+
 ---
 
 ```jsx


### PR DESCRIPTION
looks like `useResetRecoilState` setter call  will not trigger component re-rendering. 
I did not have a chance to validate it, but I sure it's true.

I propose to add the same phrase as in https://recoiljs.org/docs/api-reference/core/useSetRecoilState about re-rendering

In case if I'm wrong please decline the PR and possible it could be the reason to fix the behaviour since from API-usage point both setters  (`useResetRecoilState`, `useSetRecoilState`)are the same.