### PR TITLE
Use React <Profiler> for counting renders

### DIFF
--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -10,9 +10,9 @@
  */
 'use strict';
 
-import type {RecoilValue} from '../core/Recoil_RecoilValue';
-import type {MutableSnapshot} from '../core/Recoil_Snapshot';
-import type {Store, StoreRef, StoreState} from '../core/Recoil_State';
+import type {RecoilValue} from './Recoil_RecoilValue';
+import type {MutableSnapshot} from './Recoil_Snapshot';
+import type {Store, StoreRef, StoreState} from './Recoil_State';
 
 const React = require('React');
 const {useContext, useEffect, useMemo, useRef, useState} = require('React');
@@ -21,26 +21,26 @@ const {useContext, useEffect, useMemo, useRef, useState} = require('React');
 // @fb-only: const URI = require('URI');
 
 const Queue = require('../adt/Recoil_Queue');
-const {
-  cleanUpNode,
-  getDownstreamNodes,
-  setNodeValue,
-  setUnvalidatedAtomValue_DEPRECATED,
-} = require('../core/Recoil_FunctionalCore');
-const {graph, saveDependencyMapToStore} = require('../core/Recoil_Graph');
-const {cloneGraph} = require('../core/Recoil_Graph');
-const {applyAtomValueWrites} = require('../core/Recoil_RecoilValueInterface');
-const {freshSnapshot} = require('../core/Recoil_Snapshot');
-const {
-  getNextTreeStateVersion,
-  makeEmptyStoreState,
-} = require('../core/Recoil_State');
 const {mapByDeletingMultipleFromMap} = require('../util/Recoil_CopyOnWrite');
 const expectationViolation = require('../util/Recoil_expectationViolation');
 const nullthrows = require('../util/Recoil_nullthrows');
 // @fb-only: const recoverableViolation = require('../util/Recoil_recoverableViolation');
 const Tracing = require('../util/Recoil_Tracing');
 const unionSets = require('../util/Recoil_unionSets');
+const {
+  cleanUpNode,
+  getDownstreamNodes,
+  setNodeValue,
+  setUnvalidatedAtomValue_DEPRECATED,
+} = require('./Recoil_FunctionalCore');
+const {graph, saveDependencyMapToStore} = require('./Recoil_Graph');
+const {cloneGraph} = require('./Recoil_Graph');
+const {applyAtomValueWrites} = require('./Recoil_RecoilValueInterface');
+const {freshSnapshot} = require('./Recoil_Snapshot');
+const {
+  getNextTreeStateVersion,
+  makeEmptyStoreState,
+} = require('./Recoil_State');
 // @fb-only: const gkx = require('gkx');
 
 type Props = {

--- a/src/core/Recoil_RecoilValueInterface.js
+++ b/src/core/Recoil_RecoilValueInterface.js
@@ -318,7 +318,7 @@ function setUnvalidatedRecoilValue<T>(
   );
 }
 
-export type ComponentSubscription = {release: Store => void};
+export type ComponentSubscription = {release: () => void};
 let subscriptionID = 0;
 function subscribeToRecoilValue<T>(
   store: Store,

--- a/src/core/__tests__/Recoil_RecoilValueInterface-test.js
+++ b/src/core/__tests__/Recoil_RecoilValueInterface-test.js
@@ -96,7 +96,7 @@ testRecoil('selector subscriber is called when upstream changes', () => {
   expect(callback).toHaveBeenCalledTimes(0);
   setRecoilValue(store, a, 1);
   expect(callback).toHaveBeenCalledTimes(1);
-  release(store);
+  release();
   setRecoilValue(store, a, 2);
   expect(callback).toHaveBeenCalledTimes(1);
 });
@@ -114,7 +114,7 @@ testRecoil(
     expect(callback).toHaveBeenCalledTimes(0);
     setRecoilValue(store, a, 1);
     expect(callback).toHaveBeenCalledTimes(1);
-    release(store);
+    release();
     setRecoilValue(store, a, 2);
     expect(callback).toHaveBeenCalledTimes(1);
   },

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -104,11 +104,11 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
     key => {
       const sub = subscriptions.current.get(key);
       if (sub) {
-        sub.release(storeRef.current);
+        sub.release();
         subscriptions.current.delete(key);
       }
     },
-    [storeRef, subscriptions],
+    [subscriptions],
   );
 
   const componentName = useComponentName();
