### PR TITLE
add missing GK combination to recoil testing

### DIFF
--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -269,6 +269,7 @@ const WWW_GKS_TO_TEST = [
   ['recoil_hamt_2020'],
   ['recoil_memory_managament_2020'],
   ['recoil_async_selector_refactor', 'recoil_memory_managament_2020'],
+  ['recoil_async_selector_refactor', 'recoil_hamt_2020'],
 ];
 
 /**


### PR DESCRIPTION
Summary: I noticed we weren't testing selector_new and recoil_hamt_2020 together in GK combinations, which may or may not be significant, but is important as there's a few tests that **only** run when the selector_new GK is on, so for the time being all GK combinations should contain `recoil_async_selector_refactor`

Reviewed By: drarmstr

Differential Revision: D26113572

