### PR TITLE
Fix Graph import for OSS build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 0.0.11 (2020-09-02)
+
+- Experimental React Concurrent Mode Support
+- Performance
+- Flow Types
+- ES, CommonJS, and UMD packages
+- Synchronization Across React Roots
+- Preliminary Developer Tools API
+- Test Infrastructure Fixes
+
 ## 0.0.10 (2020-06-18)
 
 ### Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Recoil - A state management library for React",
   "main": "cjs/recoil.js",
   "module": "es/recoil.js",

--- a/src/core/Recoil_Dependencies.js
+++ b/src/core/Recoil_Dependencies.js
@@ -8,10 +8,9 @@
  * @flow strict
  * @format
  */
-
 'use strict';
 
-import type Graph from 'Recoil_Graph';
+import type {Graph} from 'Recoil_Graph';
 import type {NodeKey, Version} from './Recoil_Keys';
 import type {Store} from './Recoil_State';
 

--- a/src/core/Recoil_Graph.js
+++ b/src/core/Recoil_Graph.js
@@ -8,7 +8,6 @@
  * @flow strict
  * @format
  */
-
 'use strict';
 
 import type {NodeKey} from './Recoil_Keys';
@@ -144,4 +143,4 @@ class Graph {
   }
 }
 
-module.exports = Graph;
+module.exports = {Graph};

--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -27,7 +27,7 @@ const {
   setNodeValue,
   setUnvalidatedAtomValue,
 } = require('../core/Recoil_FunctionalCore');
-const Graph = require('../core/Recoil_Graph');
+const {Graph} = require('../core/Recoil_Graph');
 const {applyAtomValueWrites} = require('../core/Recoil_RecoilValueInterface');
 const {freshSnapshot} = require('../core/Recoil_Snapshot');
 const {

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -29,7 +29,7 @@ const {
   getDownstreamNodes,
   peekNodeLoadable,
 } = require('./Recoil_FunctionalCore');
-const Graph = require('./Recoil_Graph');
+const {Graph} = require('./Recoil_Graph');
 const {DEFAULT_VALUE, recoilValues} = require('./Recoil_Node');
 const {
   getRecoilValueAsLoadable,

--- a/src/core/Recoil_State.js
+++ b/src/core/Recoil_State.js
@@ -14,7 +14,7 @@ import type {Loadable} from '../adt/Recoil_Loadable';
 import type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
 export type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
 
-const Graph = require('./Recoil_Graph');
+const {Graph} = require('./Recoil_Graph');
 
 // flowlint-next-line unclear-type:off
 export type AtomValues = Map<NodeKey, Loadable<any>>;

--- a/src/core/__tests__/Recoil_Graph-test.js
+++ b/src/core/__tests__/Recoil_Graph-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const Graph = require('../Recoil_Graph');
+const {Graph} = require('../Recoil_Graph');
 
 test('setGraphNodeParents sets children correctly across versions', () => {
   const g0 = new Graph();

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -18,7 +18,7 @@ const {useEffect} = require('React');
 const ReactDOM = require('ReactDOM');
 const {act} = require('ReactTestUtils');
 
-const Graph = require('../core/Recoil_Graph');
+const {Graph} = require('../core/Recoil_Graph');
 const {
   RecoilRoot,
   sendEndOfBatchNotifications_FOR_TESTING,

--- a/src/util/Recoil_traverseDepGraph.js
+++ b/src/util/Recoil_traverseDepGraph.js
@@ -12,7 +12,7 @@
  */
 'use strict';
 
-import type Graph from '../core/Recoil_Graph';
+import type {Graph} from '../core/Recoil_Graph';
 import type {NodeKey} from '../core/Recoil_State';
 
 type VisitInfo = $ReadOnly<{


### PR DESCRIPTION
Summary: The ES module packaging for the OSS Recoil build wasn't handling default exports properly.  Export the Graph as a named export.

Differential Revision: D23485350

