### PR TITLE
Avoid re-rendering components if selector values don't change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## NEXT
+
+- Performance optimization to suppress re-rendering components when subscribed selectors evaluate to the same value. (#749)
+- Added useGetRecoilValueInfo_UNSTABLE() hook for dev tools. (#713, #714)
+
 ## 0.1.2 (2020-10-30)
 
 - Fix TypeScript exports

--- a/src/adt/Recoil_Loadable.js
+++ b/src/adt/Recoil_Loadable.js
@@ -36,7 +36,6 @@ type Accessors<T> = $ReadOnly<{
   // If there's an error, throw an error.  If it's still loading, throw a Promise
   // This is useful for composing with React Suspense or in a Recoil Selector.
   getValue: () => T,
-
   toPromise: () => Promise<T>,
 
   // Convenience accessors
@@ -46,6 +45,8 @@ type Accessors<T> = $ReadOnly<{
   errorOrThrow: () => Error,
   promiseMaybe: () => Promise<T> | void,
   promiseOrThrow: () => Promise<T>,
+
+  is: (Loadable<mixed>) => boolean,
 
   map: <T, S>(map: (T) => Promise<S> | S) => Loadable<S>,
 }>;
@@ -128,6 +129,10 @@ const loadableAccessors = {
     return gkx('recoil_async_selector_refactor')
       ? (this.contents: Promise<$FlowFixMe>).then(({__value}) => __value)
       : (this.contents: Promise<$FlowFixMe>);
+  },
+
+  is(other: Loadable<mixed>): boolean {
+    return other.state === this.state && other.contents === this.contents;
   },
 
   // TODO Unit tests

--- a/src/hooks/Recoil_useGetRecoilValueInfo.js
+++ b/src/hooks/Recoil_useGetRecoilValueInfo.js
@@ -13,9 +13,7 @@ import type {RecoilValue} from '../core/Recoil_RecoilValue';
 const {peekNodeInfo} = require('../core/Recoil_FunctionalCore');
 const {useStoreRef} = require('../core/Recoil_RecoilRoot.react');
 
-module.exports = function useGetRecoilValueInfo(): <T>(
-  RecoilValue<T>,
-) => RecoilValueInfo<T> {
+function useGetRecoilValueInfo(): <T>(RecoilValue<T>) => RecoilValueInfo<T> {
   const storeRef = useStoreRef();
 
   return <T>({key}): RecoilValueInfo<T> =>
@@ -24,4 +22,6 @@ module.exports = function useGetRecoilValueInfo(): <T>(
       storeRef.current.getState().currentTree,
       key,
     );
-};
+}
+
+module.exports = useGetRecoilValueInfo;

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -261,8 +261,14 @@ const testGKs = (
 };
 
 const getRecoilTestFn = (reloadImports: ReloadImports): TestFn =>
-  // @fb-only: testGKs(reloadImports, [['recoil_async_selector_refactor']]);
- testGKs(reloadImports, []); // @oss-only
+  testGKs(reloadImports, [
+    // @fb-only: ['recoil_async_selector_refactor'],
+    ['recoil_suppress_rerender_in_callback'],
+    [
+      // @fb-only: 'recoil_async_selector_refactor',
+      // @fb-only: 'recoil_suppress_rerender_in_callback',
+    ],
+  ]);
 
 module.exports = {
   makeStore,


### PR DESCRIPTION
Summary:
An optimization that will avoid re-rendering React components if selector values they subscribe to don't change (based on reference equality).

Currently, changing an atom to the same value (based on reference equality) will not propagate any downstream updates.  However, any updates to a selector would propagate updates to all downstream selectors and re-render all subscribing components.

This is only a partial optimization because downstream selectors will still re-evaluate.  However, the React component itself will see that the final value has not changed and will suppress re-rendering.  This is also only a partial fix because it only limits suppression based on reference-equality, and does not allow for a user-defined equality check.

Additionally - In order to compare the new and old values before re-rendering, the subscribing component will evaluate the selector before deciding to re-render.  It gets the value again during rendering, however the value will be cached in `atomValues`, so this should be cheap.  By moving this evaluation earlier, it may actually help "pre-fetch" asynchronous requests before rendering starts.

Differential Revision: D25040920

