### PR TITLE
Snapshot.peekStatus() for Dev Tools

### DIFF
--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -43,15 +43,13 @@ function getNodeLoadable<T>(
   return getNode(key).get(store, state);
 }
 
-// Peek at the current value loadable for a node.
-// NOTE: Only use in contexts where you don't need to update the store with
-//       new dependencies for the node!
+// Peek at the current value loadable for a node without any evaluation or state change
 function peekNodeLoadable<T>(
   store: Store,
   state: TreeState,
   key: NodeKey,
-): Loadable<T> {
-  return getNodeLoadable(store, state, key)[1];
+): ?Loadable<T> {
+  return getNode(key).peek(store, state);
 }
 
 // Write value directly to state bypassing the Node interface as the node

--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -100,22 +100,20 @@ function getDownstreamNodes(
   state: TreeState,
   keys: $ReadOnlySet<NodeKey>,
 ): $ReadOnlySet<NodeKey> {
-  const dependentNodes = new Set();
   const visitedNodes = new Set();
   const visitingNodes = Array.from(keys);
+  const graph = store.getGraph(state.version);
+
   for (let key = visitingNodes.pop(); key; key = visitingNodes.pop()) {
-    dependentNodes.add(key);
     visitedNodes.add(key);
-    const subscribedNodes =
-      store.getGraph(state.version).nodeToNodeSubscriptions.get(key) ??
-      emptySet;
+    const subscribedNodes = graph.nodeToNodeSubscriptions.get(key) ?? emptySet;
     for (const downstreamNode of subscribedNodes) {
       if (!visitedNodes.has(downstreamNode)) {
         visitingNodes.push(downstreamNode);
       }
     }
   }
-  return dependentNodes;
+  return visitedNodes;
 }
 
 module.exports = {

--- a/src/core/Recoil_Node.js
+++ b/src/core/Recoil_Node.js
@@ -39,6 +39,9 @@ export type PersistenceInfo = $ReadOnly<{
 export type ReadOnlyNodeOptions<T> = $ReadOnly<{
   key: NodeKey,
 
+  // Returns the current value without evaluating or modifying state
+  peek: (Store, TreeState) => ?Loadable<T>,
+
   // Returns the discovered deps and the loadable value of the node
   get: (Store, TreeState) => [DependencyMap, Loadable<T>],
 

--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -30,7 +30,6 @@ const {freshSnapshot} = require('../core/Recoil_Snapshot');
 const {
   getNextTreeStateVersion,
   makeEmptyStoreState,
-  makeStoreState,
 } = require('../core/Recoil_State');
 const {mapByDeletingMultipleFromMap} = require('../util/Recoil_CopyOnWrite');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -227,7 +226,7 @@ function initialStoreState_DEPRECATED(store, initializeState): StoreState {
 
 function initialStoreState(initializeState): StoreState {
   const snapshot = freshSnapshot().map(initializeState);
-  return makeStoreState(snapshot.getStore_INTERNAL().getState().currentTree);
+  return snapshot.getStore_INTERNAL().getState();
 }
 
 let nextID = 0;

--- a/src/core/Recoil_RecoilValueInterface.js
+++ b/src/core/Recoil_RecoilValueInterface.js
@@ -25,7 +25,6 @@ const Tracing = require('../util/Recoil_Tracing');
 const unionSets = require('../util/Recoil_unionSets');
 const {
   getNodeLoadable,
-  peekNodeLoadable,
   setNodeValue,
   setUnvalidatedAtomValue,
 } = require('./Recoil_FunctionalCore');
@@ -74,8 +73,8 @@ function valueFromValueOrUpdater<T>(
     // pending or errored):
     const storeState = store.getState();
     const state = storeState.nextTree ?? storeState.currentTree;
-    // NOTE: This will not update state with node subscriptions.
-    const current = peekNodeLoadable(store, state, key);
+    // NOTE: This will evaluate node, but not update state with node subscriptions!
+    const current = getNodeLoadable(store, state, key)[1];
     if (current.state === 'loading') {
       throw new RecoilValueNotReady(key);
     } else if (current.state === 'hasError') {

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -22,7 +22,10 @@ import type {StateID, Store, StoreState, TreeState} from './Recoil_State';
 const gkx = require('../util/Recoil_gkx');
 const mapIterable = require('../util/Recoil_mapIterable');
 const nullthrows = require('../util/Recoil_nullthrows');
-const {getDownstreamNodes} = require('./Recoil_FunctionalCore');
+const {
+  getDownstreamNodes,
+  peekNodeLoadable,
+} = require('./Recoil_FunctionalCore');
 const {graph} = require('./Recoil_Graph');
 const {DEFAULT_VALUE, recoilValues} = require('./Recoil_Node');
 const {
@@ -130,10 +133,13 @@ class Snapshot {
     recoilValue: RecoilValue<T>,
   ) => {
     this.getLoadable(recoilValue); // Evaluate node to ensure deps are up-to-date
-    const storeState = this._store.getState();
-    const deps = storeState.graphsByVersion
-      .get(storeState.currentTree.version)
-      ?.nodeDeps.get(recoilValue.key);
+    const deps = this._store
+      .getGraph(this._store.getState().currentTree.version)
+      .nodeDeps.get(recoilValue.key);
+    // const storeState = this._store.getState();
+    // const deps = storeState.graphsByVersion
+    //   .get(storeState.currentTree.version)
+    //   ?.nodeDeps.get(recoilValue.key);
     return (function*() {
       for (const key of deps ?? []) {
         yield nullthrows(recoilValues.get(key));
@@ -166,6 +172,47 @@ class Snapshot {
           yield nullthrows(recoilValues.get(node));
         }
       })(),
+    };
+  };
+
+  // Report the current status of a node.
+  // This peeks the current state and does not affect the snapshot state at all
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  peekStatus_UNSTABLE: <T>(
+    RecoilValue<T>,
+  ) => {
+    loadable: ?Loadable<T>,
+    isInitialized: boolean,
+    isSet: boolean,
+    isModified: boolean, // TODO report modified selectors
+    type: 'atom' | 'selector' | void, // void until initialized for now
+    deps: Iterable<RecoilValue<mixed>>,
+    subscribers: {
+      nodes: Iterable<RecoilValue<mixed>>,
+    },
+  } = <T>(recoilValue: RecoilValue<T>) => {
+    const {key} = recoilValue;
+    const state = this._store.getState().currentTree;
+    const graph = this._store.getGraph(state.version);
+    return {
+      loadable: peekNodeLoadable(this._store, state, key),
+      isInitialized:
+        this._store.getState().knownAtoms.has(key) ||
+        this._store.getState().knownSelectors.has(key),
+      isSet: state.atomValues.has(key),
+      isModified: state.dirtyAtoms.has(key),
+      type: this._store.getState().knownAtoms.has(key)
+        ? 'atom'
+        : this._store.getState().knownSelectors.has(key)
+        ? 'selector'
+        : undefined,
+      // Don't use this.getDeps() as it will evaluate the node
+      deps: graph.nodeDeps.has(key)
+        ? Array.from(nullthrows(graph.nodeDeps.get(key))).map(key =>
+            nullthrows(recoilValues.get(key)),
+          )
+        : [],
+      subscribers: this.getSubscribers_UNSTABLE(recoilValue),
     };
   };
 

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -134,30 +134,26 @@ function makeEmptyTreeState(): TreeState {
   };
 }
 
-function makeStoreState(treeState: TreeState): StoreState {
+function makeEmptyStoreState(): StoreState {
+  const currentTree = makeEmptyTreeState();
   return {
-    currentTree: treeState,
+    currentTree,
     nextTree: null,
     previousTree: null,
     knownAtoms: new Set(),
     knownSelectors: new Set(),
     transactionSubscriptions: new Map(),
     nodeTransactionSubscriptions: new Map(),
+    nodeToComponentSubscriptions: new Map(),
     queuedComponentCallbacks_DEPRECATED: [],
     suspendedComponentResolvers: new Set(),
-    nodeToComponentSubscriptions: new Map(),
-    graphsByVersion: new Map().set(treeState.version, graph()),
+    graphsByVersion: new Map().set(currentTree.version, graph()),
     versionsUsedByComponent: new Map(),
   };
-}
-
-function makeEmptyStoreState(): StoreState {
-  return makeStoreState(makeEmptyTreeState());
 }
 
 module.exports = {
   makeEmptyTreeState,
   makeEmptyStoreState,
-  makeStoreState,
   getNextTreeStateVersion,
 };

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -28,15 +28,20 @@ const {
 } = require('../../testing/Recoil_TestingUtils');
 const {Snapshot, freshSnapshot} = require('../Recoil_Snapshot');
 
-// Run test first since it is testing all registered atoms
+// Test first since we are testing all registered nodes
 test('getNodes', () => {
   const snapshot = freshSnapshot();
   const {getNodes_UNSTABLE} = snapshot;
   expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
+  // expect(Array.from(getNodes_UNSTABLE({isSet: true})).length).toEqual(0);
 
   // Test atoms
   const myAtom = atom({key: 'snapshot getNodes atom', default: 'DEFAULT'});
   expect(Array.from(getNodes_UNSTABLE()).length).toEqual(1);
+  expect(Array.from(getNodes_UNSTABLE({isInitialized: true})).length).toEqual(
+    0,
+  );
   expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
   const nodesAfterGet = Array.from(getNodes_UNSTABLE());
   expect(nodesAfterGet.length).toEqual(1);
@@ -49,26 +54,39 @@ test('getNodes', () => {
     get: ({get}) => get(myAtom) + '-SELECTOR',
   });
   expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  expect(Array.from(getNodes_UNSTABLE({isInitialized: true})).length).toEqual(
+    1,
+  );
   expect(snapshot.getLoadable(mySelector).contents).toEqual('DEFAULT-SELECTOR');
-  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  expect(Array.from(getNodes_UNSTABLE({isInitialized: true})).length).toEqual(
+    2,
+  );
   // expect(Array.from(getNodes_UNSTABLE({types: ['atom']})).length).toEqual(1);
   // const selectorNodes = Array.from(getNodes_UNSTABLE({types: ['selector']}));
   // expect(selectorNodes.length).toEqual(1);
   // expect(selectorNodes[0]).toBe(mySelector);
 
   // Test dirty atoms
-  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
-    0,
-  );
-  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
-  expect(Array.from(snapshot.getNodes_UNSTABLE({dirty: true})).length).toEqual(
-    0,
-  );
+  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(2);
+  // expect(Array.from(getNodes_UNSTABLE({isSet: true})).length).toEqual(0);
   expect(
-    Array.from(updatedSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+    Array.from(snapshot.getNodes_UNSTABLE({isModified: true})).length,
+  ).toEqual(0);
+  const updatedSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
+  expect(
+    Array.from(snapshot.getNodes_UNSTABLE({isModified: true})).length,
+  ).toEqual(0);
+  expect(
+    Array.from(updatedSnapshot.getNodes_UNSTABLE({isModified: true})).length,
   ).toEqual(1);
+  // expect(
+  //   Array.from(snapshot.getNodes_UNSTABLE({isSet: true})).length,
+  // ).toEqual(0);
+  // expect(
+  //   Array.from(updatedSnapshot.getNodes_UNSTABLE({isSet: true})).length,
+  // ).toEqual(1);
   const dirtyAtom = Array.from(
-    updatedSnapshot.getNodes_UNSTABLE({dirty: true}),
+    updatedSnapshot.getNodes_UNSTABLE({isModified: true}),
   )[0];
   expect(snapshot.getLoadable(dirtyAtom).contents).toEqual('DEFAULT');
   expect(updatedSnapshot.getLoadable(dirtyAtom).contents).toEqual('SET');
@@ -76,8 +94,11 @@ test('getNodes', () => {
   // Test reset
   const resetSnapshot = updatedSnapshot.map(({reset}) => reset(myAtom));
   expect(
-    Array.from(resetSnapshot.getNodes_UNSTABLE({dirty: true})).length,
+    Array.from(resetSnapshot.getNodes_UNSTABLE({isModified: true})).length,
   ).toEqual(1);
+  // expect(
+  //   Array.from(resetSnapshot.getNodes_UNSTABLE({isSet: true})).length,
+  // ).toEqual(0);
 
   // TODO Test dirty selectors
 });

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -33,7 +33,9 @@ test('getNodes', () => {
   const snapshot = freshSnapshot();
   const {getNodes_UNSTABLE} = snapshot;
   expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
-  expect(Array.from(getNodes_UNSTABLE()).length).toEqual(0);
+  expect(Array.from(getNodes_UNSTABLE({isInitialized: true})).length).toEqual(
+    0,
+  );
   // expect(Array.from(getNodes_UNSTABLE({isSet: true})).length).toEqual(0);
 
   // Test atoms
@@ -339,11 +341,11 @@ describe('getSubscriptions', () => {
 
     // No initial subscribers
     expect(Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes)).toEqual(
-      expect.arrayContaining([]),
+      [],
     );
     expect(
       Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes),
-    ).toEqual(expect.arrayContaining([]));
+    ).toEqual([]);
 
     // Evaluate selectorC to update all of its upstream node subscriptions
     snapshot.getLoadable(selectorC);
@@ -358,6 +360,188 @@ describe('getSubscriptions', () => {
     ).toEqual(expect.arrayContaining([selectorC]));
     expect(
       Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes),
-    ).toEqual(expect.arrayContaining([]));
+    ).toEqual([]);
   });
+});
+
+test('peekStatus', () => {
+  const snapshot = freshSnapshot();
+
+  const myAtom = atom<string>({
+    key: 'snapshot peekStatus atom',
+    default: 'DEFAULT',
+  });
+  const selectorA = selector({
+    key: 'peekStatus A',
+    get: ({get}) => get(myAtom),
+  });
+  const selectorB = selector({
+    key: 'peekStatus B',
+    get: ({get}) => get(selectorA) + get(myAtom),
+  });
+
+  // Initial status
+  expect(snapshot.peekStatus_UNSTABLE(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isInitialized: false,
+    isSet: false,
+    isModified: false,
+    type: undefined,
+  });
+  expect(Array.from(snapshot.peekStatus_UNSTABLE(myAtom).deps)).toEqual([]);
+  expect(
+    Array.from(snapshot.peekStatus_UNSTABLE(myAtom).subscribers.nodes),
+  ).toEqual([]);
+  expect(snapshot.peekStatus_UNSTABLE(selectorA)).toMatchObject({
+    loadable: undefined,
+    isInitialized: false,
+    isSet: false,
+    isModified: false,
+    type: undefined,
+  });
+  expect(Array.from(snapshot.peekStatus_UNSTABLE(selectorA).deps)).toEqual([]);
+  expect(
+    Array.from(snapshot.peekStatus_UNSTABLE(selectorA).subscribers.nodes),
+  ).toEqual([]);
+  expect(snapshot.peekStatus_UNSTABLE(selectorB)).toMatchObject({
+    loadable: undefined,
+    isInitialized: false,
+    isSet: false,
+    isModified: false,
+    type: undefined,
+  });
+  expect(Array.from(snapshot.peekStatus_UNSTABLE(selectorB).deps)).toEqual([]);
+  expect(
+    Array.from(snapshot.peekStatus_UNSTABLE(selectorB).subscribers.nodes),
+  ).toEqual([]);
+
+  // After reading values
+  snapshot.getLoadable(selectorB);
+  expect(snapshot.peekStatus_UNSTABLE(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isInitialized: true,
+    isSet: false,
+    isModified: false,
+    type: 'atom',
+  });
+  expect(Array.from(snapshot.peekStatus_UNSTABLE(myAtom).deps)).toEqual([]);
+  expect(
+    Array.from(snapshot.peekStatus_UNSTABLE(myAtom).subscribers.nodes),
+  ).toEqual(expect.arrayContaining([selectorA, selectorB]));
+  expect(snapshot.peekStatus_UNSTABLE(selectorA)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isInitialized: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(snapshot.peekStatus_UNSTABLE(selectorA).deps)).toEqual(
+    expect.arrayContaining([myAtom]),
+  );
+  expect(
+    Array.from(snapshot.peekStatus_UNSTABLE(selectorA).subscribers.nodes),
+  ).toEqual(expect.arrayContaining([selectorB]));
+  expect(snapshot.peekStatus_UNSTABLE(selectorB)).toMatchObject({
+    loadable: expect.objectContaining({
+      state: 'hasValue',
+      contents: 'DEFAULTDEFAULT',
+    }),
+    isInitialized: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(snapshot.peekStatus_UNSTABLE(selectorB).deps)).toEqual(
+    expect.arrayContaining([myAtom, selectorA]),
+  );
+  expect(
+    Array.from(snapshot.peekStatus_UNSTABLE(selectorB).subscribers.nodes),
+  ).toEqual([]);
+
+  // After setting a value
+  const setSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
+  setSnapshot.getLoadable(selectorB); // Read value to prime
+  expect(setSnapshot.peekStatus_UNSTABLE(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
+    isInitialized: true,
+    isSet: true,
+    isModified: true,
+    type: 'atom',
+  });
+  expect(Array.from(setSnapshot.peekStatus_UNSTABLE(myAtom).deps)).toEqual([]);
+  expect(
+    Array.from(setSnapshot.peekStatus_UNSTABLE(myAtom).subscribers.nodes),
+  ).toEqual(expect.arrayContaining([selectorA, selectorB]));
+  expect(setSnapshot.peekStatus_UNSTABLE(selectorA)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
+    isInitialized: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(setSnapshot.peekStatus_UNSTABLE(selectorA).deps)).toEqual(
+    expect.arrayContaining([myAtom]),
+  );
+  expect(
+    Array.from(setSnapshot.peekStatus_UNSTABLE(selectorA).subscribers.nodes),
+  ).toEqual(expect.arrayContaining([selectorB]));
+  expect(setSnapshot.peekStatus_UNSTABLE(selectorB)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'SETSET'}),
+    isInitialized: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(setSnapshot.peekStatus_UNSTABLE(selectorB).deps)).toEqual(
+    expect.arrayContaining([myAtom, selectorA]),
+  );
+  expect(
+    Array.from(setSnapshot.peekStatus_UNSTABLE(selectorB).subscribers.nodes),
+  ).toEqual([]);
+
+  // After reseting a value
+  const resetSnapshot = setSnapshot.map(({reset}) => reset(myAtom));
+  resetSnapshot.getLoadable(selectorB); // prime snapshot
+  expect(resetSnapshot.peekStatus_UNSTABLE(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isInitialized: true,
+    isSet: false,
+    isModified: true,
+    type: 'atom',
+  });
+  expect(Array.from(resetSnapshot.peekStatus_UNSTABLE(myAtom).deps)).toEqual(
+    [],
+  );
+  expect(
+    Array.from(resetSnapshot.peekStatus_UNSTABLE(myAtom).subscribers.nodes),
+  ).toEqual(expect.arrayContaining([selectorA, selectorB]));
+  expect(resetSnapshot.peekStatus_UNSTABLE(selectorA)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isInitialized: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(resetSnapshot.peekStatus_UNSTABLE(selectorA).deps)).toEqual(
+    expect.arrayContaining([myAtom]),
+  );
+  expect(
+    Array.from(resetSnapshot.peekStatus_UNSTABLE(selectorA).subscribers.nodes),
+  ).toEqual(expect.arrayContaining([selectorB]));
+  expect(resetSnapshot.peekStatus_UNSTABLE(selectorB)).toMatchObject({
+    loadable: expect.objectContaining({
+      state: 'hasValue',
+      contents: 'DEFAULTDEFAULT',
+    }),
+    isInitialized: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(resetSnapshot.peekStatus_UNSTABLE(selectorB).deps)).toEqual(
+    expect.arrayContaining([myAtom, selectorA]),
+  );
+  expect(
+    Array.from(resetSnapshot.peekStatus_UNSTABLE(selectorB).subscribers.nodes),
+  ).toEqual([]);
 });

--- a/src/core/__tests__/Recoil_core-test.js
+++ b/src/core/__tests__/Recoil_core-test.js
@@ -13,14 +13,14 @@
 const atom = require('../../recoil_values/Recoil_atom');
 const {makeStore} = require('../../testing/Recoil_TestingUtils');
 const nullthrows = require('../../util/Recoil_nullthrows');
-const {peekNodeLoadable, setNodeValue} = require('../Recoil_FunctionalCore');
+const {getNodeLoadable, setNodeValue} = require('../Recoil_FunctionalCore');
 
 const a = atom<number>({key: 'a', default: 0}).key;
 
 test('read default value', () => {
   const store = makeStore();
   expect(
-    peekNodeLoadable(store, store.getState().currentTree, a),
+    getNodeLoadable(store, store.getState().currentTree, a)[1],
   ).toMatchObject({
     state: 'hasValue',
     contents: 0,

--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -11,8 +11,10 @@ const React = require('React');
 const {useEffect} = require('React');
 const {act} = require('ReactTestUtils');
 
+const {freshSnapshot} = require('../../core/Recoil_Snapshot');
 const atom = require('../../recoil_values/Recoil_atom');
 const constSelector = require('../../recoil_values/Recoil_constSelector');
+const selector = require('../../recoil_values/Recoil_selector');
 const {
   ReadsAtom,
   asyncSelector,
@@ -151,4 +153,67 @@ test('useRecoilSnapshot - async selectors', async () => {
 
   expect(snapshots.length).toEqual(2);
   expect(snapshots[0].getLoadable(mySelector).contents).toEqual('RESOLVE');
+});
+
+test('getSubscriptions', async () => {
+  const myAtom = atom<string>({
+    key: 'useRecoilSnapshot getSubscriptions atom',
+    default: 'ATOM',
+  });
+  const selectorA = selector({
+    key: 'useRecoilSnapshot getSubscriptions A',
+    get: ({get}) => get(myAtom),
+  });
+  const selectorB = selector({
+    key: 'useRecoilSnapshot getSubscriptions B',
+    get: ({get}) => get(selectorA) + get(myAtom),
+  });
+  const selectorC = selector({
+    key: 'useRecoilSnapshot getSubscriptions C',
+    get: async ({get}) => {
+      const ret = get(selectorA) + get(selectorB);
+      await Promise.resolve();
+      return ret;
+    },
+  });
+
+  let snapshot = freshSnapshot();
+  function RecoilSnapshot() {
+    snapshot = useRecoilSnapshot();
+    return null;
+  }
+  const c = renderElements(
+    <>
+      <ReadsAtom atom={selectorC} />
+      <RecoilSnapshot />
+    </>,
+  );
+  await flushPromisesAndTimers();
+  await flushPromisesAndTimers();
+  expect(c.textContent).toBe('"ATOMATOMATOM"');
+
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes).length,
+  ).toBe(3);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB, selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes).length,
+  ).toBe(2);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes)).toEqual(
+    expect.arrayContaining([selectorB, selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes).length,
+  ).toBe(1);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes)).toEqual(
+    expect.arrayContaining([selectorC]),
+  );
+  expect(
+    Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes).length,
+  ).toBe(0);
+  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes)).toEqual(
+    expect.arrayContaining([]),
+  );
 });

