### PR TITLE
Ability to iterate all registered atoms with getNodes()

### DIFF
--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -100,22 +100,20 @@ function getDownstreamNodes(
   state: TreeState,
   keys: $ReadOnlySet<NodeKey>,
 ): $ReadOnlySet<NodeKey> {
-  const dependentNodes = new Set();
   const visitedNodes = new Set();
   const visitingNodes = Array.from(keys);
+  const graph = store.getGraph(state.version);
+
   for (let key = visitingNodes.pop(); key; key = visitingNodes.pop()) {
-    dependentNodes.add(key);
     visitedNodes.add(key);
-    const subscribedNodes =
-      store.getGraph(state.version).nodeToNodeSubscriptions.get(key) ??
-      emptySet;
+    const subscribedNodes = graph.nodeToNodeSubscriptions.get(key) ?? emptySet;
     for (const downstreamNode of subscribedNodes) {
       if (!visitedNodes.has(downstreamNode)) {
         visitingNodes.push(downstreamNode);
       }
     }
   }
-  return dependentNodes;
+  return visitedNodes;
 }
 
 module.exports = {

--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -30,7 +30,6 @@ const {freshSnapshot} = require('../core/Recoil_Snapshot');
 const {
   getNextTreeStateVersion,
   makeEmptyStoreState,
-  makeStoreState,
 } = require('../core/Recoil_State');
 const {mapByDeletingMultipleFromMap} = require('../util/Recoil_CopyOnWrite');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -227,7 +226,7 @@ function initialStoreState_DEPRECATED(store, initializeState): StoreState {
 
 function initialStoreState(initializeState): StoreState {
   const snapshot = freshSnapshot().map(initializeState);
-  return makeStoreState(snapshot.getStore_INTERNAL().getState().currentTree);
+  return snapshot.getStore_INTERNAL().getState();
 }
 
 let nextID = 0;

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -134,30 +134,26 @@ function makeEmptyTreeState(): TreeState {
   };
 }
 
-function makeStoreState(treeState: TreeState): StoreState {
+function makeEmptyStoreState(): StoreState {
+  const currentTree = makeEmptyTreeState();
   return {
-    currentTree: treeState,
+    currentTree,
     nextTree: null,
     previousTree: null,
     knownAtoms: new Set(),
     knownSelectors: new Set(),
     transactionSubscriptions: new Map(),
     nodeTransactionSubscriptions: new Map(),
+    nodeToComponentSubscriptions: new Map(),
     queuedComponentCallbacks_DEPRECATED: [],
     suspendedComponentResolvers: new Set(),
-    nodeToComponentSubscriptions: new Map(),
-    graphsByVersion: new Map().set(treeState.version, graph()),
+    graphsByVersion: new Map().set(currentTree.version, graph()),
     versionsUsedByComponent: new Map(),
   };
-}
-
-function makeEmptyStoreState(): StoreState {
-  return makeStoreState(makeEmptyTreeState());
 }
 
 module.exports = {
   makeEmptyTreeState,
   makeEmptyStoreState,
-  makeStoreState,
   getNextTreeStateVersion,
 };

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -28,15 +28,20 @@ const {
 } = require('../../testing/Recoil_TestingUtils');
 const {Snapshot, freshSnapshot} = require('../Recoil_Snapshot');
 
-// Run test first since it is testing all registered atoms
+// Test first since we are testing all registered nodes
 test('getNodes', () => {
   const snapshot = freshSnapshot();
   const {getNodes_UNSTABLE} = snapshot;
   expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
+  // expect(Array.from(getNodes_UNSTABLE({isSet: true})).length).toEqual(0);
 
   // Test atoms
   const myAtom = atom({key: 'snapshot getNodes atom', default: 'DEFAULT'});
   expect(Array.from(getNodes_UNSTABLE()).length).toEqual(1);
+  expect(Array.from(getNodes_UNSTABLE({isInitialized: true})).length).toEqual(
+    0,
+  );
   expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
   const nodesAfterGet = Array.from(getNodes_UNSTABLE());
   expect(nodesAfterGet.length).toEqual(1);
@@ -49,26 +54,39 @@ test('getNodes', () => {
     get: ({get}) => get(myAtom) + '-SELECTOR',
   });
   expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  expect(Array.from(getNodes_UNSTABLE({isInitialized: true})).length).toEqual(
+    1,
+  );
   expect(snapshot.getLoadable(mySelector).contents).toEqual('DEFAULT-SELECTOR');
-  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  expect(Array.from(getNodes_UNSTABLE({isInitialized: true})).length).toEqual(
+    2,
+  );
   // expect(Array.from(getNodes_UNSTABLE({types: ['atom']})).length).toEqual(1);
   // const selectorNodes = Array.from(getNodes_UNSTABLE({types: ['selector']}));
   // expect(selectorNodes.length).toEqual(1);
   // expect(selectorNodes[0]).toBe(mySelector);
 
   // Test dirty atoms
-  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
-    0,
-  );
-  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
-  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
-    0,
-  );
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  // expect(Array.from(getNodes_UNSTABLE({isSet: true})).length).toEqual(0);
   expect(
-    Array.from(updatedSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+    Array.from(snapshot.getNodes_UNSTABLE({isModified: true})).length,
+  ).toEqual(0);
+  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
+  expect(
+    Array.from(snapshot.getNodes_UNSTABLE({isModified: true})).length,
+  ).toEqual(0);
+  expect(
+    Array.from(updatedSnapshot.getNodes_UNSTABLE({isModified: true})).length,
   ).toEqual(1);
+  // expect(
+  //   Array.from(snapshot.getNodes_UNSTABLE({isSet: true})).length,
+  // ).toEqual(0);
+  // expect(
+  //   Array.from(updatedSnapshot.getNodes_UNSTABLE({isSet: true})).length,
+  // ).toEqual(1);
   const dirtyAtom = Array.from(
-    updatedSnapshot.getNodes_UNSTABLE({dirty: true}),
+    updatedSnapshot.getNodes_UNSTABLE({isModified: true}),
   )[0];
   expect(snapshot.getLoadable(dirtyAtom).contents).toEqual('DEFAULT');
   expect(updatedSnapshot.getLoadable(dirtyAtom).contents).toEqual('SET');
@@ -76,8 +94,11 @@ test('getNodes', () => {
   // Test reset
   const resetSnapshot = updatedSnapshot.map(({reset}) => reset(myAtom));
   expect(
-    Array.from(resetSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+    Array.from(resetSnapshot.getNodes_UNSTABLE({isModified: true})).length,
   ).toEqual(1);
+  // expect(
+  //   Array.from(resetSnapshot.getNodes_UNSTABLE({isSet: true})).length,
+  // ).toEqual(0);
 
   // TODO Test dirty selectors
 });

--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -11,8 +11,10 @@ const React = require('React');
 const {useEffect} = require('React');
 const {act} = require('ReactTestUtils');
 
+const {freshSnapshot} = require('../../core/Recoil_Snapshot');
 const atom = require('../../recoil_values/Recoil_atom');
 const constSelector = require('../../recoil_values/Recoil_constSelector');
+const selector = require('../../recoil_values/Recoil_selector');
 const {
   ReadsAtom,
   asyncSelector,
@@ -151,4 +153,67 @@ test('useRecoilSnapshot - async selectors', async () => {
 
   expect(snapshots.length).toEqual(2);
   expect(snapshots[0].getLoadable(mySelector).contents).toEqual('RESOLVE');
+});
+
+test('getSubscriptions', async () => {
+  const myAtom = atom<string>({
+    key: 'useRecoilSnapshot getSubscriptions atom',
+    default: 'ATOM',
+  });
+  const selectorA = selector({
+    key: 'useRecoilSnapshot getSubscriptions A',
+    get: ({get}) => get(myAtom),
+  });
+  const selectorB = selector({
+    key: 'useRecoilSnapshot getSubscriptions B',
+    get: ({get}) => get(selectorA) + get(myAtom),
+  });
+  const selectorC = selector({
+    key: 'useRecoilSnapshot getSubscriptions C',
+    get: async ({get}) => {
+      const ret = get(selectorA) + get(selectorB);
+      await Promise.resolve();
+      return ret;
+    },
+  });
+
+  let snapshot = freshSnapshot();
+  function RecoilSnapshot() {
+    snapshot = useRecoilSnapshot();
+    return null;
+  }
+  const c = renderElements(
+    <>
+      <ReadsAtom atom={selectorC} />
+      <RecoilSnapshot />
+    </>,
+  );
+  await flushPromisesAndTimers();
+  await flushPromisesAndTimers();
+  expect(c.textContent).toBe('"ATOMATOMATOM"');
+
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes).length,
+  ).toBe(3);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB, selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes).length,
+  ).toBe(2);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes)).toEqual(
+    expect.arrayContaining([selectorB, selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes).length,
+  ).toBe(1);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes)).toEqual(
+    expect.arrayContaining([selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes).length,
+  ).toBe(0);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes)).toEqual(
+    expect.arrayContaining([]),
+  );
 });

