### PR TITLE
test(getSubscriptions): Fixed warning message for getSubscriptions

### DIFF
--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -155,65 +155,66 @@ test('useRecoilSnapshot - async selectors', async () => {
   expect(snapshots[0].getLoadable(mySelector).contents).toEqual('RESOLVE');
 });
 
-test('getSubscriptions', async () => {
-  const myAtom = atom<string>({
-    key: 'useRecoilSnapshot getSubscriptions atom',
-    default: 'ATOM',
-  });
-  const selectorA = selector({
-    key: 'useRecoilSnapshot getSubscriptions A',
-    get: ({get}) => get(myAtom),
-  });
-  const selectorB = selector({
-    key: 'useRecoilSnapshot getSubscriptions B',
-    get: ({get}) => get(selectorA) + get(myAtom),
-  });
-  const selectorC = selector({
-    key: 'useRecoilSnapshot getSubscriptions C',
-    get: async ({get}) => {
-      const ret = get(selectorA) + get(selectorB);
-      await Promise.resolve();
-      return ret;
-    },
-  });
+test('getSubscriptions', () => {
+  act(async () => {
+    const myAtom = atom({
+      key: 'useRecoilSnapshot getSubscriptions atom',
+      default: 'ATOM',
+    });
+    const selectorA = selector({
+      key: 'useRecoilSnapshot getSubscriptions A',
+      get: ({get}) => get(myAtom),
+    });
+    const selectorB = selector({
+      key: 'useRecoilSnapshot getSubscriptions B',
+      get: ({get}) => get(selectorA) + get(myAtom),
+    });
+    const selectorC = selector({
+      key: 'useRecoilSnapshot getSubscriptions C',
+      get: async ({get}) => {
+        const ret = get(selectorA) + get(selectorB);
+        await Promise.resolve();
+        return ret;
+      },
+    });
 
-  let snapshot = freshSnapshot();
-  function RecoilSnapshot() {
-    snapshot = useRecoilSnapshot();
-    return null;
-  }
-  const c = renderElements(
-    <>
-      <ReadsAtom atom={selectorC} />
-      <RecoilSnapshot />
-    </>,
-  );
-  await flushPromisesAndTimers();
-  await flushPromisesAndTimers();
-  expect(c.textContent).toBe('"ATOMATOMATOM"');
-
-  expect(
-    Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes).length,
-  ).toBe(3);
-  expect(Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes)).toEqual(
-    expect.arrayContaining([selectorA, selectorB, selectorC]),
-  );
-  expect(
-    Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes).length,
-  ).toBe(2);
-  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes)).toEqual(
-    expect.arrayContaining([selectorB, selectorC]),
-  );
-  expect(
-    Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes).length,
-  ).toBe(1);
-  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes)).toEqual(
-    expect.arrayContaining([selectorC]),
-  );
-  expect(
-    Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes).length,
-  ).toBe(0);
-  expect(Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes)).toEqual(
-    expect.arrayContaining([]),
-  );
+    let snapshot = freshSnapshot();
+    function RecoilSnapshot() {
+      snapshot = useRecoilSnapshot();
+      return null;
+    }
+    const c = renderElements(
+      <>
+        <ReadsAtom atom={selectorC} />
+        <RecoilSnapshot />
+      </>,
+    );
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    expect(c.textContent).toBe('"ATOMATOMATOM"');
+    expect(
+      Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes).length,
+    ).toBe(3);
+    expect(Array.from(snapshot.getSubscribers_UNSTABLE(myAtom).nodes)).toEqual(
+      expect.arrayContaining([selectorA, selectorB, selectorC]),
+    );
+    expect(
+      Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes).length,
+    ).toBe(2);
+    expect(
+      Array.from(snapshot.getSubscribers_UNSTABLE(selectorA).nodes),
+    ).toEqual(expect.arrayContaining([selectorB, selectorC]));
+    expect(
+      Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes).length,
+    ).toBe(1);
+    expect(
+      Array.from(snapshot.getSubscribers_UNSTABLE(selectorB).nodes),
+    ).toEqual(expect.arrayContaining([selectorC]));
+    expect(
+      Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes).length,
+    ).toBe(0);
+    expect(
+      Array.from(snapshot.getSubscribers_UNSTABLE(selectorC).nodes),
+    ).toEqual(expect.arrayContaining([]));
+  });
 });


### PR DESCRIPTION
I saw this warning in the tests so I've fixed it.
```console.error
      Warning: An update to Batcher inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
          in Batcher (created by RecoilRoot)
          in RecoilRoot```