--- a/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
@@ -63,46 +63,50 @@ test('getNodes', () => {
   expect(c.textContent).toEqual('"A""B""A-SELECTOR"');
 
   expect(
-    Array.from(snapshot.getNodes_UNSTABLE()).length,
-  ).toBeGreaterThanOrEqual(2);
+    Array.from(snapshot.getNodes_UNSTABLE({isInitialized: true})).length,
+  ).toEqual(0);
   act(() => setAtomA('A'));
   // Greater than 3 because we expect at least nodes for atom's A and B from
   // the family and selectorA.  In reality we currenlty get 8 due to internal
   // helper selectors and default fallback atoms.
-  expect(Array.from(snapshot.getNodes_UNSTABLE()).length).toBeGreaterThan(3);
-  const nodes = Array.from(snapshot.getNodes_UNSTABLE());
+  expect(
+    Array.from(snapshot.getNodes_UNSTABLE({isInitialized: true})).length,
+  ).toBeGreaterThan(3);
+  const nodes = Array.from(snapshot.getNodes_UNSTABLE({isInitialized: true}));
   expect(nodes).toEqual(
     expect.arrayContaining([atoms('A'), atoms('B'), selectorA]),
   );
 
   // Test atom A is set
-  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  const aDirty = Array.from(snapshot.getNodes_UNSTABLE({isModified: true}));
   expect(aDirty.length).toEqual(1);
   expect(snapshot.getLoadable(aDirty[0]).contents).toEqual('A');
 
   // Test atom B is set
   act(() => setAtomB('B'));
-  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  const bDirty = Array.from(snapshot.getNodes_UNSTABLE({isModified: true}));
   expect(bDirty.length).toEqual(1);
   expect(snapshot.getLoadable(bDirty[0]).contents).toEqual('B');
 
-  // // Test atoms
-  // const atomNodes = Array.from(snapshot.getNodes_UNSTABLE({types: ['atom']}));
-  // expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
-  //   expect.arrayContaining(['A', 'B']),
-  // );
+  // Test atoms
+  const atomNodes = Array.from(
+    snapshot.getNodes_UNSTABLE({isInitialized: true}),
+  );
+  expect(atomNodes.map(atom => snapshot.getLoadable(atom).contents)).toEqual(
+    expect.arrayContaining(['A', 'B']),
+  );
 
-  // // Test selector
-  // const selectorNodes = Array.from(
-  //   snapshot.getNodes_UNSTABLE({types: ['selector']}),
-  // );
-  // expect(
-  //   selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
-  // ).toEqual(expect.arrayContaining(['A-SELECTOR']));
+  // Test selector
+  const selectorNodes = Array.from(
+    snapshot.getNodes_UNSTABLE({isInitialized: true}),
+  );
+  expect(
+    selectorNodes.map(atom => snapshot.getLoadable(atom).contents),
+  ).toEqual(expect.arrayContaining(['A-SELECTOR']));
 
   // Test Reset
   act(resetAtomA);
-  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({dirty: true}));
+  const resetDirty = Array.from(snapshot.getNodes_UNSTABLE({isModified: true}));
   expect(resetDirty.length).toEqual(1);
   expect(resetDirty[0]).toBe(aDirty[0]);
 

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -245,6 +245,10 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     }
   }
 