@@ -301,7 +301,7 @@ function useRecoilValueLoadable_MUTABLESOURCE<T>(
   const subscribe = useCallback(
     (_something, callback) => {
       const store = storeRef.current;
-      const sub = subscribeToRecoilValue(
+      const subscription = subscribeToRecoilValue(
         store,
         recoilValue,
         () => {
@@ -315,7 +315,7 @@ function useRecoilValueLoadable_MUTABLESOURCE<T>(
         },
         componentName,
       );
-      return () => sub.release(store);
+      return subscription.release;
     },
     [recoilValue, storeRef, componentName],
   );
@@ -337,7 +337,8 @@ function useRecoilValueLoadable_LEGACY<T>(
 
   useEffect(() => {
     const store = storeRef.current;
-    const sub = subscribeToRecoilValue(
+    const storeState = store.getState();
+    const subscription = subscribeToRecoilValue(
       store,
       recoilValue,
       _state => {
@@ -376,8 +377,8 @@ function useRecoilValueLoadable_LEGACY<T>(
       }
     });
 
-    return () => sub.release(store);
-  }, [recoilValue, storeRef]);
+    return subscription.release;
+  }, [componentName, recoilValue, storeRef]);
 
   return getRecoilValueAsLoadable(storeRef.current, recoilValue);
 }

--- a/src/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/src/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -23,6 +23,7 @@ const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 let React,
   useEffect,
   useState,
+  Profiler,
   act,
   Queue,
   batchUpdates,
@@ -49,7 +50,7 @@ let {mutableSourceExists} = require('../../util/Recoil_mutableSource');
 
 const testRecoil = getRecoilTestFn(() => {
   React = require('React');
-  ({useEffect, useState} = require('React'));
+  ({useEffect, useState, Profiler} = require('React'));
   ({act} = require('ReactTestUtils'));
 
   Queue = require('../../adt/Recoil_Queue');
@@ -199,8 +200,11 @@ function componentThatReadsTwoAtoms(one, two) {
 function componentThatReadsAtomWithCommitCount(atom) {
   const commit = jest.fn(() => {});
   function ReadsAtom() {
-    useEffect(commit);
-    return useRecoilValue(atom);
+    return (
+      <Profiler id="test" onRender={commit}>
+        {useRecoilValue(atom)}
+      </Profiler>
+    );
   }
   return [ReadsAtom, commit];
 }

--- a/src/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/src/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -354,8 +354,8 @@ testRecoil('Async selectors can depend on async selectors', async () => {
   }
 });
 
-testRecoil('Dep of upstream selector can change while pending', async gk => {
-  if (gk !== 'recoil_async_selector_refactor') {
+testRecoil('Dep of upstream selector can change while pending', async gks => {
+  if (!gks.includes('recoil_async_selector_refactor')) {
     return;
   }
 

--- a/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -11,7 +11,6 @@ const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   act,
-  gkx,
   atom,
   selector,
   ReadsAtom,
@@ -24,7 +23,6 @@ const testRecoil = getRecoilTestFn(() => {
   ({act} = require('ReactTestUtils'));
 
   atom = require('../../recoil_values/Recoil_atom');
-  gkx = require('../../util/Recoil_gkx');
   selector = require('../../recoil_values/Recoil_selector');
   ({
     ReadsAtom,
@@ -34,243 +32,284 @@ const testRecoil = getRecoilTestFn(() => {
   useGetRecoilValueInfo = require('../Recoil_useGetRecoilValueInfo');
 });
 
-testRecoil('useGetRecoilValueInfo', () => {
-  const recoil_infer_component_names = gkx('recoil_infer_component_names');
-  gkx.setPass('recoil_infer_component_names');
+testRecoil(
+  'useGetRecoilValueInfo',
+  gk => {
+    const myAtom = atom<string>({
+      key: 'useGetRecoilValueInfo atom',
+      default: 'DEFAULT',
+    });
+    const selectorA = selector({
+      key: 'useGetRecoilValueInfo A',
+      get: ({get}) => get(myAtom),
+    });
+    const selectorB = selector({
+      key: 'useGetRecoilValueInfo B',
+      get: ({get}) => get(selectorA) + get(myAtom),
+    });
 
-  const myAtom = atom<string>({
-    key: 'useGetRecoilValueInfo atom',
-    default: 'DEFAULT',
-  });
-  const selectorA = selector({
-    key: 'useGetRecoilValueInfo A',
-    get: ({get}) => get(myAtom),
-  });
-  const selectorB = selector({
-    key: 'useGetRecoilValueInfo B',
-    get: ({get}) => get(selectorA) + get(myAtom),
-  });
+    let getRecoilValueInfo = _ => {
+      expect(false).toBe(true);
+      throw new Error('getRecoilValue not set');
+    };
+    function GetRecoilValueInfo() {
+      getRecoilValueInfo = useGetRecoilValueInfo();
+      return null;
+    }
 
-  let getRecoilValueInfo = _ => {
-    expect(false).toBe(true);
-    throw new Error('getRecoilValue not set');
-  };
-  function GetRecoilValueInfo() {
-    getRecoilValueInfo = useGetRecoilValueInfo();
-    return null;
-  }
+    // Initial status
+    renderElements(<GetRecoilValueInfo />);
 
-  // Initial status
-  renderElements(<GetRecoilValueInfo />);
+    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'DEFAULT',
+      }),
+      isActive: false,
+      isSet: false,
+      isModified: false,
+      type: undefined,
+    });
+    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+      [],
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
+      ).toEqual([]);
+    }
+    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+      loadable: undefined,
+      isActive: false,
+      isSet: false,
+      isModified: false,
+      type: undefined,
+    });
+    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual([]);
+    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+      [],
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+      ).toEqual([]);
+    }
+    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+      loadable: undefined,
+      isActive: false,
+      isSet: false,
+      isModified: false,
+      type: undefined,
+    });
+    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual([]);
+    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+      [],
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+      ).toEqual([]);
+    }
 
-  expect(getRecoilValueInfo(myAtom)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
-    isActive: false,
-    isSet: false,
-    isModified: false,
-    type: undefined,
-  });
-  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual([]);
-  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.components)).toEqual(
-    [],
-  );
-  expect(getRecoilValueInfo(selectorA)).toMatchObject({
-    loadable: undefined,
-    isActive: false,
-    isSet: false,
-    isModified: false,
-    type: undefined,
-  });
-  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual([]);
-  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
-    [],
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-  ).toEqual([]);
-  expect(getRecoilValueInfo(selectorB)).toMatchObject({
-    loadable: undefined,
-    isActive: false,
-    isSet: false,
-    isModified: false,
-    type: undefined,
-  });
-  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual([]);
-  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-    [],
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-  ).toEqual([]);
+    // After reading values
+    const [ReadWriteAtom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(
+      myAtom,
+    );
+    const c = renderElements(
+      <>
+        <GetRecoilValueInfo />
+        <ReadWriteAtom />
+        <ReadsAtom atom={selectorB} />
+      </>,
+    );
+    expect(c.textContent).toEqual('"DEFAULT""DEFAULTDEFAULT"');
 
-  // After reading values
-  const [ReadWriteAtom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(
-    myAtom,
-  );
-  const c = renderElements(
-    <>
-      <GetRecoilValueInfo />
-      <ReadWriteAtom />
-      <ReadsAtom atom={selectorB} />
-    </>,
-  );
-  expect(c.textContent).toEqual('"DEFAULT""DEFAULTDEFAULT"');
+    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'DEFAULT',
+      }),
+      isActive: true,
+      isSet: false,
+      isModified: false,
+      type: 'atom',
+    });
+    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+      expect.arrayContaining([selectorA, selectorB]),
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
+      ).toEqual([{name: 'ReadsAndWritesAtom'}]);
+    }
+    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'DEFAULT',
+      }),
+      isActive: true,
+      isSet: false,
+      isModified: false,
+      type: 'selector',
+    });
+    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+      expect.arrayContaining([myAtom]),
+    );
+    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+      expect.arrayContaining([selectorB]),
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+      ).toEqual([]);
+    }
+    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'DEFAULTDEFAULT',
+      }),
+      isActive: true,
+      isSet: false,
+      isModified: false,
+      type: 'selector',
+    });
+    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+      expect.arrayContaining([myAtom, selectorA]),
+    );
+    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+      [],
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+      ).toEqual([{name: 'ReadsAtom'}]);
+    }
 
