### PR TITLE
Native atom support for async defaults

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -13,6 +13,7 @@
 'use strict';
 
 export type {
+  AtomEffect,
   PersistenceSettings,
   PersistenceType,
 } from './recoil_values/Recoil_atom';

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -94,7 +94,7 @@ export type PersistenceSettings<Stored> = $ReadOnly<{
 }>;
 
 // Effect is called the first time a node is used with a <RecoilRoot>
-type AtomEffect<T> = ({
+export type AtomEffect<T> = ({
   node: RecoilState<T>,
   trigger: 'set' | 'get',
 

--- a/src/recoil_values/Recoil_atomFamily.js
+++ b/src/recoil_values/Recoil_atomFamily.js
@@ -13,7 +13,7 @@
 // @fb-only: import type {ScopeRules} from 'Recoil_ScopedAtom';
 import type {CacheImplementation} from '../caches/Recoil_Cache';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
-import type {AtomOptions} from './Recoil_atom';
+import type {AtomEffect, AtomOptions} from './Recoil_atom';
 
 // @fb-only: const {parameterizedScopedAtomLegacy} = require('Recoil_ScopedAtom');
 
@@ -43,6 +43,9 @@ export type AtomFamilyOptions<T, P: Parameter> = $ReadOnly<{
     | Promise<T>
     | T
     | (P => T | RecoilValue<T> | Promise<T>),
+  effects_UNSTABLE?:
+    | $ReadOnlyArray<AtomEffect<T>>
+    | (P => $ReadOnlyArray<AtomEffect<T>>),
 
   // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS?: ParameterizedScopeRules<P>,
 }>;
@@ -136,6 +139,12 @@ function atomFamily<T, P: Parameter>(
       ...options,
       key: `${options.key}__${stableStringify(params) ?? 'void'}`,
       default: atomFamilyDefault(params),
+
+      effects_UNSTABLE:
+        typeof options.effects_UNSTABLE === 'function'
+          ? options.effects_UNSTABLE(params)
+          : options.effects_UNSTABLE,
+
       // prettier-ignore
       // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS: mapScopeRules(
         // @fb-only: options.scopeRules_APPEND_ONLY_READ_THE_DOCS,

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -96,6 +96,63 @@ describe('Valid values', () => {
   });
 });
 
+describe('Async Defaults', () => {
+  test('default promise', () => {
+    const myAtom = atom<string>({
+      key: 'atom async default',
+      default: Promise.resolve('RESOLVE'),
+    });
+    const container = renderElements(<ReadsAtom atom={myAtom} />);
+
+    expect(container.textContent).toEqual('loading');
+    act(() => jest.runAllTimers());
+    expect(container.textContent).toEqual('"RESOLVE"');
+  });
+
+  test('default promise overwritten before resolution', () => {
+    let resolveAtom;
+    const myAtom = atom<string>({
+      key: 'atom async default overwritten',
+      default: new Promise(resolve => {
+        resolveAtom = resolve;
+      }),
+    });
+
+    const [
+      ReadsWritesAtom,
+      setAtom,
+      resetAtom,
+    ] = componentThatReadsAndWritesAtom(myAtom);
+    const container = renderElements(<ReadsWritesAtom />);
+
+    expect(container.textContent).toEqual('loading');
+
+    act(() => setAtom('SET'));
+    act(() => jest.runAllTimers());
+    expect(container.textContent).toEqual('"SET"');
+
+    act(() => resolveAtom('RESOLVE'));
+    expect(container.textContent).toEqual('"SET"');
+
+    act(() => resetAtom());
+    act(() => jest.runAllTimers());
+    expect(container.textContent).toEqual('"RESOLVE"');
+  });
+
+  // NOTE: This test intentionally throws an error
+  test('default promise rejection', () => {
+    const myAtom = atom<string>({
+      key: 'atom async default',
+      default: Promise.reject('REJECT'),
+    });
+    const container = renderElements(<ReadsAtom atom={myAtom} />);
+
+    expect(container.textContent).toEqual('loading');
+    act(() => jest.runAllTimers());
+    expect(container.textContent).toEqual('error');
+  });
+});
+
 test("Updating with same value doesn't rerender", () => {
   const myAtom = atom({key: 'atom same value rerender', default: 'DEFAULT'});
 
@@ -140,7 +197,7 @@ test("Updating with same value doesn't rerender", () => {
 });
 
 describe('Effects', () => {
-  test('effect', () => {
+  test('initialization', () => {
     let inited = false;
     const myAtom = atom({
       key: 'atom effect',
@@ -150,12 +207,42 @@ describe('Effects', () => {
           inited = true;
           expect(trigger).toEqual('get');
           expect(node).toBe(myAtom);
-          setSelf('EFFECT');
+          setSelf('INIT');
         },
       ],
     });
-    expect(get(myAtom)).toEqual('EFFECT');
+    expect(get(myAtom)).toEqual('INIT');
     expect(inited).toEqual(true);
+  });
+
+  test('async default', () => {
+    let inited = false;
+    const myAtom = atom<string>({
+      key: 'atom effect async default',
+      default: Promise.resolve('RESOLVE'),
+      effects_UNSTABLE: [
+        ({setSelf, onSet}) => {
+          inited = true;
+          setSelf('INIT');
+          // This only fires on the reset action, not the default promise resolving
+          onSet(newValue => {
+            expect(newValue).toBeInstanceOf(DefaultValue);
+          });
+        },
+      ],
+    });
+
+    expect(inited).toEqual(false);
+
+    const [ReadsWritesAtom, _, reset] = componentThatReadsAndWritesAtom(myAtom);
+    const c = renderElements(<ReadsWritesAtom />);
+    expect(inited).toEqual(true);
+    expect(c.textContent).toEqual('"INIT"');
+
+    act(reset);
+    expect(c.textContent).toEqual('loading');
+    act(() => jest.runAllTimers());
+    expect(c.textContent).toEqual('"RESOLVE"');
   });
 
   test('order of effects', () => {

--- a/src/recoil_values/__tests__/Recoil_atomWithFallback-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomWithFallback-test.js
@@ -27,7 +27,6 @@ const {
   useSetUnvalidatedAtomValues,
 } = require('../../hooks/Recoil_Hooks');
 const {
-  ReadsAtom,
   componentThatReadsAndWritesAtom,
   makeStore,
   renderElements,
@@ -64,18 +63,6 @@ test('atomWithFallback', () => {
   expect(get(hasFallback)).toBe(2);
   set(hasFallback, 3);
   expect(get(hasFallback)).toBe(3);
-});
-
-test('Async fallback', () => {
-  const asyncFallback = atom<number>({
-    key: 'asyncFallback',
-    default: Promise.resolve(42),
-  });
-  const container = renderElements(<ReadsAtom atom={asyncFallback} />);
-
-  expect(container.textContent).toEqual('loading');
-  act(() => jest.runAllTimers());
-  expect(container.textContent).toEqual('42');
 });
 
 describe('ReturnDefaultOrFallback', () => {
@@ -213,9 +200,13 @@ test('Atom with selector fallback can store null and undefined', () => {
 
 test('Effects', () => {
   let inited = false;
+  const fallbackAtom = atom({
+    key: 'atom with fallback effects init fallback',
+    default: 'FALLBACK',
+  });
   const myAtom = atom<string>({
-    key: 'atom hooks init',
-    default: Promise.resolve('RESOLVE'),
+    key: 'atom with fallback effects init',
+    default: fallbackAtom,
     effects_UNSTABLE: [
       ({setSelf}) => {
         inited = true;
@@ -232,7 +223,5 @@ test('Effects', () => {
   expect(c.textContent).toEqual('"INIT"');
 
   act(reset);
-  expect(c.textContent).toEqual('loading');
-  act(() => jest.runAllTimers());
-  expect(c.textContent).toEqual('"RESOLVE"');
+  expect(c.textContent).toEqual('"FALLBACK"');
 });


### PR DESCRIPTION
Summary:
Add native atom support for async defaults.

Follow the [Async Atom Semantics](https://fb.quip.com/TUAhAfJI1CfJ).  Creating an atom with an async default set to a `Promise` will cause the atom to be in a "loading" state when read from components or selectors.  When the default resolves or rejects any subscribing components will re-render.  However, this will NOT be a state change and the resolved value will not be stored in state or cause observers to fire.

The `atomWithFallback` wrapper selector will only be used if the default is another `RecoilValue<T>`.  We may consider to remove that functionality from `atom()` and use an explicit helper utility instead.  However, we would want to consider this only after finishing migration of URL persistence to the new library that manages cross-atom backward compatibility with `restore` instead of fallback selectors.  We would also have to carefully consider composability issues, particularly for families and "get-on-set".

Differential Revision: D22367409

