### PR TITLE
Fix TypeScript Loadable export

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -193,11 +193,11 @@ export const RecoilBridge: React.FC;
 export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
 
 // loadable.d.ts
-type ResolvedLoadablePromiseInfo<T> = Readonly<{
-  value: T;
-}>;
-
-export type LoadablePromise<T> = Promise<ResolvedLoadablePromiseInfo<T>>;
+declare const LoadablePromiseValue_OPAQUE: unique symbol;
+interface LoadablePromiseValue {
+  readonly [LoadablePromiseValue_OPAQUE]: true;
+}
+type LoadablePromise<T> = Promise<LoadablePromiseValue>;
 
 interface BaseLoadable<T> {
   getValue: () => T;
@@ -222,11 +222,11 @@ interface LoadingLoadable<T> extends BaseLoadable<T> {
 }
 
 interface ErrorLoadable<T> extends BaseLoadable<T> {
-  state: 'error';
+  state: 'hasError';
   contents: Error;
 }
 
-type Loadable<T> =
+export type Loadable<T> =
   | ValueLoadable<T>
   | LoadingLoadable<T>
   | ErrorLoadable<T>;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -146,7 +146,7 @@ useRecoilCallback(({ snapshot, set, reset, gotoSnapshot }) => async () => {
   gotoSnapshot(myAtom); // $ExpectError
 
   loadable.contents; // $ExpectType number | LoadablePromise<number> | Error
-  loadable.state; // $ExpectType "hasValue" | "loading" | "error"
+  loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
 
   set(myAtom, 5);
   set(myAtom, 'hello'); // $ExpectError
@@ -169,7 +169,7 @@ useRecoilCallback(({ snapshot, set, reset, gotoSnapshot }) => async () => {
 
       for (const node of Array.from(snapshot.getNodes_UNSTABLE({isModified: true}))) {
         const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
-        loadable.state; // $ExpectType "hasValue" | "loading" | "error"
+        loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
       }
     },
   );


### PR DESCRIPTION
Summary: Fix the `Loadable` export for TypeScript, which was broken in D24281676 (https://github.com/facebookexperimental/recoil/commit/0851dc6711d92ad6f4840f794b9ee8a3fe63b1ad).

Reviewed By: csantos42

Differential Revision: D24653590

