### PR TITLE
fix: snapshot variable is not defined

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -18,9 +18,9 @@ const multipliedState = selector({
 
 test('Test multipliedState', () => {
   const initialSnapshot = snapshot_UNSTABLE();
-  expect(mySnapshot.getLoadable(multipliedState).valueOrThrow()).toBe(0);
+  expect(initialSnapshot.getLoadable(multipliedState).valueOrThrow()).toBe(0);
 
   const testSnapshot = snapshot_UNSTABLE(({set}) => set(numberState, 1));
-  expect(mySnapshot.getLoadable(multipliedState).valueOrThrow()).toBe(100);
+  expect(testSnapshot.getLoadable(multipliedState).valueOrThrow()).toBe(100);
 })
 ```


### PR DESCRIPTION
**Summary**
There is an error because the variable is wrong.
`initialSnapshot`, `testSnapshot` and `mySnapshot` should be changed correctly.