+  function myPeek(_store, state: TreeState): ?Loadable<T> {
+    return state.atomValues.get(key) ?? loadableWithValue(options.default);
+  }
+
   function myGet(store: Store, state: TreeState): [DependencyMap, Loadable<T>] {
     initAtom(store, state, 'get');
 
@@ -318,6 +322,10 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
 
   const node = registerNode({
     key,
+    peek: myPeek,
+    get: myGet,
+    set: mySet,
+    invalidate,
     dangerouslyAllowMutability: options.dangerouslyAllowMutability,
     persistence_UNSTABLE: options.persistence_UNSTABLE
       ? {
@@ -325,9 +333,6 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
           backButton: options.persistence_UNSTABLE.backButton,
         }
       : undefined,
-    get: myGet,
-    invalidate,
-    set: mySet,
     shouldRestoreFromSnapshots: true,
   });
   return node;


### PR DESCRIPTION
Summary:
Add a `peekStatus_UNSTABLE()` method to `Snapshot` to "peek" the current status of a node.  It returns a structure with the following:

```
function peekStatus_UNSTABLE(RecoilValue): {
    loadable: ?Loadable<T>,
    isInitialized: boolean,
    isSet: boolean,
    isModified: boolean,
    type: 'atom' | 'selector' | void,
    deps: Iterable<RecoilValue<mixed>>,
    subscribers: {
      nodes: Iterable<RecoilValue<mixed>>,
    },
}
```

This API could replace both `getDeps()` and `getSubscribers()` if we decide we prefer this approach.

There is a semantic difference that this only "peeks" the state and will not evaluate selectors that have not already been evaluated or change the snapshot in any way, unlike the current `getDeps()`.  Based on needs for dev tools we can decide if we prefer this or change it to `getStatus()` and hopefully remove the other...

Differential Revision: D22204282

