### PR TITLE
Disable recoil_async_selector_refactor testing in OSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "description": "Recoil - A state management library for React",
   "main": "cjs/recoil.js",
   "module": "es/recoil.js",

--- a/src/caches/Recoil_TreeNodeCache.js
+++ b/src/caches/Recoil_TreeNodeCache.js
@@ -5,7 +5,6 @@
  * @flow strict-local
  * @format
  */
-
 'use strict';
 
 import type {Handlers} from 'Recoil_NodeCache';
@@ -13,7 +12,7 @@ import type {Loadable} from '../adt/Recoil_Loadable';
 import type {NodeKey} from '../core/Recoil_State';
 import type {GetNodeValue, NodeCacheRoute} from './Recoil_NodeCache';
 
-import invariant from '../util/Recoil_invariant';
+const invariant = require('../util/Recoil_invariant');
 
 export type TreeCacheNode<T> = TreeCacheResult<T> | TreeCacheBranch<T>;
 

--- a/src/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/src/core/__tests__/Recoil_RecoilRoot-test.js
@@ -9,7 +9,7 @@
 
 import type {Store} from '../Recoil_State';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   ReactDOM,

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   act,

--- a/src/core/__tests__/Recoil_batcher-test.js
+++ b/src/core/__tests__/Recoil_batcher-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let unstable_batchedUpdates, batchUpdates, getBatcher, setBatcher;
 

--- a/src/core/__tests__/Recoil_core-test.js
+++ b/src/core/__tests__/Recoil_core-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let a, atom, store, nullthrows, getNodeLoadable, setNodeValue;
 

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -41,7 +41,6 @@ const testRecoil = getRecoilTestFn(() => {
   const {makeStore} = require('../../testing/Recoil_TestingUtils');
 
   React = require('React');
-  nullthrows = require('nullthrows');
   ({useEffect, useState} = require('React'));
   ({act} = require('ReactTestUtils'));
   atom = require('../Recoil_atom');
@@ -54,6 +53,7 @@ const testRecoil = getRecoilTestFn(() => {
   } = require('../../hooks/Recoil_Hooks'));
   constSelector = require('../Recoil_constSelector');
   errorSelector = require('../Recoil_errorSelector');
+  nullthrows = require('../../util/Recoil_nullthrows');
   ({
     getRecoilValueAsLoadable,
     setRecoilValue,

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -221,32 +221,34 @@ function flushPromisesAndTimers(): Promise<void> {
   );
 }
 
-type ReloadImports = (isGkPassing: boolean) => void;
-type AssertionsFn = (isGkPassing: boolean) => ?Promise<mixed>;
+type ReloadImports = () => void;
+type AssertionsFn = () => ?Promise<mixed>;
 type TestFn = (string, AssertionsFn) => void;
 
-const getTestThatTestsFeatureFlag = (
-  featureFlag: string,
-  reloadImports: ReloadImports,
-): TestFn => (testDescription: string, assertionsFn: AssertionsFn) => {
-  test.each([[true], [false]])(
-    `${testDescription} (GK ${featureFlag} set to %p)`,
-    isGkPassing => {
-      jest.resetModules();
+const testGKs = (gks: Array<string>, reloadImports: ReloadImports): TestFn => (
+  testDescription: string,
+  assertionsFn: AssertionsFn,
+) => {
+  const gkx = require('../util/Recoil_gkx');
+  test.each([[''], ...gks.map(gk => [gk])])(`${testDescription} %s`, gk => {
+    jest.resetModules();
 
-      const gkx = require('../util/Recoil_gkx');
-      const setGk = isGkPassing ? gkx.setPass : gkx.setFail;
+    if (gk) {
+      gkx.setPass(gk);
+    }
 
-      setGk(featureFlag);
-      reloadImports(isGkPassing);
+    reloadImports();
+    assertionsFn();
 
-      return assertionsFn(isGkPassing);
-    },
-  );
+    if (gk) {
+      gkx.setFail(gk);
+    }
+  });
 };
 
 const getRecoilTestFn = (reloadImports: ReloadImports): TestFn =>
-  getTestThatTestsFeatureFlag('recoil_async_selector_refactor', reloadImports);
+  // @fb-only: testGKs(['recoil_async_selector_refactor'], reloadImports);
+ testGKs([], reloadImports); // @oss-only
 
 module.exports = {
   makeStore,

--- a/src/util/Recoil_stackTraceParser.js
+++ b/src/util/Recoil_stackTraceParser.js
@@ -46,7 +46,7 @@ const UNKNOWN_FUNCTION = '<unknown>';
  * This parses the different stack traces and puts them into one format
  * This borrows heavily from TraceKit (https://github.com/csnover/TraceKit)
  */
-export default function stackTraceParser(stackString: string): Array<Frame> {
+function stackTraceParser(stackString: string): Array<Frame> {
   const lines = stackString.split('\n');
 
   return lines.reduce((stack, line) => {
@@ -177,3 +177,5 @@ function parseNode(line): ?Frame {
     column: parts[4] ? +parts[4] : null,
   };
 }
+
+module.exports = stackTraceParser;

--- a/src/util/Recoil_useComponentName.js
+++ b/src/util/Recoil_useComponentName.js
@@ -8,15 +8,14 @@
  * @flow strict-local
  * @format
  */
-
 'use strict';
 
-import {useRef} from 'React';
+const {useRef} = require('React');
 
-import gkx from '../util/Recoil_gkx';
-import stackTraceParser from '../util/Recoil_stackTraceParser';
+const gkx = require('../util/Recoil_gkx');
+const stackTraceParser = require('../util/Recoil_stackTraceParser');
 
-export default function useComponentName(): string {
+function useComponentName(): string {
   const nameRef = useRef();
   if (__DEV__) {
     if (gkx('recoil_infer_component_names')) {
@@ -46,3 +45,5 @@ export default function useComponentName(): string {
   // @fb-only: return "<component name only available when both in dev mode and when passing GK 'recoil_infer_component_names'>";
   return "<component name not available>"; // @oss-only
 }
+
+module.exports = useComponentName;


### PR DESCRIPTION
Summary: Tests are failing with the `recoil_async_selector_refactor` GK in OSS.  Disable it for now until we investigate if there is an issue with the GK polyfill or an issue with the new selector in OSS or OSS React environment.

Differential Revision: D24614291