-  expect(getRecoilValueInfo(myAtom)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
-    isActive: true,
-    isSet: false,
-    isModified: false,
-    type: 'atom',
-  });
-  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
-    expect.arrayContaining([selectorA, selectorB]),
-  );
-  expect(
-    Array.from(getRecoilValueInfo(myAtom).subscribers.components),
-  ).toEqual([{name: 'ReadsAndWritesAtom'}]);
-  expect(getRecoilValueInfo(selectorA)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
-    isActive: true,
-    isSet: false,
-    isModified: false,
-    type: 'selector',
-  });
-  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
-    expect.arrayContaining([myAtom]),
-  );
-  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
-    expect.arrayContaining([selectorB]),
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-  ).toEqual([]);
-  expect(getRecoilValueInfo(selectorB)).toMatchObject({
-    loadable: expect.objectContaining({
-      state: 'hasValue',
-      contents: 'DEFAULTDEFAULT',
-    }),
-    isActive: true,
-    isSet: false,
-    isModified: false,
-    type: 'selector',
-  });
-  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
-    expect.arrayContaining([myAtom, selectorA]),
-  );
-  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-    [],
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-  ).toEqual([{name: 'ReadsAtom'}]);
+    // After setting a value
+    act(() => setAtom('SET'));
 
-  // After setting a value
-  act(() => setAtom('SET'));
+    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+      loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
+      isActive: true,
+      isSet: true,
+      isModified: true,
+      type: 'atom',
+    });
+    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+      expect.arrayContaining([selectorA, selectorB]),
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
+      ).toEqual([{name: 'ReadsAndWritesAtom'}]);
+    }
+    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+      loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
+      isActive: true,
+      isSet: false,
+      isModified: false,
+      type: 'selector',
+    });
+    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+      expect.arrayContaining([myAtom]),
+    );
+    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+      expect.arrayContaining([selectorB]),
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+      ).toEqual([]);
+    }
+    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'SETSET',
+      }),
+      isActive: true,
+      isSet: false,
+      isModified: false,
+      type: 'selector',
+    });
+    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+      expect.arrayContaining([myAtom, selectorA]),
+    );
+    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+      [],
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+      ).toEqual([{name: 'ReadsAtom'}]);
+    }
 
