### PR TITLE
Restore OSS build Flow suppression

### DIFF
--- a/src/util/Recoil_deepFreezeValue.js
+++ b/src/util/Recoil_deepFreezeValue.js
@@ -63,6 +63,7 @@ function shouldNotBeFrozen(value: mixed): boolean {
   if (
     !isSSR &&
     !isReactNative &&
+    // $FlowFixMe(site=recoil) Window does not have a FlowType definition https://github.com/facebook/flow/issues/6709
     (value === window || value instanceof Window)
   ) {
     return true;


### PR DESCRIPTION
Summary: Restore again the Flow error suppression needed by the Recoil OSS build from D24763717 (https://github.com/facebookexperimental/recoil/commit/a5dce061f077ad0ddd3d8a9585cab7807b2d01c8) that was removed again in D24856440 (https://github.com/facebookexperimental/recoil/commit/8cfb41a3f00a4442ddf01023283930430b5953a6)

Differential Revision: D24865548

