### PR TITLE
Add error reporting for attempted async selector set

### DIFF
--- a/src/recoil_values/Recoil_selector_NEW.js
+++ b/src/recoil_values/Recoil_selector_NEW.js
@@ -879,10 +879,17 @@ function selector<T>(
     function mySet(store, state, newValue): [DependencyMap, AtomValues] {
       initSelector(store);
 
+      let syncSelectorSetFinished = false;
       const dependencyMap: DependencyMap = new Map();
       const writes: AtomValues = new Map();
 
       function getRecoilValue<S>({key}: RecoilValue<S>): S {
+        if (syncSelectorSetFinished) {
+          throw new Error(
+            'Recoil: Async selector sets are not currently supported.',
+          );
+        }
+
         const [, loadable] = getCachedNodeLoadable(store, state, key);
 
         if (loadable.state === 'hasValue') {
@@ -898,6 +905,12 @@ function selector<T>(
         recoilState: RecoilState<S>,
         valueOrUpdater: S | DefaultValue | ((S, GetRecoilValue) => S),
       ) {
+        if (syncSelectorSetFinished) {
+          throw new Error(
+            'Recoil: Async selector sets are not currently supported.',
+          );
+        }
+
         const newValue =
           typeof valueOrUpdater === 'function'
             ? // cast to any because we can't restrict type S from being a function itself without losing support for opaque types
@@ -919,11 +932,21 @@ function selector<T>(
         setRecoilState(recoilState, DEFAULT_VALUE);
       }
 
-      set(
+      const ret = set(
         {set: setRecoilState, get: getRecoilValue, reset: resetRecoilState},
         newValue,
       );
 
+      // set should be a void method, but if the user makes it `async`, then it
+      // will return a Promise, which we don't currently support.
+      if (ret !== undefined) {
+        throw isPromise(ret)
+          ? new Error(
+              'Recoil: Async selector sets are not currently supported.',
+            )
+          : new Error('Recoil: selector set should be a void function.');
+      }
+      syncSelectorSetFinished = true;
       return [dependencyMap, writes];
     }
 

--- a/src/recoil_values/Recoil_selector_OLD.js
+++ b/src/recoil_values/Recoil_selector_OLD.js
@@ -458,10 +458,17 @@ function selector<T>(
     function mySet(store, state, newValue): [DependencyMap, AtomValues] {
       initSelector(store);
 
+      let syncSelectorSetFinished = false;
       const dependencyMap: DependencyMap = new Map();
       const writes: AtomValues = new Map();
 
       function getRecoilValue<S>({key}: RecoilValue<S>): S {
+        if (syncSelectorSetFinished) {
+          throw new Error(
+            'Recoil: Async selector sets are not currently supported.',
+          );
+        }
+
         const [deps, loadable] = getNodeLoadable(store, state, key);
         mergeDepsIntoDependencyMap(deps, dependencyMap);
 
@@ -478,6 +485,12 @@ function selector<T>(
         recoilState: RecoilState<S>,
         valueOrUpdater: S | DefaultValue | ((S, GetRecoilValue) => S),
       ) {
+        if (syncSelectorSetFinished) {
+          throw new Error(
+            'Recoil: Async selector sets are not currently supported.',
+          );
+        }
+
         const newValue =
           typeof valueOrUpdater === 'function'
             ? // cast to any because we can't restrict type S from being a function itself without losing support for opaque types
@@ -499,10 +512,21 @@ function selector<T>(
         setRecoilState(recoilState, DEFAULT_VALUE);
       }
 
-      set(
+      const ret = set(
         {set: setRecoilState, get: getRecoilValue, reset: resetRecoilState},
         newValue,
       );
+
+      // set should be a void method, but if the user makes it `async`, then it
+      // will return a Promise, which we don't currently support.
+      if (ret !== undefined) {
+        throw isPromise(ret)
+          ? new Error(
+              'Recoil: Async selector sets are not currently supported.',
+            )
+          : new Error('Recoil: selector set should be a void function.');
+      }
+      syncSelectorSetFinished = true;
       return [dependencyMap, writes];
     }
     return registerNode<T>({


### PR DESCRIPTION
Summary: Recoil does not support async selector sets.  However, as it does support async gets many users expect async sets.  Flow reports a static error if an `async` function is used, TypeScript should as well.  Though users may not have or notice this error.  This diff throws an error if callbacks in the `set` are attempted to be used asynchronously.  However, those errors may not be caughts and be lost.  So, we also detect if an `async` function was used by checking if the user's set returns a `Promise` and throws an error for that as well.

Differential Revision: D25250686

