### PR TITLE
report subscribing components

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -57,6 +57,7 @@ const {
   useSetUnvalidatedAtomValues,
   useTransactionObservation_DEPRECATED,
 } = require('./hooks/Recoil_Hooks');
+const useGetRecoilValueInfo = require('./hooks/Recoil_useGetRecoilValueInfo');
 const useRecoilBridgeAcrossReactRoots = require('./hooks/Recoil_useRecoilBridgeAcrossReactRoots');
 const atom = require('./recoil_values/Recoil_atom');
 const atomFamily = require('./recoil_values/Recoil_atomFamily');
@@ -98,6 +99,7 @@ module.exports = {
   useRecoilStateLoadable,
   useSetRecoilState,
   useResetRecoilState,
+  useGetRecoilValueInfo_UNSTABLE: useGetRecoilValueInfo,
 
   // Hooks for asynchronous Recoil
   useRecoilCallback,

--- a/src/core/Recoil_FunctionalCore.js
+++ b/src/core/Recoil_FunctionalCore.js
@@ -22,6 +22,7 @@ const {
   setByAddingToSet,
 } = require('../util/Recoil_CopyOnWrite');
 const filterIterable = require('../util/Recoil_filterIterable');
+const mapIterable = require('../util/Recoil_mapIterable');
 const {getNode, getNodeMaybe, recoilValuesForKeys} = require('./Recoil_Node');
 
 // flowlint-next-line unclear-type:off
@@ -103,6 +104,7 @@ export type RecoilValueInfo<T> = {
   deps: Iterable<RecoilValue<mixed>>,
   subscribers: {
     nodes: Iterable<RecoilValue<mixed>>,
+    components: Iterable<string>,
   },
 };
 
@@ -132,6 +134,10 @@ function peekNodeInfo<T>(
     deps: recoilValuesForKeys(graph.nodeDeps.get(key) ?? []),
     subscribers: {
       nodes: recoilValuesForKeys(downstreamNodes),
+      components: mapIterable(
+        storeState.nodeToComponentSubscriptions.get(key)?.values() ?? [],
+        ([name]) => name,
+      ),
     },
   };
 }

--- a/src/core/Recoil_Node.js
+++ b/src/core/Recoil_Node.js
@@ -16,6 +16,8 @@ import type {RecoilValue} from './Recoil_RecoilValue';
 import type {AtomValues, NodeKey, Store, TreeState} from './Recoil_State';
 
 const expectationViolation = require('../util/Recoil_expectationViolation');
+const mapIterable = require('../util/Recoil_mapIterable');
+const nullthrows = require('../util/Recoil_nullthrows');
 const recoverableViolation = require('../util/Recoil_recoverableViolation');
 const RecoilValueClasses = require('./Recoil_RecoilValue');
 
@@ -87,6 +89,12 @@ declare function registerNode<T>(
   node: ReadOnlyNodeOptions<T>,
 ): RecoilValueClasses.RecoilValueReadOnly<T>;
 
