### PR TITLE
Attempt to restore OSS Flow error suppression

### DIFF
--- a/src/util/Recoil_deepFreezeValue.js
+++ b/src/util/Recoil_deepFreezeValue.js
@@ -64,6 +64,7 @@ function shouldNotBeFrozen(value: mixed): boolean {
   if (
     !isSSR &&
     !isReactNative &&
+    // $FlowFixMe(site=recoil) Window does not have a FlowType definition https://github.com/facebook/flow/issues/6709
     (value === window || value instanceof Window)
   ) {
     return true;


### PR DESCRIPTION
Summary: D24646060 (https://github.com/facebookexperimental/recoil/commit/3813f7f504b46f4b5a44c2085430e3a0a5db530d) Removed a `$FlowFixMe` suppression that was used in open-source.  Attempt to restore it with a `$FlowFixMe(site=recoil)` that should protect it from the reaper.

Reviewed By: mroch, aaronabramov

Differential Revision: D24763717

