### PR TITLE
Fix OSS build with non-relative import

### DIFF
--- a/src/caches/Recoil_TreeNodeCache.js
+++ b/src/caches/Recoil_TreeNodeCache.js
@@ -5,7 +5,6 @@
  * @flow strict-local
  * @format
  */
-
 'use strict';
 
 import type {Handlers} from 'Recoil_NodeCache';
@@ -13,7 +12,7 @@ import type {Loadable} from '../adt/Recoil_Loadable';
 import type {NodeKey} from '../core/Recoil_State';
 import type {GetNodeValue, NodeCacheRoute} from './Recoil_NodeCache';
 
-import invariant from '../util/Recoil_invariant';
+const invariant = require('../util/Recoil_invariant');
 
 export type TreeCacheNode<T> = TreeCacheResult<T> | TreeCacheBranch<T>;
 

--- a/src/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/src/core/__tests__/Recoil_RecoilRoot-test.js
@@ -9,7 +9,7 @@
 
 import type {Store} from '../Recoil_State';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   ReactDOM,

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   act,

--- a/src/core/__tests__/Recoil_batcher-test.js
+++ b/src/core/__tests__/Recoil_batcher-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let unstable_batchedUpdates, batchUpdates, getBatcher, setBatcher;
 

--- a/src/core/__tests__/Recoil_core-test.js
+++ b/src/core/__tests__/Recoil_core-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let a, atom, store, nullthrows, getNodeLoadable, setNodeValue;
 

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -41,7 +41,6 @@ const testRecoil = getRecoilTestFn(() => {
   const {makeStore} = require('../../testing/Recoil_TestingUtils');
 
   React = require('React');
-  nullthrows = require('nullthrows');
   ({useEffect, useState} = require('React'));
   ({act} = require('ReactTestUtils'));
   atom = require('../Recoil_atom');
@@ -54,6 +53,7 @@ const testRecoil = getRecoilTestFn(() => {
   } = require('../../hooks/Recoil_Hooks'));
   constSelector = require('../Recoil_constSelector');
   errorSelector = require('../Recoil_errorSelector');
+  nullthrows = require('../../util/Recoil_nullthrows');
   ({
     getRecoilValueAsLoadable,
     setRecoilValue,

--- a/src/util/Recoil_stackTraceParser.js
+++ b/src/util/Recoil_stackTraceParser.js
@@ -46,7 +46,7 @@ const UNKNOWN_FUNCTION = '<unknown>';
  * This parses the different stack traces and puts them into one format
  * This borrows heavily from TraceKit (https://github.com/csnover/TraceKit)
  */
-export default function stackTraceParser(stackString: string): Array<Frame> {
+function stackTraceParser(stackString: string): Array<Frame> {
   const lines = stackString.split('\n');
 
   return lines.reduce((stack, line) => {
@@ -177,3 +177,5 @@ function parseNode(line): ?Frame {
     column: parts[4] ? +parts[4] : null,
   };
 }
+
+module.exports = stackTraceParser;

--- a/src/util/Recoil_useComponentName.js
+++ b/src/util/Recoil_useComponentName.js
@@ -8,15 +8,14 @@
  * @flow strict-local
  * @format
  */
-
 'use strict';
 
-import {useRef} from 'React';
+const {useRef} = require('React');
 
-import gkx from '../util/Recoil_gkx';
-import stackTraceParser from '../util/Recoil_stackTraceParser';
+const gkx = require('../util/Recoil_gkx');
+const stackTraceParser = require('../util/Recoil_stackTraceParser');
 
-export default function useComponentName(): string {
+function useComponentName(): string {
   const nameRef = useRef();
   if (__DEV__) {
     if (gkx('recoil_infer_component_names')) {
@@ -46,3 +45,5 @@ export default function useComponentName(): string {
   // @fb-only: return "<component name only available when both in dev mode and when passing GK 'recoil_infer_component_names'>";
   return "<component name not available>"; // @oss-only
 }
+
+module.exports = useComponentName;


### PR DESCRIPTION
Summary: More non-relative imports have leaked in breaking the OSS build.  We really should have a lint rule for this...

Reviewed By: mondaychen

Differential Revision: D24610316

