### PR TITLE
[Docs] Fix mis-located inner links in persistence/asynchronous-state-sync

### DIFF
--- a/docs/docs/guides/asynchronous-state-sync.md
+++ b/docs/docs/guides/asynchronous-state-sync.md
@@ -9,7 +9,7 @@ sidebar_label: Asynchronous State Sync
 
 ----
 
-Recoil [atoms](/docs/api-reference/core/atom) represent local application state.  Your application may have remote or server-side state as well, such as via a RESTful API.  Consider synchronizing the remote state with Recoil atoms.  Doing this allows you to easily access or write to the  state from React components using the `useRecoilState()` hook, or use that state as input to the Recoil data-flow graph for other derived state selectors.  If you're looking to [query a database or server for read-only data](asynchronous-data-queries), consider using asynchronous selectors.
+Recoil [atoms](/docs/api-reference/core/atom) represent local application state.  Your application may have remote or server-side state as well, such as via a RESTful API.  Consider synchronizing the remote state with Recoil atoms.  Doing this allows you to easily access or write to the  state from React components using the `useRecoilState()` hook, or use that state as input to the Recoil data-flow graph for other derived state selectors.  If you're looking to [query a database or server for read-only data](/docs/guides/asynchronous-data-queries), consider using asynchronous selectors.
 
 ## Local State Example
 
@@ -56,7 +56,7 @@ function MyApp() {
 }
 ```
 
-If you want to handle synchronization of multiple atoms in a single place, you can also use the [State Persistence](persistence) pattern.
+If you want to handle synchronization of multiple atoms in a single place, you can also use the [State Persistence](/docs/guides/persistence) pattern.
 
 ## Bi-Directional Synching
 

--- a/docs/docs/guides/persistence.md
+++ b/docs/docs/guides/persistence.md
@@ -13,7 +13,7 @@ Recoil allows you to persist application state using atoms.
 
 ## Saving State
 
-To save state, subscribe to atom changes and record the new state.  You could use React effects to subscribe to individual atoms (*See [Asynchronous State Sync](asynchronous-state-sync)*).  However, Recoil provides a hook to allow you to subscribe to state changes for all atoms using [**`useRecoilTransactionObserver_UNSTABLE()`**](/docs/api-reference/core/useRecoilTransactionObserver).
+To save state, subscribe to atom changes and record the new state.  You could use React effects to subscribe to individual atoms (*See [Asynchronous State Sync](/docs/guides/asynchronous-state-sync)*).  However, Recoil provides a hook to allow you to subscribe to state changes for all atoms using [**`useRecoilTransactionObserver_UNSTABLE()`**](/docs/api-reference/core/useRecoilTransactionObserver).
 
 The subscription callback provides all of the atom state and tells you which atoms changed.  From this you can save the changes with the storage and serialization of your preference.  Here is an example of a basic implementation using JSON:
 


### PR DESCRIPTION
fix to navigate right (before: [Page Not Found](https://recoiljs.org/docs/guides/persistence/asynchronous-state-sync))