### PR TITLE
Fix flow file destination & merge command to postscript.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   "license": "MIT",
   "scripts": {
     "prepare": "install-peers",
-    "build:flow": "gen-flow-files src --out-dir cjs && mv cjs/Recoil_index.js.flow cjs/recoil.js.flow",
-    "build": "rollup -c && node scripts/postbuild.js && yarn build:flow",
+    "build": "rollup -c && node scripts/postbuild.js",
     "test": "jest src/*",
     "format": "prettier --write \"./**/*.{js,md,json}\"",
     "flow": "flow --show-all-errors",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "scripts": {
     "prepare": "install-peers",
-    "build:flow": "gen-flow-files src --out-dir lib && mv lib/Recoil_index.js.flow lib/recoil.js.flow",
+    "build:flow": "gen-flow-files src --out-dir cjs && mv cjs/Recoil_index.js.flow cjs/recoil.js.flow",
     "build": "rollup -c && node scripts/postbuild.js && yarn build:flow",
     "test": "jest src/*",
     "format": "prettier --write \"./**/*.{js,md,json}\"",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const {exec} = require('child_process');
 
 function logErrors(err) {
   if (err) {
@@ -6,5 +7,11 @@ function logErrors(err) {
   }
 }
 
-// Copying index.d.ts
+console.log('Copying index.d.ts for Typescript support...');
 fs.copyFile('./typescript/index.d.ts', './index.d.ts', logErrors);
+
+console.log('Generating Flow type files...');
+exec('npx gen-flow-files src --out-dir cjs', err => {
+  logErrors(err);
+  fs.rename('cjs/Recoil_index.js.flow', 'cjs/recoil.js.flow', logErrors);
+});

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -7,7 +7,7 @@ function logErrors(err) {
   }
 }
 
-console.log('Copying index.d.ts for Typescript support...');
+console.log('Copying index.d.ts for TypeScript support...');
 fs.copyFile('./typescript/index.d.ts', './index.d.ts', logErrors);
 
 console.log('Generating Flow type files...');


### PR DESCRIPTION
As we change default CommonJS folder to "cjs", this command needs to be updated.

Also, "build:flow" script is merged into postscript.js to make our build steps a little less messy (I had to use `exec` because `gen-flow-files` does not support callback)