### PR TITLE
Avoid freezing Errors

### DIFF
--- a/src/util/Recoil_deepFreezeValue.js
+++ b/src/util/Recoil_deepFreezeValue.js
@@ -52,6 +52,10 @@ function shouldNotBeFrozen(value: mixed): boolean {
     return true;
   }
 
+  if (value instanceof Error) {
+    return true;
+  }
+
   if (ArrayBuffer.isView(value)) {
     return true;
   }

--- a/src/util/__tests__/Recoil_deepFreezeValue-test.js
+++ b/src/util/__tests__/Recoil_deepFreezeValue-test.js
@@ -13,6 +13,20 @@
 const deepFreezeValue = require('../Recoil_deepFreezeValue');
 
 describe('deepFreezeValue', () => {
+  test('Do not freeze Promises', () => {
+    const obj = {test: new Promise(() => {})};
+    deepFreezeValue(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+    expect(Object.isFrozen(obj.test)).toBe(false);
+  });
+
+  test('Do not freeze Errors', () => {
+    const obj = {test: new Error()};
+    deepFreezeValue(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+    expect(Object.isFrozen(obj.test)).toBe(false);
+  });
+
   test('check no error: object with ArrayBufferView property', () => {
     expect(() => deepFreezeValue({test: new Int8Array(4)})).not.toThrow();
     expect(() => deepFreezeValue({test: new Uint8Array(4)})).not.toThrow();


### PR DESCRIPTION
Summary: Avoid freezing `Error` objects.  They are usually encountered when thrown by selectors.  This can disrupt environments which expect mutable Errors.  Freezing is intended to help catch issues with users changing state by mutating objects and errors are not usually mutated to reflect state changes anyway.

Differential Revision: D26090167

