### PR TITLE
Fix typescript bug for the Loadable interface (#697)

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -222,7 +222,7 @@ interface LoadingLoadable<T> extends BaseLoadable<T> {
 }
 
 interface ErrorLoadable<T> extends BaseLoadable<T> {
-  state: 'error';
+  state: 'hasError';
   contents: Error;
 }
 

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -146,7 +146,7 @@ useRecoilCallback(({ snapshot, set, reset, gotoSnapshot }) => async () => {
   gotoSnapshot(myAtom); // $ExpectError
 
   loadable.contents; // $ExpectType number | LoadablePromise<number> | Error
-  loadable.state; // $ExpectType "hasValue" | "loading" | "error"
+  loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
 
   set(myAtom, 5);
   set(myAtom, 'hello'); // $ExpectError
@@ -169,7 +169,7 @@ useRecoilCallback(({ snapshot, set, reset, gotoSnapshot }) => async () => {
 
       for (const node of Array.from(snapshot.getNodes_UNSTABLE({isModified: true}))) {
         const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
-        loadable.state; // $ExpectType "hasValue" | "loading" | "error"
+        loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
       }
     },
   );


### PR DESCRIPTION
Summary: The error state of Loadable should be "hasError" not "error."