### PR TITLE
Use dynamic resolve config to build for react-native

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
         "root": ["./src"],
         "alias": {
           "React": "react",
+          "ReactRenderer": "react-dom",
           "ReactDOM": "react-dom",
           "ReactNative": "react-native",
           "ReactTestUtils": "react-dom/test-utils"

--- a/.flowconfig
+++ b/.flowconfig
@@ -18,6 +18,7 @@ suppress_type=$FlowOSSFixMe
 
 module.name_mapper='React' -> '<PROJECT_ROOT>/node_modules/react'
 module.name_mapper='ReactDOM' -> '<PROJECT_ROOT>/node_modules/react-dom'
+module.name_mapper='ReactRenderer' -> '<PROJECT_ROOT>/node_modules/react-dom'
 module.name_mapper='ReactTestUtils' -> '<PROJECT_ROOT>/node_modules/react-dom/test-utils'
 
 module.name_mapper='RecoilUtils' -> '<PROJECT_ROOT>/src/RecoilUtils.js'

--- a/src/hooks/Recoil_useGetRecoilValueInfo.js
+++ b/src/hooks/Recoil_useGetRecoilValueInfo.js
@@ -13,7 +13,7 @@ import type {RecoilValue} from '../core/Recoil_RecoilValue';
 const {peekNodeInfo} = require('../core/Recoil_FunctionalCore');
 const {useStoreRef} = require('../core/Recoil_RecoilRoot.react');
 
-export default function useGetRecoilValueInfo(): <T>(
+module.exports = function useGetRecoilValueInfo(): <T>(
   RecoilValue<T>,
 ) => RecoilValueInfo<T> {
   const storeRef = useStoreRef();
@@ -24,4 +24,4 @@ export default function useGetRecoilValueInfo(): <T>(
       storeRef.current.getState().currentTree,
       key,
     );
-}
+};

--- a/src/util/Recoil_ReactBatchedUpdates.js
+++ b/src/util/Recoil_ReactBatchedUpdates.js
@@ -8,11 +8,13 @@
  * @flow strict
  * @format
  *
- * This is to export esstiential functions from react-dom
- * for our web build
+ * This is to export esstiential functions from a react renderer,
+ * such as react-dom or react-native
  */
 
-const {unstable_batchedUpdates} = require('ReactDOM'); // @oss-only
+// in OSS it's configured in rollup.config.js
+const {unstable_batchedUpdates} = require('ReactRenderer'); // @oss-only
+// in FB, ReactDOMComet falls back to ReactDOM in non-comet environment
 // @fb-only: const {unstable_batchedUpdates} = require('ReactDOMComet');
 
 module.exports = {unstable_batchedUpdates};


### PR DESCRIPTION
Instead of using different suffix (.native.js), use a different resolve plugin to build for react native support, so we don't have a file that's seemingly useless to codemod bots.

Output:

head native/recoil.js
```
import reactNative from 'react-native';
import react from 'react';
```
head cjs/recoil.js
```
'use strict';

Object.defineProperty(exports, '__esModule', { value: true });

function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }

var reactDom = _interopDefault(require('react-dom'));
var react = _interopDefault(require('react'));
```

head es/recoil.js
```
import reactDom from 'react-dom';
import react from 'react';
```