### PR TITLE
fix last failing OSS test

### DIFF
--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -1035,6 +1035,14 @@ describe('Async selector resolution notifies all stores that read pending', () =
       const query = useRecoilValueLoadable(shouldQuery ? selectorB : selectorA);
 
       doIt = useRecoilCallback(({snapshot, set}) => () => {
+        /**
+         * this is required as we need the selector accessed below to outlive
+         * the end of this callback so that the async resolution notifies the
+         * store of the resolution and a re-render is triggered. Otherwise, the
+         * selector will be cleaned up at the end of the callback, meaning the
+         * resolution of the selector will not result in a re-render.
+         */
+        snapshot.retain();
         snapshot.getLoadable(selectorB); // cause query to be triggered in context of snapshot store
         set(switchAtom, true); // cause us to then read from the pending selector
       });

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -275,9 +275,7 @@ const WWW_GKS_TO_TEST = [
  * GK combinations to exclude in OSS, presumably because these combinations pass
  * in FB internally but not in OSS. Ideally this array would be empty.
  */
-const OSS_GK_COMBINATION_EXCLUSIONS = [
-  ['recoil_async_selector_refactor', 'recoil_memory_managament_2020'], // FIXME
-];
+const OSS_GK_COMBINATION_EXCLUSIONS = [];
 
 // eslint-disable-next-line no-unused-vars
 const OSS_GKS_TO_TEST = WWW_GKS_TO_TEST.filter(


### PR DESCRIPTION
Summary:
The final remaining failing test in OSS was regarding selector_NEW and the new memory management changes that recently went in behind a GK. The combination of selector_NEW GK and the memory management GK was making a test fail.

After meeting with davidmccabe and he walked me through memory management changes it turned out the test is supposed to fail (not sure why it's not failing internally), so the behavior is actually as expected in OSS.

The TLDR; of the test is that under the new memory management changes, selectors read in a Recoil callback synchronously will be cleaned up when the callback finishes executing, meaning any async selector that resolves after the end of the callback will not result in a re-render. The fix is to use the new `Snapshot.retain()` to signal that we want to keep the snapshot alive past the end of the Recoil callback.

Differential Revision: D26152627

