### PR TITLE
Removed ES exports from Recoil OSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^3.6.11",
     "eslint": "^7.2.0",
-    "eslint-plugin-fb-www": "^1.0.2",
+    "eslint-plugin-fb-www": "^1.0.4",
     "eslint-plugin-flowtype": "^5.1.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",

--- a/src/core/Recoil_Retention.js
+++ b/src/core/Recoil_Retention.js
@@ -251,7 +251,7 @@ function scheduleOrPerformPossibleReleaseOfRetainable(
   }
 }
 
-export function updateRetainCount(
+function updateRetainCount(
   store: Store,
   retainable: Retainable,
   delta: 1 | -1,
@@ -269,7 +269,7 @@ export function updateRetainCount(
   }
 }
 
-export function releaseScheduledRetainablesNow(store: Store) {
+function releaseScheduledRetainablesNow(store: Store) {
   if (!gkx('recoil_memory_managament_2020')) {
     return;
   }
@@ -281,7 +281,13 @@ export function releaseScheduledRetainablesNow(store: Store) {
   state.retention.retainablesToCheckForRelease.clear();
 }
 
-export function retainedByOptionWithDefault(r: RetainedBy | void): RetainedBy {
+function retainedByOptionWithDefault(r: RetainedBy | void): RetainedBy {
   // The default will change from 'recoilRoot' to 'components' in the future.
   return r === undefined ? 'recoilRoot' : r;
 }
+
+module.exports = {
+  updateRetainCount,
+  releaseScheduledRetainablesNow,
+  retainedByOptionWithDefault,
+};

--- a/src/core/Recoil_RetentionZone.js
+++ b/src/core/Recoil_RetentionZone.js
@@ -11,8 +11,13 @@
 
 'use strict';
 
-export class RetentionZone {}
+class RetentionZone {}
 
-export function retentionZone(): RetentionZone {
+function retentionZone(): RetentionZone {
   return new RetentionZone();
 }
+
+module.exports = {
+  RetentionZone,
+  retentionZone,
+};

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -243,7 +243,6 @@ const testGKs = (
   {gks: additionalGKs = []}: TestOptions = {},
 ) => {
   test.each([
-    // [testDescription, []],
     ...[...gks, ...additionalGKs].map(gks => [
       !gks.length ? testDescription : `${testDescription} [${gks.join(', ')}]`,
       gks,
@@ -273,7 +272,7 @@ const WWW_GKS_TO_TEST = [
 
 // TODO Disable testing GKs in OSS until that infra is fixed
 // eslint-disable-next-line no-unused-vars
-const OSS_GKS_TO_TEST = [];
+const OSS_GKS_TO_TEST = [[]];
 
 const getRecoilTestFn = (reloadImports: ReloadImports): TestFn =>
   testGKs(

--- a/src/util/Recoil_mapSet.js
+++ b/src/util/Recoil_mapSet.js
@@ -18,7 +18,7 @@
  * "map" operation, in that the cardinality of the returned set may be less than
  * the cardinality of the starting set.
  */
-export default function mapSet<TValue, TValueOut>(
+function mapSet<TValue, TValueOut>(
   set: $ReadOnlySet<TValue>,
   callback: (value: TValue) => TValueOut,
 ): Set<TValueOut> {
@@ -28,3 +28,5 @@ export default function mapSet<TValue, TValueOut>(
   }
   return result;
 }
+
+module.exports = mapSet;

--- a/src/util/Recoil_someSet.js
+++ b/src/util/Recoil_someSet.js
@@ -15,7 +15,7 @@
  * The someSet() method tests whether some elements in the given Set pass the
  * test implemented by the provided function.
  */
-export default function someSet<T>(
+function someSet<T>(
   set: $ReadOnlySet<T>,
   callback: (value: T, key: T, set: $ReadOnlySet<T>) => boolean,
   context?: mixed,
@@ -31,3 +31,5 @@ export default function someSet<T>(
   }
   return false;
 }
+
+module.exports = someSet;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,10 +1951,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-fb-www@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.2.tgz#c4a9415e99e63d742c2495fc876f153152ae21d4"
-  integrity sha512-yZOCrEZwS/99a5frXFuTM3HyQvPkJN68Vpq846a4JBNcZpsoMgTNpHxRNClsO0eewEoCu8ifVcvWNcUZ6PcGsw==
+eslint-plugin-fb-www@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.4.tgz#8fb4beb4105e4e355582363bd4a199230eed26a4"
+  integrity sha512-m/XABkdtBcml2cTwDysQx/laAU1sAhwjaELP8X/RYY0CoKAQelYZvBHOF2Puc8sZlGNJy3cNnjZ48qYzgTIRqQ==
 
 eslint-plugin-flowtype@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
Summary: Using ES exports breaks Github CI. CommonJS exports must be used instead.

Differential Revision: D25924544

