### PR TITLE
Cleanup Handlers for Atom Effects

### DIFF
--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -92,6 +92,11 @@ function setNodeValue<T>(
   return node.set(store, state, newValue);
 }
 
+function cleanupNode(store: Store, key: NodeKey) {
+  const node = getNode(key);
+  node.cleanup(store);
+}
+
 // Find all of the recursively dependent nodes
 function getDownstreamNodes(
   store: Store,
@@ -119,5 +124,6 @@ module.exports = {
   peekNodeLoadable,
   setNodeValue,
   setUnvalidatedAtomValue,
+  cleanupNode,
   getDownstreamNodes,
 };

--- a/src/core/Recoil_Node.js
+++ b/src/core/Recoil_Node.js
@@ -45,6 +45,9 @@ export type ReadOnlyNodeOptions<T> = $ReadOnly<{
   // Returns the discovered deps and the loadable value of the node
   get: (Store, TreeState) => [DependencyMap, Loadable<T>],
 
+  // Cleanup the node when it is removed from a <RecoilRoot>
+  cleanup: Store => void,
+
   // Informs the node to invalidate any caches it has within its own closure,
   // in cases other than when `set` is called (when this will not be)
   invalidate?: () => void,

--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -22,6 +22,7 @@ const {useContext, useEffect, useMemo, useRef, useState} = require('React');
 
 const Queue = require('../adt/Recoil_Queue');
 const {
+  cleanupNode,
   getDownstreamNodes,
   setNodeValue,
   setUnvalidatedAtomValue,
@@ -386,6 +387,16 @@ function RecoilRoot({
           )
         : null,
     [createMutableSource, storeState],
+  );
+
+  // Cleanup when the <RecoilRoot> is unmounted
+  useEffect(
+    () => () => {
+      for (const atomKey of storeRef.current.getState().knownAtoms) {
+        cleanupNode(storeRef.current, atomKey);
+      }
+    },
+    [],
   );
 
   return (

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -120,7 +120,7 @@ export type AtomEffect<T> = ({
   onSet: (
     (newValue: T | DefaultValue, oldValue: T | DefaultValue) => void,
   ) => void,
-}) => void; // TODO Allow returning a cleanup function
+}) => void | (() => void);
 
 export type AtomOptions<T> = $ReadOnly<{
   key: NodeKey,
@@ -157,6 +157,10 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
   let cachedAnswerForUnvalidatedValue:
     | void
     | [DependencyMap, Loadable<T>] = undefined;
+
+  // Cleanup handlers for this atom
+  // Rely on stable reference equality of the store to use it as a key per <RecoilRoot>
+  const cleanupEffects: Map<Store, () => void> = new Map();
 
   function wrapPendingPromise(
     store: Store,
@@ -235,6 +239,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
 
       function onSet(handler: (T | DefaultValue, T | DefaultValue) => void) {
         store.subscribeToTransactions(currentStore => {
+          // eslint-disable-next-line prefer-const
           let {currentTree, previousTree} = currentStore.getState();
           if (!previousTree) {
             recoverableViolation(
@@ -259,7 +264,10 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       }
 
       for (const effect of options.effects_UNSTABLE ?? []) {
-        effect({node, trigger, setSelf, resetSelf, onSet});
+        const cleanup = effect({node, trigger, setSelf, resetSelf, onSet});
+        if (cleanup != null) {
+          cleanupEffects.set(store, cleanup);
+        }
       }
 
       duringInit = false;
@@ -323,6 +331,11 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     }
   }
 
+  function myCleanup(store: Store) {
+    cleanupEffects.get(store)?.();
+    cleanupEffects.delete(store);
+  }
+
   function invalidate() {
     cachedAnswerForUnvalidatedValue = undefined;
   }
@@ -364,6 +377,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       peek: myPeek,
       get: myGet,
       set: mySet,
+      cleanup: myCleanup,
       invalidate,
       dangerouslyAllowMutability: options.dangerouslyAllowMutability,
       persistence_UNSTABLE: options.persistence_UNSTABLE

--- a/src/recoil_values/Recoil_selector_OLD.js
+++ b/src/recoil_values/Recoil_selector_OLD.js
@@ -492,6 +492,7 @@ function selector<T>(
       peek: myPeek,
       get: myGet,
       set: mySet,
+      cleanup: () => {},
       dangerouslyAllowMutability: options.dangerouslyAllowMutability,
       shouldRestoreFromSnapshots: false,
     });
@@ -500,6 +501,7 @@ function selector<T>(
       key,
       peek: myPeek,
       get: myGet,
+      cleanup: () => {},
       dangerouslyAllowMutability: options.dangerouslyAllowMutability,
       shouldRestoreFromSnapshots: false,
     });


### PR DESCRIPTION
Summary:
Add support for Atom Effects to register cleanup handlers as per [this RFC](https://fb.quip.com/bauvAeBEX5Ee).  These handlers will be called when the dynamic atom goes out of scope.  Currently the atoms only go in or out of scope when they are first used by a `<RecoilRoot>` and then when that `<RecoilRoot>` is unmounted.

This is important for cleaning up subscriptions.

## Atom Effects Interface
```
type AtomEffect<T> = ({
  node: RecoilState<T>,
  trigger: 'get' | 'set',

  // Can call either synchronously to initialize value or async to change it later
  setSelf: (
    | T
    | DefaultValue
    | Promise<T | DefaultValue>
    | (T | DefaultValue => T | DefaultValue)
  ) => void,
  resetSelf: () => void,

  // Subscribe to events
  // Called when React batch ends, but before global RecoilTransactionObserver
  onSet: (
    (newValue: T | DefaultValue, oldValue: T | DefaultValue) => void,
  ) => void,
}) => void | () => void; // Return optional cleanup handler
```

## Example
```
const myAtom = atom({
  key: 'MyAtom',
  default: undefined,

  effects: [({node, setSelf, onSet}) => {
    const storage = getStorage(node.key);

    // set a value for synchronous init that overrides default
    setSelf(storage.get());

    // Subscribe to storage updates
    storage.subscribe(value => setSelf(value));

    // Subscribe local changes to write-through to storage
    onSet(value =>
      value instanceof DefaultValue
        ? storage.reset()
        : storage.set(value)
    );

    // Cleanup subscription
    return () => storage.unsubscribe();
  }],
});
```

Differential Revision: D23723600

