### PR TITLE
docs: help prevent "selector without dependencies" testing issues

### DIFF
--- a/docs/docs/api-reference/core/RecoilRoot.md
+++ b/docs/docs/api-reference/core/RecoilRoot.md
@@ -5,6 +5,8 @@ sidebar_label: <RecoilRoot />
 
 Provides the context in which atoms have values. Must be an ancestor of any component that uses any Recoil hooks. Multiple roots may co-exist; atoms will have distinct values within each root. If they are nested, the innermost root will completely mask any outer roots.
 
+Note: This does **not** mean that `RecoilRoot`s are always completely isolated from each other. For example, a selector that does not depend on any atom may have its result cached across roots. This can cause problems if the selector reads external resources, especially in tests that only render a new `RecoilRoot` for every test, but do not [reset](/docs/guides/asynchronous-data-queries#use-a-request-id) the selector in any way.
+
 ---
 
 **Props**:


### PR DESCRIPTION
I ran into #422/#650, costing me a lot of time, when writing tests for a selector that
retrieves data from a mocked fetch function that returns different values in different test cases.
Being confused how there can be any state persisting across a re-mount of `RecoilRoot`,
this is one of the documentation locations where I would have found the issue quicker.