-  expect(getRecoilValueInfo(myAtom)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
-    isActive: true,
-    isSet: true,
-    isModified: true,
-    type: 'atom',
-  });
-  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
-    expect.arrayContaining([selectorA, selectorB]),
-  );
-  expect(
-    Array.from(getRecoilValueInfo(myAtom).subscribers.components),
-  ).toEqual([{name: 'ReadsAndWritesAtom'}]);
-  expect(getRecoilValueInfo(selectorA)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
-    isActive: true,
-    isSet: false,
-    isModified: false,
-    type: 'selector',
-  });
-  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
-    expect.arrayContaining([myAtom]),
-  );
-  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
-    expect.arrayContaining([selectorB]),
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-  ).toEqual([]);
-  expect(getRecoilValueInfo(selectorB)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'SETSET'}),
-    isActive: true,
-    isSet: false,
-    isModified: false,
-    type: 'selector',
-  });
-  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
-    expect.arrayContaining([myAtom, selectorA]),
-  );
-  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-    [],
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-  ).toEqual([{name: 'ReadsAtom'}]);
+    // After reseting a value
+    act(resetAtom);
 
-  // After reseting a value
-  act(resetAtom);
-
-  expect(getRecoilValueInfo(myAtom)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
-    isActive: true,
-    isSet: false,
-    isModified: true,
-    type: 'atom',
-  });
-  expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-  expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
-    expect.arrayContaining([selectorA, selectorB]),
-  );
-  expect(
-    Array.from(getRecoilValueInfo(myAtom).subscribers.components),
-  ).toEqual([{name: 'ReadsAndWritesAtom'}]);
-  expect(getRecoilValueInfo(selectorA)).toMatchObject({
-    loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
-    isActive: true,
-    isSet: false,
-    isModified: false,
-    type: 'selector',
-  });
-  expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
-    expect.arrayContaining([myAtom]),
-  );
-  expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
-    expect.arrayContaining([selectorB]),
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-  ).toEqual([]);
-  expect(getRecoilValueInfo(selectorB)).toMatchObject({
-    loadable: expect.objectContaining({
-      state: 'hasValue',
-      contents: 'DEFAULTDEFAULT',
-    }),
-    isActive: true,
-    isSet: false,
-    isModified: false,
-    type: 'selector',
-  });
-  expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
-    expect.arrayContaining([myAtom, selectorA]),
-  );
-  expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-    [],
-  );
-  expect(
-    Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-  ).toEqual([{name: 'ReadsAtom'}]);
-
-  recoil_infer_component_names
-    ? gkx.setPass('recoil_infer_component_names')
-    : gkx.setFail('recoil_infer_component_names');
-});
+    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'DEFAULT',
+      }),
+      isActive: true,
+      isSet: false,
+      isModified: true,
+      type: 'atom',
+    });
+    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+      expect.arrayContaining([selectorA, selectorB]),
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
+      ).toEqual([{name: 'ReadsAndWritesAtom'}]);
+    }
+    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'DEFAULT',
+      }),
+      isActive: true,
+      isSet: false,
+      isModified: false,
+      type: 'selector',
+    });
+    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+      expect.arrayContaining([myAtom]),
+    );
+    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+      expect.arrayContaining([selectorB]),
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
+      ).toEqual([]);
+    }
+    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+      loadable: expect.objectContaining({
+        state: 'hasValue',
+        contents: 'DEFAULTDEFAULT',
+      }),
+      isActive: true,
+      isSet: false,
+      isModified: false,
+      type: 'selector',
+    });
+    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+      expect.arrayContaining([myAtom, selectorA]),
+    );
+    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
+      [],
+    );
+    if (gk === 'recoil_infer_component_names') {
+      expect(
+        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
+      ).toEqual([{name: 'ReadsAtom'}]);
+    }
+  },
+  // @fb-only: ['recoil_infer_component_names'],
+);

