### PR TITLE
Don't use fake timers in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
       "src/hooks/__tests__/Recoil_PublicHooks-test.js",
       "src/hooks/__tests__/Recoil_useRecoilCallback-test.js",
       "src/recoil_values/__tests__/Recoil_atomFamily-test.js",
-      "src/recoil_values/__tests__/Recoil_selector-test.js"
+      "src/recoil_values/__tests__/Recoil_atom-test.js",
+      "src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js"
     ],
     "setupFiles": [
       "./setupJestMock.js"

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -208,6 +208,31 @@ function flushPromisesAndTimers(): Promise<mixed> {
   });
 }
 
+// Async util function that calls predicate multiple times until it returns `true`
+// or throws if predicate never returned `true` and the function reached its timeout
+// Example:
+//    let x = 0;
+//    setTimeout(() => x = 1, 1000);
+//    await waitFor(() => x === 1);
+async function waitFor(
+  fn: () => boolean,
+  message?: string,
+  timeout: number = 1000,
+) {
+  const error = new Error(
+    message != null
+      ? message
+      : 'Expected the function to start returning "true" but it never did',
+  );
+  const startTime = Date.now();
+  while (!Boolean(fn())) {
+    if (Date.now() - startTime > timeout) {
+      throw error;
+    }
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+}
+
 module.exports = {
   makeStore,
   renderElements,
@@ -219,4 +244,5 @@ module.exports = {
   loadingAsyncSelector,
   asyncSelector,
   flushPromisesAndTimers,
+  waitFor,
 };


### PR DESCRIPTION
fake timers are a pain to debug and work with. These tests are currently breaking, because internally at fb promises work differently and it's pretty painful to debug why and how. I removed all fake timers in this tests and added a `waitFor` utility, that will wait for the entire thing to happen naturally with real timers (as it would in the real world).

cons of this approach:
- since this is using real timers, it actually has to wait for things to happen. It will result in slower tests, but practically it's only a 10ms difference. 
- some cases need additional infra to be built in order to test these cases. E.g. we need to have hooks to manually resolve some selectors (instead of relying on X number of ticks for them to be resolved). If we actually build this infra (i mean it's like 10 lines of code) the test will also become much more maintainable and readable, since there' will not be obscure flows depending on timer ticks