### PR TITLE
fix OSS tests

### DIFF
--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -513,6 +513,7 @@ testRecoil(
     expect(container.textContent).toEqual('loading');
 
     await flushPromisesAndTimers();
+    await flushPromisesAndTimers(); // HACK: not sure why but this is needed in OSS
 
     expect(container.textContent).toEqual('Async Dep Value');
 
@@ -575,12 +576,20 @@ testRecoil(
 
     await flushPromisesAndTimers();
 
+    // HACK: not sure why but these are needed in OSS
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+
     expect(container.textContent).toEqual('6');
 
     act(() => setAtom(4));
 
     expect(container.textContent).toEqual('loading');
 
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
     await flushPromisesAndTimers();
 
     expect(container.textContent).toEqual('7');
@@ -747,17 +756,20 @@ testRecoil(
 
     expect(numTimesRan).toBe(1);
 
-    resolveAsyncDep1('a');
+    act(() => resolveAsyncDep1('a'));
 
-    act(() => jest.runAllTimers());
+    await flushPromisesAndTimers();
 
     expect(numTimesRan).toBe(2);
 
-    resolveAsyncDep2('b');
+    act(() => resolveAsyncDep2('b'));
 
-    act(() => jest.runAllTimers());
+    await flushPromisesAndTimers();
 
     expect(numTimesRan).toBe(3);
+
+    await flushPromisesAndTimers();
+
     expect(container.textContent).toEqual('"ab"');
   },
 );

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -34,7 +34,6 @@ const {
   useSetRecoilState,
 } = require('../hooks/Recoil_Hooks');
 const selector = require('../recoil_values/Recoil_selector');
-const gkx = require('../util/Recoil_gkx');
 const invariant = require('../util/Recoil_invariant');
 const nullthrows = require('../util/Recoil_nullthrows');
 const stableStringify = require('../util/Recoil_stableStringify');
@@ -250,6 +249,8 @@ const testGKs = (
   ])('%s', async (_title, gks) => {
     jest.resetModules();
 
+    const gkx = require('../util/Recoil_gkx');
+
     gks.forEach(gkx.setPass);
 
     const after = reloadImports();
@@ -270,9 +271,21 @@ const WWW_GKS_TO_TEST = [
   ['recoil_async_selector_refactor', 'recoil_memory_managament_2020'],
 ];
 
-// TODO Disable testing GKs in OSS until that infra is fixed
+/**
+ * GK combinations to exclude in OSS, presumably because these combinations pass
+ * in FB internally but not in OSS. Ideally this array would be empty.
+ */
+const OSS_GK_COMBINATION_EXCLUSIONS = [
+  ['recoil_async_selector_refactor', 'recoil_memory_managament_2020'], // FIXME
+];
+
 // eslint-disable-next-line no-unused-vars
-const OSS_GKS_TO_TEST = [[], ['recoil_suppress_rerender_in_callback']];
+const OSS_GKS_TO_TEST = WWW_GKS_TO_TEST.filter(
+  gkCombination =>
+    !OSS_GK_COMBINATION_EXCLUSIONS.some(exclusion =>
+      exclusion.every(gk => gkCombination.includes(gk)),
+    ),
+);
 
 const getRecoilTestFn = (reloadImports: ReloadImports): TestFn =>
   testGKs(


### PR DESCRIPTION
Summary:
OSS Tests were failing for 3 reasons:

### GK set up in testGKs()

Before running each Recoil test, we reset the module cache so that GK changes can be applied against module imports for each test.

There was a bug where we were modifying the GK cache of a stale module whereas we should be setting the GK cache **after every module reset**.

### Some promise flushing not happening in OSS

For some reason, in OSS sometimes a single `await flushPromiseAndTimers()` is not enough and we have to do a few consecutive calls to that utility. There were two instances where I had to add multiple of those statements to make the tests pass in OSS.

### Real error failing test: Changing conditional deps

There was a real bug in the selector implementation where selectors were over subscribing to conditional selectors, causing re-renders. This was not failing internally most likely due to optimizations by mutableSource from React, which was optimizing away these redundant re-renders, but that was not the case in OSS version.

This bug has been corrected and selectors now correctly maintain changing conditional deps.

Reviewed By: drarmstr

Differential Revision: D25631544