--- a/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -34,7 +34,7 @@ const testRecoil = getRecoilTestFn(() => {
 
 testRecoil(
   'useGetRecoilValueInfo',
-  gk => {
+  gks => {
     const myAtom = atom<string>({
       key: 'useGetRecoilValueInfo atom',
       default: 'DEFAULT',
@@ -74,7 +74,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
       [],
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(myAtom).subscribers.components),
       ).toEqual([]);
@@ -90,7 +90,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
       [],
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorA).subscribers.components),
       ).toEqual([]);
@@ -106,7 +106,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
       [],
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorB).subscribers.components),
       ).toEqual([]);
@@ -139,7 +139,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorA, selectorB]),
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(myAtom).subscribers.components),
       ).toEqual([{name: 'ReadsAndWritesAtom'}]);
@@ -160,7 +160,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorB]),
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorA).subscribers.components),
       ).toEqual([]);
@@ -181,7 +181,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
       [],
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorB).subscribers.components),
       ).toEqual([{name: 'ReadsAtom'}]);
@@ -201,7 +201,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorA, selectorB]),
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(myAtom).subscribers.components),
       ).toEqual([{name: 'ReadsAndWritesAtom'}]);
@@ -219,7 +219,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorB]),
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorA).subscribers.components),
       ).toEqual([]);
@@ -240,7 +240,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
       [],
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorB).subscribers.components),
       ).toEqual([{name: 'ReadsAtom'}]);
@@ -263,7 +263,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorA, selectorB]),
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(myAtom).subscribers.components),
       ).toEqual([{name: 'ReadsAndWritesAtom'}]);
@@ -284,7 +284,7 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorB]),
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorA).subscribers.components),
       ).toEqual([]);
@@ -305,11 +305,11 @@ testRecoil(
     expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
       [],
     );
-    if (gk === 'recoil_infer_component_names') {
+    if (gks.includes('recoil_infer_component_names')) {
       expect(
         Array.from(getRecoilValueInfo(selectorB).subscribers.components),
       ).toEqual([{name: 'ReadsAtom'}]);
     }
   },
-  // @fb-only: ['recoil_infer_component_names'],
+  // @fb-only: [['recoil_infer_component_names']],
 );

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -10,8 +10,8 @@
 const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
-  useEffect,
   useState,
+  Profiler,
   ReactDOM,
   act,
   DEFAULT_VALUE,
