### PR TITLE
getSubscriptions accessor for Snapshot

### DIFF
--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -100,22 +100,20 @@ function getDownstreamNodes(
   state: TreeState,
   keys: $ReadOnlySet<NodeKey>,
 ): $ReadOnlySet<NodeKey> {
-  const dependentNodes = new Set();
   const visitedNodes = new Set();
   const visitingNodes = Array.from(keys);
+  const graph = store.getGraph(state.version);
+
   for (let key = visitingNodes.pop(); key; key = visitingNodes.pop()) {
-    dependentNodes.add(key);
     visitedNodes.add(key);
-    const subscribedNodes =
-      store.getGraph(state.version).nodeToNodeSubscriptions.get(key) ??
-      emptySet;
+    const subscribedNodes = graph.nodeToNodeSubscriptions.get(key) ?? emptySet;
     for (const downstreamNode of subscribedNodes) {
       if (!visitedNodes.has(downstreamNode)) {
         visitingNodes.push(downstreamNode);
       }
     }
   }
-  return dependentNodes;
+  return visitedNodes;
 }
 
 module.exports = {

--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -30,7 +30,6 @@ const {freshSnapshot} = require('../core/Recoil_Snapshot');
 const {
   getNextTreeStateVersion,
   makeEmptyStoreState,
-  makeStoreState,
 } = require('../core/Recoil_State');
 const {mapByDeletingMultipleFromMap} = require('../util/Recoil_CopyOnWrite');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -227,7 +226,7 @@ function initialStoreState_DEPRECATED(store, initializeState): StoreState {
 
 function initialStoreState(initializeState): StoreState {
   const snapshot = freshSnapshot().map(initializeState);
-  return makeStoreState(snapshot.getStore_INTERNAL().getState().currentTree);
+  return snapshot.getStore_INTERNAL().getState();
 }
 
 let nextID = 0;

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -134,30 +134,26 @@ function makeEmptyTreeState(): TreeState {
   };
 }
 
-function makeStoreState(treeState: TreeState): StoreState {
+function makeEmptyStoreState(): StoreState {
+  const currentTree = makeEmptyTreeState();
   return {
-    currentTree: treeState,
+    currentTree,
     nextTree: null,
     previousTree: null,
     knownAtoms: new Set(),
     knownSelectors: new Set(),
     transactionSubscriptions: new Map(),
     nodeTransactionSubscriptions: new Map(),
+    nodeToComponentSubscriptions: new Map(),
     queuedComponentCallbacks_DEPRECATED: [],
     suspendedComponentResolvers: new Set(),
-    nodeToComponentSubscriptions: new Map(),
-    graphsByVersion: new Map().set(treeState.version, graph()),
+    graphsByVersion: new Map().set(currentTree.version, graph()),
     versionsUsedByComponent: new Map(),
   };
-}
-
-function makeEmptyStoreState(): StoreState {
-  return makeStoreState(makeEmptyTreeState());
 }
 
 module.exports = {
   makeEmptyTreeState,
   makeEmptyStoreState,
-  makeStoreState,
   getNextTreeStateVersion,
 };

--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -11,8 +11,10 @@ const React = require('React');
 const {useEffect} = require('React');
 const {act} = require('ReactTestUtils');
 
+const {freshSnapshot} = require('../../core/Recoil_Snapshot');
 const atom = require('../../recoil_values/Recoil_atom');
 const constSelector = require('../../recoil_values/Recoil_constSelector');
+const selector = require('../../recoil_values/Recoil_selector');
 const {
   ReadsAtom,
   asyncSelector,
@@ -151,4 +153,67 @@ test('useRecoilSnapshot - async selectors', async () => {
 
   expect(snapshots.length).toEqual(2);
   expect(snapshots[0].getLoadable(mySelector).contents).toEqual('RESOLVE');
+});
+
+test('getSubscriptions', async () => {
+  const myAtom = atom<string>({
+    key: 'useRecoilSnapshot getSubscriptions atom',
+    default: 'ATOM',
+  });
+  const selectorA = selector({
+    key: 'useRecoilSnapshot getSubscriptions A',
+    get: ({get}) => get(myAtom),
+  });
+  const selectorB = selector({
+    key: 'useRecoilSnapshot getSubscriptions B',
+    get: ({get}) => get(selectorA) + get(myAtom),
+  });
+  const selectorC = selector({
+    key: 'useRecoilSnapshot getSubscriptions C',
+    get: async ({get}) => {
+      const ret = get(selectorA) + get(selectorB);
+      await Promise.resolve();
+      return ret;
+    },
+  });
+
+  let snapshot = freshSnapshot();
+  function RecoilSnapshot() {
+    snapshot = useRecoilSnapshot();
+    return null;
+  }
+  const c = renderElements(
+    <>
+      <ReadsAtom atom={selectorC} />
+      <RecoilSnapshot />
+    </>,
+  );
+  await flushPromisesAndTimers();
+  await flushPromisesAndTimers();
+  expect(c.textContent).toBe('"ATOMATOMATOM"');
+
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes).length,
+  ).toBe(3);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB, selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes).length,
+  ).toBe(2);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes)).toEqual(
+    expect.arrayContaining([selectorB, selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes).length,
+  ).toBe(1);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes)).toEqual(
+    expect.arrayContaining([selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes).length,
+  ).toBe(0);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes)).toEqual(
+    expect.arrayContaining([]),
+  );
 });


### PR DESCRIPTION
Summary:
Add a `getSubscriptions_UNSTABLE()` access for `Snapshot`.  This will report different types of subscriptions of a provided node, though currently only node subscriptions are reported.

This API has some problems:
  * We can't report component, transaction observer, and atom effect subscriptions currently because those subscriptions are stored in the store instead of tree state and not part of the `Snapshot`
  * `getDeps()` evaluates a node first and always reports the proper immediate dependencies for the node given the current Recoil atom state, though it may change with async resolutions.  `getSubscriptions()` reports the known subscribers for a node.  But, evaluating other nodes may cause new subscriptions to be created.  So, this API may report these additional subscriptions after other nodes are evaluated.

So, we need to think through cleaning this up.

Reviewed By: csantos42, maxijb, davidmccabe

Differential Revision: D21969850

