### PR TITLE
[docs] async fix typo userRecoilValue

### DIFF
--- a/docs/docs/guides/asynchronous-data-queries.md
+++ b/docs/docs/guides/asynchronous-data-queries.md
@@ -349,7 +349,7 @@ function useRefreshUserInfo(userID) {
 
 function CurrentUserInfo() {
   const currentUserID = useRecoilValue(currentUserIDState);
-  const currentUserInfo = userRecoilValue(userInfoQuery(currentUserID));
+  const currentUserInfo = useRecoilValue(userInfoQuery(currentUserID));
   const refreshUserInfo = useRefreshUserInfo(currentUserID);
 
   return (


### PR DESCRIPTION
Recoil is looking very cool! Excited to use it where traditionally we might have reached for Redux or custom context...
I was just going through the latest docs and noticed a small typo on async queries showing `userRecoilValue` instead of `useRecoilValue`.