### PR TITLE
expose useRecoilInterface

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -42,6 +42,7 @@ const {isRecoilValue} = require('./core/Recoil_RecoilValue');
 const {
   useGotoRecoilSnapshot,
   useRecoilCallback,
+  useRecoilInterface,
   useRecoilSnapshot,
   useRecoilState,
   useRecoilStateLoadable,
@@ -86,6 +87,7 @@ module.exports = {
   readOnlySelector,
 
   // Hooks that accept RecoilValues
+  useRecoilInterface,
   useRecoilValue,
   useRecoilValueLoadable,
   useRecoilState,


### PR DESCRIPTION
I'd be great to have access to `useRecoilInterface` so that we can build more traditional global store management facilities on top of Recoil

