### PR TITLE
Remove disableRecoilValueMutableSource

### DIFF
--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -357,7 +357,7 @@ const useMutableSource =
   just undefined if not available for any reason, such as pending or error.
 */
 function useRecoilValueLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
-  if (useMutableSource && !window.disableRecoilValueMutableSource) {
+  if (useMutableSource) {
     // eslint-disable-next-line fb-www/react-hooks
     return useRecoilValueLoadable_MUTABLESOURCE(recoilValue);
   } else {


### PR DESCRIPTION
Fixes #578

The `disableRecoilValueMutableSource` has been added in #298 for testing but forgot to remove after it be merged.