### PR TITLE
Separate context for mutable source

### DIFF
--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -15,7 +15,7 @@ import type {MutableSnapshot} from '../core/Recoil_Snapshot';
 import type {Store, StoreRef, StoreState} from '../core/Recoil_State';
 
 const React = require('React');
-const {useContext, useEffect, useRef, useState} = require('React');
+const {useContext, useEffect, useMemo, useRef, useState} = require('React');
 // @fb-only: const RecoilUsageLogFalcoEvent = require('RecoilUsageLogFalcoEvent');
 // @fb-only: const URI = require('URI');
 
@@ -60,7 +60,6 @@ const defaultStore: Store = Object.freeze({
   getGraph: notInAContext,
   subscribeToTransactions: notInAContext,
   addTransactionMetadata: notInAContext,
-  mutableSource: null,
 });
 
 function startNextTreeIfNeeded(storeState: StoreState): void {
@@ -83,6 +82,9 @@ function startNextTreeIfNeeded(storeState: StoreState): void {
 
 const AppContext = React.createContext<StoreRef>({current: defaultStore});
 const useStoreRef = (): StoreRef => useContext(AppContext);
+
+const MutableSourceContext = React.createContext<mixed>(null); // TODO T2710559282599660
+const useRecoilMutableSource = (): mixed => useContext(MutableSourceContext);
 
 function sendEndOfBatchNotifications(store: Store) {
   const storeState = store.getState();
@@ -338,12 +340,6 @@ function RecoilRoot({
     getGraph,
     subscribeToTransactions,
     addTransactionMetadata,
-    mutableSource: createMutableSource
-      ? createMutableSource(
-          storeState,
-          () => storeState.current.currentTree.version,
-        )
-      : null,
   };
   const storeRef = useRef(store);
   storeState = useRef(
@@ -354,16 +350,30 @@ function RecoilRoot({
       : makeEmptyStoreState(),
   );
 
+  const mutableSource = useMemo(
+    () =>
+      createMutableSource
+        ? createMutableSource(
+            storeState,
+            () => storeState.current.currentTree.version,
+          )
+        : null,
+    [createMutableSource, storeState],
+  );
+
   return (
     <AppContext.Provider value={storeRef}>
-      <Batcher setNotifyBatcherOfChange={setNotifyBatcherOfChange} />
-      {children}
+      <MutableSourceContext.Provider value={mutableSource}>
+        <Batcher setNotifyBatcherOfChange={setNotifyBatcherOfChange} />
+        {children}
+      </MutableSourceContext.Provider>
     </AppContext.Provider>
   );
 }
 
 module.exports = {
   useStoreRef,
+  useRecoilMutableSource,
   RecoilRoot,
   sendEndOfBatchNotifications_FOR_TESTING: sendEndOfBatchNotifications,
 };

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -74,7 +74,6 @@ class Snapshot {
       addTransactionMetadata: () => {
         throw new Error('Cannot subscribe to Snapshots');
       },
-      mutableSource: null,
     };
   }
 

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -112,7 +112,6 @@ export type Store = $ReadOnly<{
   getGraph: Version => Graph,
   subscribeToTransactions: ((Store) => void, ?NodeKey) => {release: () => void},
   addTransactionMetadata: ({...}) => void,
-  mutableSource: mixed, // FIXME T2710559282599660
 }>;
 
 export type StoreRef = {

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -22,7 +22,10 @@ const {useCallback, useEffect, useMemo, useRef, useState} = require('React');
 const ReactDOM = require('ReactDOM');
 
 const {DEFAULT_VALUE, getNode, nodes} = require('../core/Recoil_Node');
-const {useStoreRef} = require('../core/Recoil_RecoilRoot.react');
+const {
+  useRecoilMutableSource,
+  useStoreRef,
+} = require('../core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('../core/Recoil_RecoilValue');
 const {
   AbstractRecoilValue,
@@ -283,7 +286,7 @@ function useRecoilValueLoadable_MUTABLESOURCE<T>(
   );
 
   const treeState = useMutableSource(
-    storeRef.current.mutableSource,
+    useRecoilMutableSource(),
     getTreeState,
     subscribe,
   );

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -59,7 +59,6 @@ function makeStore(): Store {
     addTransactionMetadata: () => {
       throw new Error('not implemented');
     },
-    mutableSource: null,
   };
   return store;
 }


### PR DESCRIPTION
Summary:
While bridging contexts to share state across React roots each React root should still maintain its own mutable source.  So, pull that out of `Store` and use a separate context provider.

Also cleans up an inefficiency that each subsequent render of `<RecoilRoot>` would create and ignore another mutable source.

Differential Revision: D23047647

