### PR TITLE
Fix TypeScript types: Couldn't pass ReadonlyArray as SerializableParam.

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -205,7 +205,7 @@ export function isRecoilValue(val: unknown): val is RecoilValue<any>; // eslint-
 // bigint not supported yet
 type Primitive = undefined | null | boolean | number | symbol | string;
 
-export type SerializableParam = Primitive | SerializableParam[] | { [key: string]: SerializableParam };
+export type SerializableParam = Primitive | ReadonlyArray<SerializableParam> | { [key: string]: SerializableParam };
 
 export interface AtomFamilyOptions<T, P extends SerializableParam> {
   key: NodeKey;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -267,6 +267,14 @@ isRecoilValue(mySelector1);
   });
 
   useRecoilState(mySelectorFamWritable(3))[0]; // $ExpectType number
+
+  const mySelectorFamArray = selectorFamily({
+    key: 'myAtomFam1',
+    get: (param: ReadonlyArray<number>) => ({ get }) => {
+      return [...param, 9];
+    },
+  });
+  mySelectorFamArray([1, 2, 3]);
 }
 
 /**


### PR DESCRIPTION
Previously, we cannot pass ReadonlyArray as a second type argument of `selectorFamily`:

```typescript
const sel = selectorFamily<bool, ReadonlyArray<number>>(  //...
```

After fix, the code above is going to be valid and we can still pass a normal `Array` as the type argument.

------

I confirm `yarn test:typescript` passed

```typescript
$ yarn test:typescript
yarn run v1.22.5
$ dtslint typescript
✨  Done in 5.65s.
yarn test:typescript  8.75s user 0.46s system 153% cpu 6.015 total
```