### PR TITLE
Exported GetRecoilValue TS type

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -49,12 +49,12 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
 // selector.d.ts
 export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
 
-type SetRecoilState = <T>(
+export type SetRecoilState = <T>(
     recoilVal: RecoilState<T>,
     newVal: T | DefaultValue | ((prevValue: T) => T | DefaultValue),
 ) => void;
 
-type ResetRecoilState = (recoilVal: RecoilState<any>) => void;
+export type ResetRecoilState = (recoilVal: RecoilState<any>) => void;
 
 export interface ReadOnlySelectorOptions<T> {
     key: string;

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -47,7 +47,7 @@ export interface AtomOptions<T> {
 export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
 
 // selector.d.ts
-type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
+export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
 
 type SetRecoilState = <T>(
     recoilVal: RecoilState<T>,


### PR DESCRIPTION
When we write recoil `selectors` we supply a function to the `get` option.
That pure function may be extracted and covered with unit tests.

I'd like to suggest exporting `GetRecoilValue` type as it can be re-used if we extract `get` selector function.
e.g.:
```ts
export function someSelector({ get }: {get: GetRecoilValue}): SomeSelectorState { // to be tested
  /* Calc derived state 

  return { /* calculated derived state */ };
}
export const someRecoilSelector = selector<SomeSelectorState>({
  key: 'someSelector',
  get: scrollStatisticsSelector,
});
```

Or we can also define the actual standalone type for the [`opts` argument of the `get`](https://github.com/facebookexperimental/Recoil/blob/master/typescript/index.d.ts#L61)

```ts
export interface ReadOnlySelectorOptions<T> {
    key: string;
    get: (opts: RecoilValueGetterOptions) => Promise<T> | RecoilValue<T> | T;
    dangerouslyAllowMutability?: boolean;
}
```