### PR TITLE
Revert use of import/export syntax

### DIFF
--- a/src/caches/Recoil_TreeNodeCache.js
+++ b/src/caches/Recoil_TreeNodeCache.js
@@ -5,7 +5,6 @@
  * @flow strict-local
  * @format
  */
-
 'use strict';
 
 import type {Handlers} from 'Recoil_NodeCache';
@@ -13,7 +12,7 @@ import type {Loadable} from '../adt/Recoil_Loadable';
 import type {NodeKey} from '../core/Recoil_State';
 import type {GetNodeValue, NodeCacheRoute} from './Recoil_NodeCache';
 
-import invariant from '../util/Recoil_invariant';
+const invariant = require('../util/Recoil_invariant');
 
 export type TreeCacheNode<T> = TreeCacheResult<T> | TreeCacheBranch<T>;
 

--- a/src/util/Recoil_stackTraceParser.js
+++ b/src/util/Recoil_stackTraceParser.js
@@ -46,7 +46,7 @@ const UNKNOWN_FUNCTION = '<unknown>';
  * This parses the different stack traces and puts them into one format
  * This borrows heavily from TraceKit (https://github.com/csnover/TraceKit)
  */
-export default function stackTraceParser(stackString: string): Array<Frame> {
+function stackTraceParser(stackString: string): Array<Frame> {
   const lines = stackString.split('\n');
 
   return lines.reduce((stack, line) => {
@@ -177,3 +177,5 @@ function parseNode(line): ?Frame {
     column: parts[4] ? +parts[4] : null,
   };
 }
+
+module.exports = stackTraceParser;

--- a/src/util/Recoil_useComponentName.js
+++ b/src/util/Recoil_useComponentName.js
@@ -8,15 +8,14 @@
  * @flow strict-local
  * @format
  */
-
 'use strict';
 
-import {useRef} from 'React';
+const {useRef} = require('React');
 
-import gkx from '../util/Recoil_gkx';
-import stackTraceParser from '../util/Recoil_stackTraceParser';
+const gkx = require('../util/Recoil_gkx');
+const stackTraceParser = require('../util/Recoil_stackTraceParser');
 
-export default function useComponentName(): string {
+function useComponentName(): string {
   const nameRef = useRef();
   if (__DEV__) {
     if (gkx('recoil_infer_component_names')) {
@@ -46,3 +45,5 @@ export default function useComponentName(): string {
   // @fb-only: return "<component name only available when both in dev mode and when passing GK 'recoil_infer_component_names'>";
   return "<component name not available>"; // @oss-only
 }
+
+module.exports = useComponentName;


### PR DESCRIPTION
Summary: Mixing use of `require()` and ES module import/export syntax was working for the internal builds, but breaks the OSS build.  This diff reverts us to consistently use the `require()` syntax until we migrate over completely.

Reviewed By: mondaychen

Differential Revision: D24610024

