### PR TITLE
Fix TS lint error and improve typing of DefaultValue

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -22,7 +22,9 @@ type TreeState = Readonly<{
 }>;
 
 // node.d.ts
-export class DefaultValue {}
+export class DefaultValue {
+  private __tag: 'DefaultValue';
+}
 
 // recoilRoot.d.ts
 import * as React from 'react';
@@ -76,7 +78,9 @@ export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueRea
 
 // Snapshot.d.ts
 declare const SnapshotID_OPAQUE: unique symbol;
-export type SnapshotID = {readonly [SnapshotID_OPAQUE]: true};
+export interface SnapshotID {
+  readonly [SnapshotID_OPAQUE]: true;
+}
 
 export class Snapshot {
   getID(): SnapshotID;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -72,6 +72,8 @@ const writeableSelector = selector({
   set: ({ get, set, reset }) => {
     get(myAtom);
     set(myAtom, 5);
+    set(myAtom, 'hello'); // $ExpectError
+    set(myAtom, new DefaultValue());
     reset(myAtom);
 
     set(readOnlySelectorSel, 2); // $ExpectError
@@ -87,7 +89,9 @@ RecoilRoot({
     reset(myAtom);
 
     set(readOnlySelectorSel, 2); // $ExpectError
+    set(writeableSelector, 10); // $ExpectError
     setUnvalidatedAtomValues({}); // $ExpectError
+    set(writeableSelector, new DefaultValue());
   },
 });
 


### PR DESCRIPTION
`DefaultValue` was defined as an empty class, which means it was behaving as `{}`, so it was allowing almost any type to be assigned to it. This PR introduces a private tag to solve the issue.

Also, this PR introduces a minor change to `SnapshotID` to conform with tslint

fixes #487 