### PR TITLE
[tests] More robust fix for DOM updates during flushes for tests.

### DIFF
--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -190,7 +190,7 @@ test('getSubscriptions', async () => {
   );
 
   // Wrap flush with act() to avoid warning that only shows up in OSS environment
-  await act(flushPromisesAndTimers);
+  await flushPromisesAndTimers();
 
   expect(c.textContent).toBe('"ATOMATOMATOM"');
 

--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -189,7 +189,6 @@ test('getSubscriptions', async () => {
     </>,
   );
 
-  // Wrap flush with act() to avoid warning that only shows up in OSS environment
   await flushPromisesAndTimers();
 
   expect(c.textContent).toBe('"ATOMATOMATOM"');

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -779,7 +779,7 @@ describe('Async selector resolution notifies all stores that read pending', () =
     });
     const selectorA = selector({
       key: 'notifiesAllStores/twoRoots/a',
-      get: () => 'foo',
+      get: () => 'SELECTOR A',
     });
     let resolve = _ => {
       throw new Error('error in test');
@@ -792,34 +792,48 @@ describe('Async selector resolution notifies all stores that read pending', () =
         }),
     });
 
-    const switches = [];
-
-    function TestComponent() {
+    function TestComponent({
+      setSwitch,
+    }: {
+      setSwitch: ((boolean) => void) => void,
+    }) {
       const [shouldQuery, setShouldQuery] = useRecoilState(switchAtom);
       const query = useRecoilValueLoadable(shouldQuery ? selectorB : selectorA);
-      switches.push(setShouldQuery);
+      setSwitch(setShouldQuery);
       return query.state === 'hasValue' ? query.contents : 'loading';
     }
 
-    const rootA = renderElements(<TestComponent />);
-    const rootB = renderElements(<TestComponent />);
+    let setRootASelector;
+    const rootA = renderElements(
+      <TestComponent
+        setSwitch={setSelector => {
+          setRootASelector = setSelector;
+        }}
+      />,
+    );
+    let setRootBSelector;
+    const rootB = renderElements(
+      <TestComponent
+        setSwitch={setSelector => {
+          setRootBSelector = setSelector;
+        }}
+      />,
+    );
 
-    expect(rootA.textContent).toEqual('foo');
-    expect(rootB.textContent).toEqual('foo');
+    expect(rootA.textContent).toEqual('SELECTOR A');
+    expect(rootB.textContent).toEqual('SELECTOR A');
 
-    expect(switches.length).toEqual(2);
-
-    act(() => switches[0](true)); // cause rootA to read the selector
+    act(() => setRootASelector(true)); // cause rootA to read the selector
     expect(rootA.textContent).toEqual('loading');
-    expect(rootB.textContent).toEqual('foo');
+    expect(rootB.textContent).toEqual('SELECTOR A');
 
-    act(() => switches[1](true)); // cause rootB to read the selector
+    act(() => setRootBSelector(true)); // cause rootB to read the selector
     expect(rootA.textContent).toEqual('loading');
     expect(rootB.textContent).toEqual('loading');
 
-    act(() => resolve('bar'));
+    act(() => resolve('SELECTOR B'));
     await flushPromisesAndTimers();
-    expect(rootA.textContent).toEqual('bar');
-    expect(rootB.textContent).toEqual('bar');
+    expect(rootA.textContent).toEqual('SELECTOR B');
+    expect(rootB.textContent).toEqual('SELECTOR B');
   });
 });

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -199,7 +199,8 @@ function componentThatReadsAndWritesAtom<T>(
   return [Component, (value: T) => setValue(value), () => resetValue()];
 }
 
-function flushPromisesAndTimers(): Promise<mixed> {
+function flushPromisesAndTimers(): Promise<void> {
+  // Wrap flush with act() to avoid warning that only shows up in OSS environment
   return act(
     () =>
       new Promise(resolve => {

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -200,11 +200,14 @@ function componentThatReadsAndWritesAtom<T>(
 }
 
 function flushPromisesAndTimers(): Promise<mixed> {
-  return new Promise(resolve => {
-    // eslint-disable-next-line no-restricted-globals
-    setTimeout(resolve, 100);
-    act(() => jest.runAllTimers());
-  });
+  return act(
+    () =>
+      new Promise(resolve => {
+        // eslint-disable-next-line no-restricted-globals
+        setTimeout(resolve, 100);
+        jest.runAllTimers();
+      }),
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
If there are updates during a flush which affect the React DOM then they need to be wrapped in an `act()` call during Jest tests.  This often only impacts testing with the OSS package and not WWW.  Instead of discovering later that this is an issue just always call `act()` from within all `flushPromisesAndTimers()` calls.

This PR also contains a second diff for fixing a selector jest unit test for OSS environment which uses production React and has a different number of initial renders.