### PR TITLE
fix: add check for window  to shouldNotBeFrozen function

### DIFF
--- a/src/util/Recoil_deepFreezeValue.js
+++ b/src/util/Recoil_deepFreezeValue.js
@@ -56,7 +56,7 @@ function shouldNotBeFrozen(value: mixed): boolean {
     return true;
   }
 
-  if (!!value && value === value.window) {
+  if (typeof window !== 'undefined' && value instanceof window) {
     return true;
   }
 

--- a/src/util/Recoil_deepFreezeValue.js
+++ b/src/util/Recoil_deepFreezeValue.js
@@ -56,6 +56,10 @@ function shouldNotBeFrozen(value: mixed): boolean {
     return true;
   }
 
+  if (!!value && value === value.window) {
+    return true;
+  }
+
   return false;
 }
 

--- a/src/util/__tests__/Recoil_deepFreezeValue-test.js
+++ b/src/util/__tests__/Recoil_deepFreezeValue-test.js
@@ -28,5 +28,8 @@ describe('deepFreezeValue', () => {
       deepFreezeValue({test: new DataView(new ArrayBuffer(16), 0)}),
     ).not.toThrow();
   });
+  test('check no error: object with Window property', () => {
+    expect(() => deepFreezeValue({test: window})).not.toThrow();
+  });
   // TODO add test of other pattern
 });

--- a/src/util/__tests__/Recoil_deepFreezeValue-test.js
+++ b/src/util/__tests__/Recoil_deepFreezeValue-test.js
@@ -29,6 +29,9 @@ describe('deepFreezeValue', () => {
     ).not.toThrow();
   });
   test('check no error: object with Window property', () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
     expect(() => deepFreezeValue({test: window})).not.toThrow();
   });
   // TODO add test of other pattern


### PR DESCRIPTION
Recoil version is 0.0.13.

## Steps To Reproduce
Run below code and click "Window"  button, then error will be thrown.
https://codesandbox.io/s/weathered-dawn-5xfhh?file=/src/App.js
```
const testState = atom({
  key: "test",
  default: null
});

const Inner = () => {
  const [test, setTest] = useRecoilState(testState);
  return (
    <div>
      value: {test && test.hoge}
      <button
        onClick={() => {
          setTest({ hoge: "fuga" });
        }}
      >
        String
      </button>
      <button
        onClick={() => {
          setTest({
            hoge: window
          });
        }}
      >
        Window
      </button>
    </div>
  );
};

export default function App() {
  return (
    <RecoilRoot>
      <div className="App">
        <Inner />
      </div>
    </RecoilRoot>
  );
}
```
error detail is below.

```
TypeError
Cannot freeze
deepFreezeValue
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:1675:10
deepFreezeValue
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:1680:9
Object.mySet [as set]
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:2143:9
setNodeValue
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:375:15
eval
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:580:30
Object.replaceState
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:1070:18
eval
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:578:60
Object.trace
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:515:10
setRecoilValue
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:578:18
eval
https://8r9gf.csb.app/node_modules/recoil/es/recoil.js:1360:5
onClick
/src/App.js:24:10
```

## Description
This error seems to relate to below line.
https://github.com/facebookexperimental/Recoil/blob/d6aca30332dcf46eaf64b417c3b4715a1678cbb4/src/util/Recoil_deepFreezeValue.js#L70

Object.freeze cannot freeze Window.
So, this PR add a check for Window to the shouldNotBeFrozen function.
(It may be rare to code like above, but the object created by a library I used in my app had the above problem, so I create a PR)