### PR TITLE
Document why certain selectors cause an update when there are no apparent changes

### DIFF
--- a/docs/docs/basic-tutorial/selectors.md
+++ b/docs/docs/basic-tutorial/selectors.md
@@ -142,6 +142,8 @@ function TodoListStats() {
 }
 ```
 
+Note that in the current implementation `TodoListStats` will re-render even when there are no apparent changes to the `todoListStatsState`, for example when you edit a `TodoItem`. This is because all downstream subscribers of an atom or selector will update when a dependency updates.
+
 To summarize, we've created a todo list app that meets all of our requirements:
 
 - Add todo items


### PR DESCRIPTION
I've been puzzling why the Tutorial example was re-rendering for no apparent reason and I finally found this explanation #41 

I wrongly assumed that selectors would behave in a react-ish way and do not cause a re-render if their value does not change. Others might fall in the same trap, I think adding a line of explanation would be useful.

Superb work on the framework, btw, and I'm really looking forward to be using the API mentioned here https://github.com/facebookexperimental/Recoil/issues/41#issuecomment-629601674. We would be happy even if it's just released as an `_UNSTABLE` preview.