### PR TITLE
Replace `fregante/setup-git-token` with `setup-git-user`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,9 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     # config GIT so it can do git push
-    - uses: fregante/setup-git-token@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
In the v2 of `actions/checkout`, setting the token is no longer necessary, so I created a new config-less action to just set the git user: https://github.com/fregante/setup-git-user