### PR TITLE
Async Atom effect initialization

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -13,6 +13,7 @@
 'use strict';
 
 export type {
+  AtomEffect,
   PersistenceSettings,
   PersistenceType,
 } from './recoil_values/Recoil_atom';

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -94,7 +94,7 @@ export type PersistenceSettings<Stored> = $ReadOnly<{
 }>;
 
 // Effect is called the first time a node is used with a <RecoilRoot>
-type AtomEffect<T> = ({
+export type AtomEffect<T> = ({
   node: RecoilState<T>,
   trigger: 'set' | 'get',
 

--- a/src/recoil_values/Recoil_atomFamily.js
+++ b/src/recoil_values/Recoil_atomFamily.js
@@ -13,7 +13,7 @@
 // @fb-only: import type {ScopeRules} from 'Recoil_ScopedAtom';
 import type {CacheImplementation} from '../caches/Recoil_Cache';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
-import type {AtomOptions} from './Recoil_atom';
+import type {AtomEffect, AtomOptions} from './Recoil_atom';
 
 // @fb-only: const {parameterizedScopedAtomLegacy} = require('Recoil_ScopedAtom');
 
@@ -43,6 +43,9 @@ export type AtomFamilyOptions<T, P: Parameter> = $ReadOnly<{
     | Promise<T>
     | T
     | (P => T | RecoilValue<T> | Promise<T>),
+  effects_UNSTABLE?:
+    | $ReadOnlyArray<AtomEffect<T>>
+    | (P => $ReadOnlyArray<AtomEffect<T>>),
 
   // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS?: ParameterizedScopeRules<P>,
 }>;
@@ -136,6 +139,12 @@ function atomFamily<T, P: Parameter>(
       ...options,
       key: `${options.key}__${stableStringify(params) ?? 'void'}`,
       default: atomFamilyDefault(params),
+
+      effects_UNSTABLE:
+        typeof options.effects_UNSTABLE === 'function'
+          ? options.effects_UNSTABLE(params)
+          : options.effects_UNSTABLE,
+
       // prettier-ignore
       // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS: mapScopeRules(
         // @fb-only: options.scopeRules_APPEND_ONLY_READ_THE_DOCS,


### PR DESCRIPTION
Summary:
Explore async atoms by adding subset of functionality to initialize an atom via a Promise with an atom effect.

This follows the semantics in [RFC Async Atoms](https://fb.quip.com/TUAhAfJI1CfJ).  If an atom is initialized to a pending async value, then set to a new value before the promise resolves, the resolved async value is ignored.  If the promise is rejected, then the atom will enter an error state and throw as appropriate during render.

Reviewed By: csantos42

Differential Revision: D22271167