--- a/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
@@ -63,46 +63,50 @@ test('getNodes', () => {
   expect(c.textContent).toEqual('"A""B""A-SELECTOR"');
 
   expect(
-    Array.from(snapshot.getNodes_UNSTABLE()).length,
-  ).toBeGreaterThanOrEqual(2);
+    Array.from(snapshot.getNodes_UNSTABLE({isInitialized: true})).length,
+  ).toEqual(0);
   act(() => setAtomA('A'));
   // Greater than 3 because we expect at least nodes for atom's A and B from
   // the family and selectorA.  In reality we currenlty get 8 due to internal
   // helper selectors and default fallback atoms.
-  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toBeGreaterThan(3);
-  const nodes = Array.from(snapshot.getNodes_UNSTABLE());
+  expect(
+    Array.from(snapshot.getNodes_UNSTABLE({isInitialized: true})).length,
+  ).toBeGreaterThan(3);
+  const nodes = Array.from(snapshot.getNodes_UNSTABLE({isInitialized: true}));
   expect(nodes).toEqual(
     expect.arrayContaining([atoms('A'), atoms('B'), selectorA]),
   );
 
   // Test atom A is set
-  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({isModified: true}));
   expect(aDirty.length).toEqual(1);
   expect(snapshot.getLoadable(aDirty[0]).contents).toEqual('A');
 
   // Test atom B is set
   act(() => setAtomB('B'));
