### PR TITLE
Atom Effect onSet() ignores setSelf() from same effect

### DIFF
--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -224,11 +224,20 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     }
 
     // Run Atom Effects
+
+    // This state is scoped by Store, since this is in the initAtom() closure
     let initValue: NewValue<T> = DEFAULT_VALUE;
+    let pendingSetSelf: ?{
+      effect: AtomEffect<T>,
+      value: T | DefaultValue,
+    } = null;
+
     if (options.effects_UNSTABLE != null) {
       let duringInit = true;
 
-      function setSelf(valueOrUpdater: NewValueOrUpdater<T>) {
+      const setSelf = (effect: AtomEffect<T>) => (
+        valueOrUpdater: NewValueOrUpdater<T>,
+      ) => {
         if (duringInit) {
           const currentValue: T | DefaultValue =
             initValue instanceof DefaultValue || isPromise(initValue)
@@ -238,9 +247,8 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
               : initValue;
           initValue =
             typeof valueOrUpdater === 'function'
-              ? // cast to any because we can't restrict type from being a function itself without losing support for opaque types
-                // flowlint-next-line unclear-type:off
-                (valueOrUpdater: any)(currentValue)
+              ? // cast to any because we can't restrict T from being a function without losing support for opaque types
+                (valueOrUpdater: any)(currentValue) // flowlint-line unclear-type:off
               : valueOrUpdater;
         } else {
           if (isPromise(valueOrUpdater)) {
@@ -248,12 +256,31 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
               'Setting atoms to async values is not implemented.',
             );
           }
-          setRecoilValue(store, node, valueOrUpdater);
-        }
-      }
-      const resetSelf = () => setSelf(DEFAULT_VALUE);
 
-      function onSet(handler: (T | DefaultValue, T | DefaultValue) => void) {
+          if (typeof valueOrUpdater !== 'function') {
+            pendingSetSelf = {effect, value: valueOrUpdater};
+          }
+
+          setRecoilValue(
+            store,
+            node,
+            typeof valueOrUpdater === 'function'
+              ? currentValue => {
+                  const newValue =
+                    // cast to any because we can't restrict T from being a function without losing support for opaque types
+                    (valueOrUpdater: any)(currentValue); // flowlint-line unclear-type:off
+                  pendingSetSelf = {effect, value: newValue};
+                  return newValue;
+                }
+              : valueOrUpdater,
+          );
+        }
+      };
+      const resetSelf = effect => () => setSelf(effect)(DEFAULT_VALUE);
+
+      const onSet = effect => (
+        handler: (T | DefaultValue, T | DefaultValue) => void,
+      ) => {
         store.subscribeToTransactions(currentStore => {
           // eslint-disable-next-line prefer-const
           let {currentTree, previousTree} = currentStore.getState();
@@ -274,13 +301,34 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
               oldLoadable.state === 'hasValue'
                 ? oldLoadable.contents
                 : DEFAULT_VALUE; // TODO This isn't actually valid, use as a placeholder for now.
-            handler(newValue, oldValue);
+
+            // Ignore atom value changes that were set via setSelf() in the same effect.
+            // We will still properly call the handler if there was a subsequent
+            // set which was batched with the `setSelf()` call.  However, we may
+            // incorrectly ignore the handler if the subsequent batched call
+            // happens to set the atom to the exact same value as the `setSelf()`
+            // But, in that case, it was kind of a noop, so the semantics are debatable..
+            if (
+              pendingSetSelf?.effect !== effect ||
+              pendingSetSelf?.value !== newValue
+            ) {
+              handler(newValue, oldValue);
+            }
+          }
+          if (pendingSetSelf?.effect === effect) {
+            pendingSetSelf = null;
           }
         }, key);
-      }
+      };
 
       for (const effect of options.effects_UNSTABLE ?? []) {
-        const cleanup = effect({node, trigger, setSelf, resetSelf, onSet});
+        const cleanup = effect({
+          node,
+          trigger,
+          setSelf: setSelf(effect),
+          resetSelf: resetSelf(effect),
+          onSet: onSet(effect),
+        });
         if (cleanup != null) {
           cleanupEffectsByStore.set(store, cleanup);
         }

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -655,14 +655,8 @@ describe('Effects', () => {
     const history: Array<() => void> = []; // Array of undo functions
 
     function historyEffect({setSelf, onSet}) {
-      let ignore = false;
       onSet((_, oldValue) => {
-        if (ignore) {
-          ignore = false;
-          return;
-        }
         history.push(() => {
-          ignore = true;
           setSelf(oldValue);
         });
       });


### PR DESCRIPTION
Summary:
Update `onSet()` subscriptions in an Atom Effect to ignore state changes due to a `setSelf()` from the same effect.

This is important to avoid feedback loops.  For example, if implementing a write-through read/write cache you don't want changes from the backing store that update the atom to also trigger `onSet()` subscriptions to then update the backing store.

This is generally the behaviour you want, so hopefully is reasonable to be the default and avoid a whole class of bugs with users forgetting to write logic to avoid infinite loops.  If users really do want to update the value and monitor all changes in the future there are a few options to support that such as using multiple effects, wrapping `setSelf()` with a wrapper that also calls the handler passed to `onSet()` (though that would have different timing semantics), or complicating the API by adding an option to `onSet()` to change the behavior.

Regarding the implementation, I was trying to best handle the situation where changes to atom values may be batched.  The general solution may have been to annotate the TreeState with information about the cause of the atom change, which would be updated with subsequent changes to the same atom in the same batch.  However, that would require a lot of plumbing and complicate the code.  The chosen implementation just remembers the latest effect that set the value (per `Store`) and the value it set it to and ignores the subscription for that effect if the value was set to that value by the end of the batch.  This means there is a potential to ignore an `onSet()` subscription if there was a subsequent change to an atom in a batch after the effect's `setSelf()` from something other than an effect, but to the exact same value.

Reviewed By: csantos42

Differential Revision: D24576417

