### PR TITLE
[docs] Flatten API Reference

### DIFF
--- a/docs/docs/api-reference/core/atom.md
+++ b/docs/docs/api-reference/core/atom.md
@@ -5,6 +5,8 @@ sidebar_label: atom()
 
 An *atom* represents state in Recoil.  The `atom()` function returns a writeable `RecoilState` object.
 
+Recoil manages atom state changes to know when to notify components subscribing to that atom to re-render, so you should use the hooks listed below to change atom state.  If an object stored in an atom was mutated directly it may bypass this and cause state changes without properly notifying subscribing components.  To help detect bugs Recoil will freeze objects stored in atoms in development mode.
+
 ---
 
 ```jsx
@@ -18,11 +20,10 @@ function atom<T>({
 }): RecoilState<T>
 ```
 
-
   - `key` - A unique string used to identify the atom internally. This string should be unique with respect to other atoms and selectors in the entire application.
   - `default` - The initial value of the atom or a `Promise` or another atom or selector representing a value of the same type.
   - `effects_UNSTABLE` - An optional array of [Atom Effects](/docs/guides/atom-effects) for the atom.
-  - `dangerouslyAllowMutability` - Recoil depends on atom state changes to know when to notify components that use the atoms to re-render.  If an atom's value were mutated, it may bypass this and cause state to change without properly notifying subscribing components.  To help protect against this all stored values are frozen.  In some cases it may be desireable to override this using this option.
+  - `dangerouslyAllowMutability` - In some cases it may be desireable allow mutating of objects stored in atoms that don't represent state changes.  Use this option to override freezing objects in development mode.
 
 ---
 

--- a/docs/docs/api-reference/core/atom.md
+++ b/docs/docs/api-reference/core/atom.md
@@ -5,8 +5,6 @@ sidebar_label: atom()
 
 An *atom* represents state in Recoil.  The `atom()` function returns a writeable `RecoilState` object.
 
-Recoil manages atom state changes to know when to notify components subscribing to that atom to re-render, so you should use the hooks listed below to change atom state.  If an object stored in an atom was mutated directly it may bypass this and cause state changes without properly notifying subscribing components.  To help detect bugs Recoil will freeze objects stored in atoms in development mode.
-
 ---
 
 ```jsx
@@ -26,6 +24,8 @@ function atom<T>({
   - `dangerouslyAllowMutability` - In some cases it may be desireable allow mutating of objects stored in atoms that don't represent state changes.  Use this option to override freezing objects in development mode.
 
 ---
+
+Recoil manages atom state changes to know when to notify components subscribing to that atom to re-render, so you should use the hooks listed below to change atom state.  If an object stored in an atom was mutated directly it may bypass this and cause state changes without properly notifying subscribing components.  To help detect bugs Recoil will freeze objects stored in atoms in development mode.
 
 Most often, you'll use the following hooks to interact with atoms:
 

--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -3,7 +3,9 @@ title: selector(options)
 sidebar_label: selector()
 ---
 
-*Selectors* represent a function, or **derived state** in Recoil.  You can think of them as a "pure function" without side-effects that always returns the same value for a given set of dependency values.  If only a `get` function is provided, the selector is read-only and returns a `RecoilValueReadOnly` object.  If a `set` is also provided, it returns a writeable `RecoilState` object.
+*Selectors* represent a function, or **derived state** in Recoil.  You can think of them as similar to an "idempotent" or "pure function" without side-effects that always returns the same value for a given set of dependency values.  If only a `get` function is provided, the selector is read-only and returns a `RecoilValueReadOnly` object.  If a `set` is also provided, it returns a writeable `RecoilState` object.
+
+Recoil manages atom and selector state changes to know when to notify components subscribing to that selector to re-render.  If an object value of a selector is mutated directly it may bypass this and avoid properly notifying subscribing components.  To help detect bugs, Recoil will freeze selector value objects in development mode.
 
 ---
 
@@ -41,7 +43,7 @@ type ResetRecoilState = <T>(RecoilState<T>) => void;
 - `set?` - If this property is set, the selector will return **writeable** state. A function that is passed an object of callbacks as the first parameter and the new incoming value.  The incoming value may be a value of type `T` or maybe an object of type `DefaultValue` if the user reset the selector.  The callbacks include:
   - `get` - a function used to retrieve values from other atoms/selectors. This function will not subscribe the selector to the given atoms/selectors.
   - `set` - a function used to set the values of upstream Recoil state. The first parameter is the Recoil state and the second parameter is the new value.  The new value may be an updater function or a `DefaultValue` object to propagate reset actions.
-- `dangerouslyAllowMutability` - Selectors represent "pure functions" of derived state and should always return the same value for the same set of dependency input values.  To help protect this all values stored in a selector are frozen by default.  In some cases this may need to be overridden using this option.
+- `dangerouslyAllowMutability` - In some cases it may be desireable allow mutating of objects stored in selectors that don't represent state changes.  Use this option to override freezing objects in development mode.
 
 ---
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -34,43 +34,27 @@ module.exports = {
       'guides/atom-effects',
       'guides/testing',
       'guides/dev-tools',
-      //   'guides/writing-test',
       //   'guides/code-splitting',
     ],
 
     'API Reference': [
+      'api-reference/core/RecoilRoot',
       {
-        Core: [
-          'api-reference/core/RecoilRoot',
-          {
-            State: [
-              'api-reference/core/atom',
-              'api-reference/core/selector',
-              'api-reference/core/Loadable',
-              'api-reference/core/useRecoilState',
-              'api-reference/core/useRecoilValue',
-              'api-reference/core/useSetRecoilState',
-              'api-reference/core/useResetRecoilState',
-              'api-reference/core/useRecoilValueLoadable',
-              'api-reference/core/useRecoilStateLoadable',
-              'api-reference/core/isRecoilValue',
-              // 'api-reference/core/DefaultValue',
-            ],
-            Snapshots: [
-              'api-reference/core/Snapshot',
-              'api-reference/core/useRecoilTransactionObserver',
-              'api-reference/core/useRecoilSnapshot',
-              'api-reference/core/useGotoRecoilSnapshot',
-            ],
-          },
-          'api-reference/core/useRecoilCallback',
-          {
-            Misc: [
-              'api-reference/core/useRecoilBridgeAcrossReactRoots',
-            ],
-          },
+        'Recoil State': [
+          'api-reference/core/atom',
+          'api-reference/core/selector',
+          'api-reference/core/Loadable',
+          'api-reference/core/useRecoilState',
+          'api-reference/core/useRecoilValue',
+          'api-reference/core/useSetRecoilState',
+          'api-reference/core/useResetRecoilState',
+          'api-reference/core/useRecoilValueLoadable',
+          'api-reference/core/useRecoilStateLoadable',
+          'api-reference/core/isRecoilValue',
+          // 'api-reference/core/DefaultValue',
         ],
       },
+      'api-reference/core/useRecoilCallback',
       {
         Utils: [
           'api-reference/utils/atomFamily',
@@ -81,6 +65,15 @@ module.exports = {
           'api-reference/utils/waitForAny',
           'api-reference/utils/waitForNone',
           'api-reference/utils/noWait',
+        ],
+        Snapshots: [
+          'api-reference/core/Snapshot',
+          'api-reference/core/useRecoilTransactionObserver',
+          'api-reference/core/useRecoilSnapshot',
+          'api-reference/core/useGotoRecoilSnapshot',
+        ],
+        Misc: [
+          'api-reference/core/useRecoilBridgeAcrossReactRoots',
         ],
       },
     ],


### PR DESCRIPTION
Flatten the API reference and adjust structure slightly to better emphasize more important topics.