### PR TITLE
eslint rule to warn on `@fb-only` and `@oss-only` comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,11 +3,18 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
  */
+
+const rulesDirPlugin = require('eslint-plugin-rulesdir');
+const path = require('path');
 
 const OFF = 0;
 const WARNING = 1;
 const ERROR = 2;
+
+rulesDirPlugin.RULES_DIR = path.resolve(__dirname, './eslint-rules');
 
 module.exports = {
   env: {
@@ -23,12 +30,13 @@ module.exports = {
     ecmaVersion: 11,
     sourceType: 'module',
   },
-  plugins: ['flowtype', 'react', 'jest', 'fb-www'],
+  plugins: ['flowtype', 'react', 'jest', 'fb-www', 'rulesdir'],
   rules: {
     strict: 0,
-    'jsx-a11y/href-no-hash': 'off',
-    'react/jsx-key': 'off',
-    'react/prop-types': 'off',
+    'jsx-a11y/href-no-hash': OFF,
+    'react/jsx-key': OFF,
+    'react/prop-types': OFF,
+    'rulesdir/no-fb-only': OFF,
   },
   settings: {
     react: {

--- a/eslint-rules/no-fb-only.js
+++ b/eslint-rules/no-fb-only.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// Simple eslint rule that warns on usage of `@fb-only` style comments.
+// These comments introduce a split point where code behaves differently
+// depending on whether it's run at facebook or in OSS and it's very difficult
+// to debug, especially if the person working on that code does not have access
+// to facebook's internal code. To minimize that complexity all of these split
+// points should be defined in one place and dependency injected in Recoil
+// at runtime.
+
+const regexps = [
+  [/^.*(@fb-only).*$/, '@fb-only'],
+  [/^.*(@oss-only).*$/, '@oss-only'],
+];
+
+// If a file paths matches any of provided regular expressions it will be
+// excluded from this lint rule.
+const excludePaths = [/.*eslint-rules.*/];
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow @fb-only style comments',
+    },
+  },
+  create: function (context) {
+    return {
+      // Only match the top level `Program` AST node that represents the entire file.
+      Program: function (node) {
+        const lines = context.getSourceCode().text.split('\n');
+        const filename = context.getFilename();
+
+        if (excludePaths.some(r => r.test(filename))) {
+          return;
+        }
+
+        lines.forEach((line, lineNumber) => {
+          for (const [regexp, descriptor] of regexps) {
+            const match = line.match(regexp);
+
+            if (match) {
+              context.report({
+                message:
+                  `Usage of "${descriptor}". Please consider depenedncy injecting this condition ` +
+                  `instead. See "${__filename}" for more details`,
+                loc: {
+                  start: {line: lineNumber + 1, column: 0},
+                  end: {line: lineNumber + 1, column: line.length - 1},
+                },
+              });
+            }
+          }
+        });
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-flowtype": "^5.1.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",
+    "eslint-plugin-rulesdir": "^0.1.0",
     "flow-bin": "^0.129.0",
     "gen-flow-files": "^0.4.11",
     "husky": ">=4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,6 +1986,11 @@ eslint-plugin-react@^7.20.0:
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
 
+eslint-plugin-rulesdir@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz#ad144d7e98464fda82963eff3fab331aecb2bf08"
+  integrity sha1-rRRNfphGT9qClj7/P6szGuyyvwg=
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"


### PR DESCRIPTION
I'm trying to investigate how to better decouple Recoil from internal infra, and the first step is figuring out where we execute the code conditionally depending on whether we're running it at FB or not.

This lint rule highlights all usages of `@fb-only` and `@oss-only`. It is disabled for now, but i'll be using it to identify and move out all these forks.

![Screen Shot 2021-01-19 at 3 37 39 PM](https://user-images.githubusercontent.com/940133/105096664-0b276b80-5a6d-11eb-9250-701d197f75d9.png)
![Screen Shot 2021-01-19 at 3 37 45 PM](https://user-images.githubusercontent.com/940133/105096668-0e225c00-5a6d-11eb-98f8-ec4dbea15aea.png)
