### PR TITLE
Recoil transactions should create a new TreeState version

### DIFF
--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -96,10 +96,6 @@ function setNodeValue<T>(
   return node.set(store, state, newValue);
 }
 
-function graphForTreeState(store: Store, treeState: TreeState): Graph {
-  return nullthrows(store.getState().graphsByVersion.get(treeState.version));
-}
-
 // Find all of the recursively dependent nodes
 function getDownstreamNodes(
   store: Store,
@@ -113,7 +109,7 @@ function getDownstreamNodes(
     dependentNodes.add(key);
     visitedNodes.add(key);
     const subscribedNodes =
-      graphForTreeState(store, state).nodeToNodeSubscriptions.get(key) ??
+      store.getGraph(state.version).nodeToNodeSubscriptions.get(key) ??
       emptySet;
     for (const downstreamNode of subscribedNodes) {
       if (!visitedNodes.has(downstreamNode)) {

--- a/src/core/Recoil_Graph.js
+++ b/src/core/Recoil_Graph.js
@@ -85,12 +85,8 @@ function saveDependencyMapToStore(
 ): void {
   // Merge the dependencies discovered into the store's dependency map
   // for the version that was read:
-  const depsByVersion = store.getState().graphsByVersion;
-  if (!depsByVersion.has(version)) {
-    depsByVersion.set(version, graph());
-  }
-  const existingMap = nullthrows(depsByVersion.get(version));
-  mergeDepedencyMapIntoGraph(dependencyMap, existingMap);
+  const graph = store.getGraph(version);
+  mergeDepedencyMapIntoGraph(dependencyMap, graph);
 }
 
 function mergeDepsIntoDependencyMap(

--- a/src/core/Recoil_RecoilValueInterface.js
+++ b/src/core/Recoil_RecoilValueInterface.js
@@ -44,10 +44,9 @@ function getRecoilValueAsLoadable<T>(
 ): Loadable<T> {
   // FIXME, should be the tree of the individual component when useMutableSource is in use
   const treeState = store.getState().currentTree;
-  const version = treeState.version;
   const [dependencyMap, loadable] = getNodeLoadable(store, treeState, key);
 
-  saveDependencyMapToStore(dependencyMap, store, version);
+  saveDependencyMapToStore(dependencyMap, store, treeState.version);
 
   return loadable;
 }

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -98,6 +98,7 @@ export type StoreState = {
 export type Store = $ReadOnly<{
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
+  getGraph: Version => Graph,
   subscribeToTransactions: ((Store) => void, ?NodeKey) => {release: () => void},
   addTransactionMetadata: ({...}) => void,
   fireNodeSubscriptions: (
@@ -110,9 +111,12 @@ export type StoreRef = {
   current: Store,
 };
 
+let nextTreeStateVersion = 0;
+const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
+
 function makeEmptyTreeState(): TreeState {
   return {
-    version: 0,
+    version: getNextTreeStateVersion(),
     transactionMetadata: {},
     dirtyAtoms: new Set(),
     atomValues: new Map(),
@@ -144,4 +148,5 @@ module.exports = {
   makeEmptyTreeState,
   makeEmptyStoreState,
   makeStoreState,
+  getNextTreeStateVersion,
 };

--- a/src/recoil_values/Recoil_selector_OLD.js
+++ b/src/recoil_values/Recoil_selector_OLD.js
@@ -237,9 +237,8 @@ function selector<T>(
 
     // First, get the current deps for this selector
     const currentDeps =
-      nullthrows(
-        store.getState().graphsByVersion.get(state.version),
-      ).nodeDeps.get(key) ?? emptySet;
+      store.getGraph(state.version).nodeDeps.get(key) ?? emptySet;
+
     const depValues: DepValues = new Map(
       Array.from(currentDeps)
         .sort()

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -74,8 +74,12 @@ export interface ReadWriteSelectorOptions<T> extends ReadOnlySelectorOptions<T> 
 export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<T>;
 export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
 
-// hooks.d.ts
+// Snapshot.d.ts
+declare const SnapshotID_OPAQUE: unique symbol;
+export type SnapshotID = {readonly [SnapshotID_OPAQUE]: true};
+
 export class Snapshot {
+  getID(): SnapshotID;
   getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
   getPromise<T>(recoilValue: RecoilValue<T>): Promise<T>;
   map(cb: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
@@ -87,6 +91,7 @@ export class MutableSnapshot extends Snapshot {
   reset: ResetRecoilState;
 }
 
+// hooks.d.ts
 export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
 export type Resetter = () => void;
 export type CallbackInterface = Readonly<{

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -25,6 +25,7 @@ import {
   useRecoilTransactionObserver_UNSTABLE,
   useGotoRecoilSnapshot,
   Snapshot,
+  SnapshotID,
   useRecoilSnapshot,
 } from 'recoil';
 
@@ -139,6 +140,7 @@ useResetRecoilState(readOnlySelectorSel); // $ExpectError
 useResetRecoilState({}); // $ExpectError
 
 useRecoilCallback(({ snapshot, set, reset, gotoSnapshot }) => async () => {
+  const id: SnapshotID = snapshot.getID();
   const val: number = await snapshot.getPromise(mySelector1);
   const loadable = snapshot.getLoadable(mySelector1);
 


### PR DESCRIPTION
Summary:
Recoil tracks state versions and updates each version with a batch commit.  The version is important for tracking async resolutions and concurrent mode.  Going to a previous `Snapshot` with `useGotoRecoilSnapshot()` would revert to the previous `TreeState` versions, which is good.  However, going to a mutated snapshot for atomic transactions did not update the `TreeState` version.  Also, going to a previous snapshot would then simply increment the version with subsequent state changes and conflict with that other previous version.

This diff fixes that by using a new version for each batch commit, `Snapshot` mutation, or fresh `Snapshot` construction.

The state version can be exposed as a `Snapshot` ID for equality checks.  This allows dev tools to check if we are going to a previous Snapshot with `useGotoRecoilSnapshot()`. (cc maxijb)

Differential Revision: D22447073

