### PR TITLE
Updated typescript index.d.ts with typed key extending NodeKey

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -273,7 +273,7 @@ type Primitive = undefined | null | boolean | number | symbol | string;
 export type SerializableParam = Primitive | ReadonlyArray<SerializableParam> | Readonly<{[key: string]: SerializableParam}>;
 
 export interface AtomFamilyOptions<T, K extends NodeKey = NodeKey, P extends SerializableParam = SerializableParam> {
-  key: NodeKey;
+  key: K;
   dangerouslyAllowMutability?: boolean;
   default: RecoilValue<T, K> | Promise<T> | T | ((param: P) => T | RecoilValue<T, K> | Promise<T>);
   effects_UNSTABLE?: | ReadonlyArray<AtomEffect<T, K>> | ((param: P) => ReadonlyArray<AtomEffect<T, K>>);


### PR DESCRIPTION
I don't have the complete overview, and the bottom part doesn't look correctly typed, so maybe this is completely off, but like this I have typed keys if I pass it the function.

This will also result in a breaking change of the generic P type being after the newly implemented K type