-  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({isModified: true}));
   expect(bDirty.length).toEqual(1);
   expect(snapshot.getLoadable(bDirty[0]).contents).toEqual('B');
 
-  // // Test atoms
-  // const atomNodes = Array.from(snapshot.getNodes_UNSTABLE({types: ['atom']}));
-  // expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
-  //   expect.arrayContaining(['A', 'B']),
-  // );
+  // Test atoms
+  const atomNodes = Array.from(
+    snapshot.getNodes_UNSTABLE({isInitialized: true}),
+  );
+  expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
+    expect.arrayContaining(['A', 'B']),
+  );
 
-  // // Test selector
-  // const selectorNodes = Array.from(
-  //   snapshot.getNodes_UNSTABLE({types: ['selector']}),
-  // );
-  // expect(
-  //   selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
-  // ).toEqual(expect.arrayContaining(['A-SELECTOR']));
+  // Test selector
+  const selectorNodes = Array.from(
+    snapshot.getNodes_UNSTABLE({isInitialized: true}),
+  );
+  expect(
+    selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
+  ).toEqual(expect.arrayContaining(['A-SELECTOR']));
 
   // Test Reset
   act(resetAtomA);
-  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({isModified: true}));
   expect(resetDirty.length).toEqual(1);
   expect(resetDirty[0]).toBe(aDirty[0]);
 


### PR DESCRIPTION
Summary:
Update interface for `getNodes_UNSTABLE()` to allow iteration of all registered or initialized nodes.

```
function getNodes_UNSTABLE({
  isInitialized?: boolean,
  isModified?: boolean,
} | void): Iterable<RecoilValue<mixed>>
```

After we figure out what we really need for dev tools, let's pare down and minimize this unstable API before publishing.

Reviewed By: maxijb, davidmccabe

Differential Revision: D22199495