+function recoilValuesForKeys(
+  keys: Iterable<NodeKey>,
+): Iterable<RecoilValue<mixed>> {
+  return mapIterable(keys, key => nullthrows(recoilValues.get(key)));
+}
+
 function registerNode<T>(node: Node<T>): RecoilValue<T> {
   if (nodes.has(node.key)) {
     const message = `Duplicate atom key "${node.key}". This is a FATAL ERROR in
@@ -140,6 +148,7 @@ module.exports = {
   registerNode,
   getNode,
   getNodeMaybe,
+  recoilValuesForKeys,
   NodeMissingError,
   DefaultValue,
   DEFAULT_VALUE,

--- a/src/hooks/Recoil_useGetRecoilValueInfo.js
+++ b/src/hooks/Recoil_useGetRecoilValueInfo.js
@@ -1,0 +1,27 @@
+/**
+ * (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {RecoilValueInfo} from '../core/Recoil_FunctionalCore';
+import type {RecoilValue} from '../core/Recoil_RecoilValue';
+
+const {peekNodeInfo} = require('../core/Recoil_FunctionalCore');
+const {useStoreRef} = require('../core/Recoil_RecoilRoot.react');
+
+export default function useGetRecoilValueInfo(): <T>(
+  RecoilValue<T>,
+) => RecoilValueInfo<T> {
+  const storeRef = useStoreRef();
+
+  return <T>({key}): RecoilValueInfo<T> =>
+    peekNodeInfo<T>(
+      storeRef.current,
+      storeRef.current.getState().currentTree,
+      key,
+    );
+}

--- a/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -11,6 +11,7 @@ const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   act,
+  gkx,
   atom,
   selector,
   ReadsAtom,
@@ -23,6 +24,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({act} = require('ReactTestUtils'));
 
   atom = require('../../recoil_values/Recoil_atom');
+  gkx = require('../../util/Recoil_gkx');
   selector = require('../../recoil_values/Recoil_selector');
   ({
     ReadsAtom,
@@ -33,6 +35,9 @@ const testRecoil = getRecoilTestFn(() => {
 });
 
 testRecoil('useGetRecoilValueInfo', () => {
+  const recoil_infer_component_names = gkx('recoil_infer_component_names');
+  gkx.setPass('recoil_infer_component_names');
+
   const myAtom = atom<string>({
     key: 'useGetRecoilValueInfo atom',
     default: 'DEFAULT',
@@ -67,6 +72,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   });
   expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
   expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual([]);
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.components)).toEqual(
+    [],
+  );
   expect(getRecoilValueInfo(selectorA)).toMatchObject({
     loadable: undefined,
     isActive: false,
@@ -78,6 +86,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
     [],
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+  ).toEqual([]);
   expect(getRecoilValueInfo(selectorB)).toMatchObject({
     loadable: undefined,
     isActive: false,
@@ -89,6 +100,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
     [],
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+  ).toEqual([]);
 
   // After reading values
   const [ReadWriteAtom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(
@@ -114,6 +128,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
     expect.arrayContaining([selectorA, selectorB]),
   );
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.components)).toEqual(
+    expect.arrayContaining(['ReadsAndWritesAtom']),
+  );
   expect(getRecoilValueInfo(selectorA)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
     isActive: true,
@@ -127,6 +144,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
     expect.arrayContaining([selectorB]),
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+  ).toEqual([]);
   expect(getRecoilValueInfo(selectorB)).toMatchObject({
     loadable: expect.objectContaining({
       state: 'hasValue',
@@ -143,6 +163,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
     [],
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+  ).toEqual(expect.arrayContaining(['ReadsAtom']));
 
   // After setting a value
   act(() => setAtom('SET'));
@@ -158,6 +181,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
     expect.arrayContaining([selectorA, selectorB]),
   );
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.components)).toEqual(
+    expect.arrayContaining(['ReadsAndWritesAtom']),
+  );
   expect(getRecoilValueInfo(selectorA)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
     isActive: true,
@@ -171,6 +197,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
     expect.arrayContaining([selectorB]),
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+  ).toEqual([]);
   expect(getRecoilValueInfo(selectorB)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'SETSET'}),
     isActive: true,
@@ -184,6 +213,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
     [],
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+  ).toEqual(expect.arrayContaining(['ReadsAtom']));
 
   // After reseting a value
   act(resetAtom);
@@ -199,6 +231,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
     expect.arrayContaining([selectorA, selectorB]),
   );
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.components)).toEqual(
+    expect.arrayContaining(['ReadsAndWritesAtom']),
+  );
   expect(getRecoilValueInfo(selectorA)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
     isActive: true,
@@ -212,6 +247,9 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
     expect.arrayContaining([selectorB]),
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+  ).toEqual([]);
   expect(getRecoilValueInfo(selectorB)).toMatchObject({
     loadable: expect.objectContaining({
       state: 'hasValue',
@@ -228,4 +266,11 @@ testRecoil('useGetRecoilValueInfo', () => {
   expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
     [],
   );
+  expect(
+    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+  ).toEqual(expect.arrayContaining(['ReadsAtom']));
+
+  recoil_infer_component_names
+    ? gkx.setPass('recoil_infer_component_names')
+    : gkx.setFail('recoil_infer_component_names');
 });

--- a/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -1,0 +1,231 @@
+/**
+ * (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+
+let React,
+  act,
+  atom,
+  selector,
+  ReadsAtom,
+  componentThatReadsAndWritesAtom,
+  renderElements,
+  useGetRecoilValueInfo;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('React');
+  ({act} = require('ReactTestUtils'));
+
+  atom = require('../../recoil_values/Recoil_atom');
+  selector = require('../../recoil_values/Recoil_selector');
+  ({
+    ReadsAtom,
+    componentThatReadsAndWritesAtom,
+    renderElements,
+  } = require('../../testing/Recoil_TestingUtils'));
+  useGetRecoilValueInfo = require('../Recoil_useGetRecoilValueInfo');
+});
+
+testRecoil('useGetRecoilValueInfo', () => {
+  const myAtom = atom<string>({
+    key: 'useGetRecoilValueInfo atom',
+    default: 'DEFAULT',
+  });
+  const selectorA = selector({
+    key: 'useGetRecoilValueInfo A',
+    get: ({get}) => get(myAtom),
+  });
+  const selectorB = selector({
+    key: 'useGetRecoilValueInfo B',
+    get: ({get}) => get(selectorA) + get(myAtom),
+  });
+
+  let getRecoilValueInfo = _ => {
+    expect(false).toBe(true);
+    throw new Error('getRecoilValue not set');
+  };
+  function GetRecoilValueInfo() {
+    getRecoilValueInfo = useGetRecoilValueInfo();
+    return null;
+  }
+
+  // Initial status
+  renderElements(<GetRecoilValueInfo />);
+
+  expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isActive: false,
+    isSet: false,
+    isModified: false,
+    type: undefined,
+  });
+  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual([]);
+  expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    loadable: undefined,
+    isActive: false,
+    isSet: false,
+    isModified: false,
+    type: undefined,
+  });
+  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual([]);
+  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+    [],
+  );
+  expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    loadable: undefined,
+    isActive: false,
+    isSet: false,
+    isModified: false,
+    type: undefined,
+  });
+  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual([]);
+  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+    [],
+  );
+
+  // After reading values
+  const [ReadWriteAtom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(
+    myAtom,
+  );
+  const c = renderElements(
+    <>
+      <GetRecoilValueInfo />
+      <ReadWriteAtom />
+      <ReadsAtom atom={selectorB} />
+    </>,
+  );
+  expect(c.textContent).toEqual('"DEFAULT""DEFAULTDEFAULT"');
+
+  expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isActive: true,
+    isSet: false,
+    isModified: false,
+    type: 'atom',
+  });
+  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB]),
+  );
+  expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isActive: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+    expect.arrayContaining([myAtom]),
+  );
+  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorB]),
+  );
+  expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    loadable: expect.objectContaining({
+      state: 'hasValue',
+      contents: 'DEFAULTDEFAULT',
+    }),
+    isActive: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+    expect.arrayContaining([myAtom, selectorA]),
+  );
+  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+    [],
+  );
+
+  // After setting a value
+  act(() => setAtom('SET'));
+
+  expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
+    isActive: true,
+    isSet: true,
+    isModified: true,
+    type: 'atom',
+  });
+  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB]),
+  );
+  expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
+    isActive: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+    expect.arrayContaining([myAtom]),
+  );
+  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorB]),
+  );
+  expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'SETSET'}),
+    isActive: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+    expect.arrayContaining([myAtom, selectorA]),
+  );
+  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+    [],
+  );
+
+  // After reseting a value
+  act(resetAtom);
+
+  expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isActive: true,
+    isSet: false,
+    isModified: true,
+    type: 'atom',
+  });
+  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB]),
+  );
+  expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
+    isActive: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+    expect.arrayContaining([myAtom]),
+  );
+  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorB]),
+  );
+  expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    loadable: expect.objectContaining({
+      state: 'hasValue',
+      contents: 'DEFAULTDEFAULT',
+    }),
+    isActive: true,
+    isSet: false,
+    isModified: false,
+    type: 'selector',
+  });
+  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+    expect.arrayContaining([myAtom, selectorA]),
+  );
+  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+    [],
+  );
+});

--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -1,7 +1,7 @@
 /**
  * (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
  *
- * @emails oncall+obviz
+ * @emails oncall+recoil
  * @flow strict-local
  * @format
  */

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -9,9 +9,10 @@
  * @format
  */
 'use strict';
-import type {RecoilValueReadOnly} from 'Recoil_RecoilValue';
-import type {RecoilState, RecoilValue} from 'Recoil_RecoilValue';
-import type {Store} from 'Recoil_State';
+
+import type {RecoilValueReadOnly} from '../core/Recoil_RecoilValue';
+import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
+import type {Store} from '../core/Recoil_State';
 
 const React = require('React');
 const {useEffect} = require('React');
@@ -202,12 +203,16 @@ function componentThatReadsAndWritesAtom<T>(
 ): [() => React.Node, (T) => void, () => void] {
   let setValue;
   let resetValue;
-  const Component = (): React.Node => {
+  const ReadsAndWritesAtom = (): React.Node => {
     setValue = useSetRecoilState(atom);
     resetValue = useResetRecoilState(atom);
     return stableStringify(useRecoilValue(atom));
   };
-  return [Component, (value: T) => setValue(value), () => resetValue()];
+  return [
+    ReadsAndWritesAtom,
+    (value: T) => setValue(value),
+    () => resetValue(),
+  ];
 }
 
 function flushPromisesAndTimers(): Promise<void> {

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -102,6 +102,7 @@ interface AtomInfo<T> {
   deps: Iterable<RecoilValue<T>>;
   subscribers: {
     nodes: Iterable<RecoilValue<T>>,
+    components: Iterable<string>,
   };
 }
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -93,22 +93,24 @@ export interface SnapshotID {
   readonly [SnapshotID_OPAQUE]: true;
 }
 
+interface AtomInfo<T> {
+  loadable?: Loadable<T>;
+  isActive: boolean;
+  isSet: boolean;
+  isModified: boolean; // TODO report modified selectors
+  type: 'atom' | 'selector' | undefined; // undefined until initialized for now
+  deps: Iterable<RecoilValue<T>>;
+  subscribers: {
+    nodes: Iterable<RecoilValue<T>>,
+  };
+}
+
 export class Snapshot {
   getID(): SnapshotID;
   getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
   getPromise<T>(recoilValue: RecoilValue<T>): Promise<T>;
   getNodes_UNSTABLE(opts?: { isModified?: boolean }): Iterable<RecoilValue<unknown>>;
-  getInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): {
-    loadable?: Loadable<T>,
-    isActive: boolean,
-    isSet: boolean,
-    isModified: boolean, // TODO report modified selectors
-    type: 'atom' | 'selector' | undefined, // undefined until initialized for now
-    deps: Iterable<RecoilValue<T>>,
-    subscribers: {
-      nodes: Iterable<RecoilValue<T>>,
-    },
-  };
+  getInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): AtomInfo<T>;
   map(cb: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
   asyncMap(cb: (mutableSnapshot: MutableSnapshot) => Promise<void>): Promise<Snapshot>;
 }
@@ -166,6 +168,11 @@ export function useSetRecoilState<T>(recoilState: RecoilState<T>): SetterOrUpdat
  * Returns a function that will reset the given state to its default value.
  */
 export function useResetRecoilState(recoilState: RecoilState<any>): Resetter; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+/**
+ * Returns current info about an atom
+ */
+export function useGetRecoilValueInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): AtomInfo<T>;
 
 /**
  * Returns a function that will run the callback that was passed when

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -8,7 +8,8 @@ import {
   selector,
   selectorFamily,
   Snapshot,
-  snapshot_UNSTABLE, useGotoRecoilSnapshot,
+  snapshot_UNSTABLE,
+  useGetRecoilValueInfo_UNSTABLE, useGotoRecoilSnapshot,
   useRecoilBridgeAcrossReactRoots_UNSTABLE, useRecoilCallback,
   useRecoilSnapshot, useRecoilState,
   useRecoilStateLoadable,
@@ -52,13 +53,14 @@ const readOnlySelectorSel = selector({
       get(myAtom) + 10;
       get(mySelector1);
       get(5); // $ExpectError
+      return 5;
   },
 });
 
 const writeableSelector = selector({
   key: 'WriteableSelector',
   get: ({ get }) => {
-    get(mySelector1) + 10;
+    return get(mySelector1) + 10;
   },
   set: ({ get, set, reset }) => {
     get(myAtom);
@@ -80,7 +82,7 @@ RecoilRoot({
     reset(myAtom);
 
     set(readOnlySelectorSel, 2); // $ExpectError
-    set(writeableSelector, 10); // $ExpectError
+    set(writeableSelector, 10);
     setUnvalidatedAtomValues({}); // $ExpectError
     set(writeableSelector, new DefaultValue());
   },
@@ -91,31 +93,31 @@ const roAtom: RecoilValueReadOnly<string> = {} as any;
 const waAtom: RecoilState<string> = {} as any;
 const nsAtom: RecoilState<number | string> = {} as any; // number or string
 
-useRecoilValue(roAtom);
-useRecoilValue(waAtom);
+useRecoilValue(roAtom); // $ExpectType string
+useRecoilValue(waAtom); // $ExpectType string
 
 useRecoilState(roAtom); // $ExpectError
-useRecoilState(waAtom);
+useRecoilState(waAtom); // $ExpectType [string, SetterOrUpdater<string>]
 
 useRecoilState<number>(waAtom); // $ExpectError
 useRecoilState<number | string>(waAtom); // $ExpectError
 useRecoilValue<number>(waAtom); // $ExpectError
-useRecoilValue<number | string>(waAtom);
+useRecoilValue<number | string>(waAtom); // $ExpectType string | number
 useRecoilValue<number>(nsAtom); // $ExpectError
 
-useRecoilValue(myAtom);
-useRecoilValue(mySelector1);
-useRecoilValue(readOnlySelectorSel);
-useRecoilValue(writeableSelector);
+useRecoilValue(myAtom); // $ExpectType number
+useRecoilValue(mySelector1); // $ExpectType number
+useRecoilValue(readOnlySelectorSel); // $ExpectType number
+useRecoilValue(writeableSelector); // $ExpectType number
 useRecoilValue({}); // $ExpectError
 
-useRecoilValueLoadable(myAtom);
-useRecoilValueLoadable(readOnlySelectorSel);
-useRecoilValueLoadable(writeableSelector);
+useRecoilValueLoadable(myAtom); // $ExpectType Loadable<number>
+useRecoilValueLoadable(readOnlySelectorSel); // $ExpectType Loadable<number>
+useRecoilValueLoadable(writeableSelector); // $ExpectType Loadable<number>
 useRecoilValueLoadable({}); // $ExpectError
 
-useRecoilState(myAtom);
-useRecoilState(writeableSelector);
+useRecoilState(myAtom); // $ExpectType [number, SetterOrUpdater<number>]
+useRecoilState(writeableSelector); // $ExpectType [number, SetterOrUpdater<number>]
 useRecoilState(readOnlySelectorSel); // $ExpectError
 useRecoilState({}); // $ExpectError
 
@@ -124,15 +126,19 @@ useRecoilStateLoadable(writeableSelector);
 useRecoilStateLoadable(readOnlySelectorSel); // $ExpectError
 useRecoilStateLoadable({}); // $ExpectError
 
-useSetRecoilState(myAtom);
-useSetRecoilState(writeableSelector);
+useSetRecoilState(myAtom); // $ExpectType SetterOrUpdater<number>
+useSetRecoilState(writeableSelector); // $ExpectType SetterOrUpdater<number>
 useSetRecoilState(readOnlySelectorSel); // $ExpectError
 useSetRecoilState({}); // $ExpectError
 
-useResetRecoilState(myAtom);
-useResetRecoilState(writeableSelector);
+useResetRecoilState(myAtom); // $ExpectType Resetter
+useResetRecoilState(writeableSelector); // $ExpectType Resetter
 useResetRecoilState(readOnlySelectorSel); // $ExpectError
 useResetRecoilState({}); // $ExpectError
+
+useGetRecoilValueInfo_UNSTABLE(myAtom); // $ExpectType AtomInfo<number>
+useGetRecoilValueInfo_UNSTABLE(mySelector2); // $ExpectType AtomInfo<string>
+useGetRecoilValueInfo_UNSTABLE({}); // $ExpectError
 
 useRecoilCallback(({ snapshot, set, reset, gotoSnapshot }) => async () => {
   snapshot; // $ExpectType Snapshot


### PR DESCRIPTION
Summary:
Report components which are subscribing to atoms and selectors via `useGetRecoilValueInfo()`.

Note that `Snapshot#getInfo()` will not report any subscribing components at this time.

This currently reports a string of the component name.  But, we likely want to change that to something more specific/useful.

Reviewed By: maxijb

Differential Revision: D24718812