@@ -34,7 +34,7 @@ const testRecoil = getRecoilTestFn(() => {
   const {makeStore} = require('../../testing/Recoil_TestingUtils');
 
   React = require('React');
-  ({useEffect, useState} = require('React'));
+  ({useState, Profiler} = require('React'));
   ReactDOM = require('ReactDOM');
   ({act} = require('ReactTestUtils'));
 
@@ -185,9 +185,6 @@ testRecoil("Updating with same value doesn't rerender", () => {
   let resetAtom;
   let renders = 0;
   function AtomComponent() {
-    useEffect(() => {
-      renders++;
-    });
     const [value, setValue] = useRecoilState(myAtom);
     const resetValue = useResetRecoilState(myAtom);
     setAtom = setValue;
@@ -195,7 +192,15 @@ testRecoil("Updating with same value doesn't rerender", () => {
     return value;
   }
   expect(renders).toEqual(0);
-  const c = renderElements(<AtomComponent />);
+  const c = renderElements(
+    <Profiler
+      id="test"
+      onRender={() => {
+        renders++;
+      }}>
+      <AtomComponent />
+    </Profiler>,
+  );
 
   // Initial render happens one time in www and 2 times in oss.
   // resetting the counter to 1 after the initial render to make them

--- a/src/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -10,13 +10,13 @@
  */
 'use strict';
 
-import type {Store} from 'Recoil_State';
+import type {Store} from '../../core/Recoil_State';
 
 const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let store: Store,
   React,
-  useEffect,
+  Profiler,
   useState,
   ReactDOM,
   act,
@@ -42,7 +42,7 @@ const testRecoil = getRecoilTestFn(() => {
   const {makeStore} = require('../../testing/Recoil_TestingUtils');
 
   React = require('React');
-  ({useEffect, useState} = require('React'));
+  ({Profiler, useState} = require('React'));
   ReactDOM = require('ReactDOM');
   ({act} = require('ReactTestUtils'));
 
@@ -443,11 +443,16 @@ testRecoil('Independent atom subscriptions', () => {
     let setValue;
 
     const Component = () => {
-      useEffect(() => {
-        numUpdates++;
-      });
       setValue = useSetRecoilState(myAtom(param));
-      return stableStringify(useRecoilValue(myAtom(param)));
+      return (
+        <Profiler
+          id="test"
+          onRender={() => {
+            numUpdates++;
+          }}>
+          {stableStringify(useRecoilValue(myAtom(param)))}
+        </Profiler>
+      );
     };
 
     return [Component, value => setValue(value), () => numUpdates];

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -403,7 +403,7 @@ testRecoil(
 // This tests ability to catch a pending result as a promise and
 // that the promise resolves to the dependency's value and it is handled
 // as an asynchronous selector
-testRecoil('useRecoilState - selector catching promise 2', async gk => {
+testRecoil('useRecoilState - selector catching promise 2', async gks => {
   let dependencyPromiseTest;
   const resolvingSel = resolvingAsyncSelector('READY');
   const catchPromiseSelector = selector({
@@ -413,7 +413,7 @@ testRecoil('useRecoilState - selector catching promise 2', async gk => {
         return get(resolvingSel);
       } catch (promise) {
         expect(promise instanceof Promise).toBe(true);
-        if (gk === 'recoil_async_selector_refactor') {
+        if (gks.includes('recoil_async_selector_refactor')) {
           // eslint-disable-next-line jest/valid-expect
           dependencyPromiseTest = expect(promise).resolves.toHaveProperty(
             '__value',
@@ -478,8 +478,8 @@ testRecoil('Detect circular dependencies', () => {
 
 testRecoil(
   'selector is able to track dependencies discovered asynchronously',
-  async gk => {
-    if (gk !== 'recoil_async_selector_refactor') {
+  async gks => {
+    if (!gks.includes('recoil_async_selector_refactor')) {
       return;
     }
 
@@ -529,8 +529,8 @@ testRecoil(
  */
 testRecoil(
   'selector should rerun entire selector when a dep changes',
-  async gk => {
-    if (gk !== 'recoil_async_selector_refactor') {
+  async gks => {
+    if (!gks.includes('recoil_async_selector_refactor')) {
       return;
     }
 
@@ -589,8 +589,8 @@ testRecoil(
  */
 testRecoil(
   'async selector runs the minimum number of times required',
-  async gk => {
-    if (gk !== 'recoil_async_selector_refactor') {
+  async gks => {
+    if (!gks.includes('recoil_async_selector_refactor')) {
       return;
     }
 
@@ -630,8 +630,8 @@ testRecoil(
 
 testRecoil(
   'async selector with changing dependencies finishes execution using original state',
-  async gk => {
-    if (gk !== 'recoil_async_selector_refactor') {
+  async gks => {
+    if (!gks.includes('recoil_async_selector_refactor')) {
       return;
     }
 
@@ -690,8 +690,8 @@ testRecoil(
   },
 );
 
-testRecoil('selector - dynamic getRecoilValue()', async gk => {
-  if (gk !== 'recoil_async_selector_refactor') {
+testRecoil('selector - dynamic getRecoilValue()', async gks => {
+  if (!gks.includes('recoil_async_selector_refactor')) {
     return;
   }
 
@@ -921,8 +921,8 @@ describe('Async selector resolution notifies all stores that read pending', () =
 
 testRecoil(
   'selector - kite pattern runs only necessary selectors',
-  async gk => {
-    if (gk !== 'recoil_async_selector_refactor') {
+  async gks => {
+    if (!gks.includes('recoil_async_selector_refactor')) {
       return;
     }
 

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -229,15 +229,16 @@ function flushPromisesAndTimers(): Promise<void> {
 
 type ReloadImports = () => void;
 type AssertionsFn = (gk: string | null) => ?Promise<mixed>;
-type TestFn = (string, AssertionsFn) => void;
+type TestFn = (string, AssertionsFn, Array<string> | void) => void;
 
 const testGKs = (gks: Array<string>, reloadImports: ReloadImports): TestFn => (
   testDescription: string,
   assertionsFn: AssertionsFn,
+  additionalGKs?: Array<string> = [],
 ) => {
   test.each([
     [testDescription, null],
-    ...gks.map(gk => [`${testDescription} (${gk})`, gk]),
+    ...[...gks, ...additionalGKs].map(gk => [`${testDescription} (${gk})`, gk]),
   ])('%s', async (_title, gk) => {
     jest.resetModules();
 

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -228,36 +228,39 @@ function flushPromisesAndTimers(): Promise<void> {
 }
 
 type ReloadImports = () => void;
-type AssertionsFn = (gk: string | null) => ?Promise<mixed>;
-type TestFn = (string, AssertionsFn, Array<string> | void) => void;
+// type AssertionsFn = (gk: string | null) => ?Promise<mixed>;
+type AssertionsFn = (gks: Array<string>) => ?Promise<mixed>;
+type TestFn = (string, AssertionsFn, Array<Array<string>> | void) => void;
 
-const testGKs = (gks: Array<string>, reloadImports: ReloadImports): TestFn => (
+const testGKs = (
+  reloadImports: ReloadImports,
+  gks: Array<Array<string>>,
+): TestFn => (
   testDescription: string,
   assertionsFn: AssertionsFn,
-  additionalGKs?: Array<string> = [],
+  additionalGKs?: Array<Array<string>> = [],
 ) => {
   test.each([
-    [testDescription, null],
-    ...[...gks, ...additionalGKs].map(gk => [`${testDescription} (${gk})`, gk]),
-  ])('%s', async (_title, gk) => {
+    [testDescription, []],
+    ...[...gks, ...additionalGKs].map(gks => [
+      !gks.length ? testDescription : `${testDescription} [${gks.join(', ')}]`,
+      gks,
+    ]),
+  ])('%s', async (_title, gks) => {
     jest.resetModules();
 
-    if (gk) {
-      gkx.setPass(gk);
-    }
+    gks.forEach(gkx.setPass);
 
     reloadImports();
-    await assertionsFn(gk);
+    await assertionsFn(gks);
 
-    if (gk) {
-      gkx.setFail(gk);
-    }
+    gks.forEach(gkx.setFail);
   });
 };
 
 const getRecoilTestFn = (reloadImports: ReloadImports): TestFn =>
-  // @fb-only: testGKs(['recoil_async_selector_refactor'], reloadImports);
- testGKs([], reloadImports); // @oss-only
+  // @fb-only: testGKs(reloadImports, [['recoil_async_selector_refactor']]);
+ testGKs(reloadImports, []); // @oss-only
 
 module.exports = {
   makeStore,


### PR DESCRIPTION
Summary:
Use React's `<Profiler>` API for counting renders in tests.

Note that this API is disabled for production builds, so it can be used for tests, but not for production logging.

Reviewed By: bvaughn

Differential Revision: D25489563

