### PR TITLE
Add error message for useRecoilCallback() misuse

### DIFF
--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -811,7 +811,13 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
       let ret = SENTINEL;
       batchUpdates(() => {
         // flowlint-next-line unclear-type:off
-        ret = (fn: any)({set, reset, snapshot, gotoSnapshot})(...args);
+        const cb = (fn: any)({set, reset, snapshot, gotoSnapshot});
+        if (typeof cb !== 'function') {
+          throw new Error(
+            'useRecoilCallback() accepts a function parameter which returns a function that matches the signature of the callback function.',
+          );
+        }
+        ret = cb(...args);
       });
       invariant(
         !(ret instanceof Sentinel),


### PR DESCRIPTION
Summary:
Add a slightly better error message when `useRecoilCallback()` is misused when a user calls it with a function that just returns a value instead a function that takes the callback interface and returns a function that matches the signature of the callback we are producing.

Before: `Uncaught TypeError: fn(...) is not a function`
After: `Uncaught Error: useRecoilCallback() accepts a function parameter which returns a function that matches the signature of the callback function.`

Flow and TypeScript will catch this, but this runtime check may help those not using a type system. (#851)

Differential Revision: D26219475

