### PR TITLE
Allow toJSON types to be used with atomFamily and selectorFamily

### DIFF
--- a/src/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -148,6 +148,18 @@ testRecoil('Works with parameterized default', () => {
   expect(get(paramDefaultAtom({num: 2}))).toBe(2);
 });
 
+testRecoil('Works with date as parameter', () => {
+  const dateAtomFamily = atomFamily({
+    key: 'dateFamily',
+    default: date => 0,
+  });
+  expect(get(dateAtomFamily(new Date(2021, 2, 25)))).toBe(0);
+  expect(get(dateAtomFamily(new Date(2021, 2, 26)))).toBe(0);
+  set(dateAtomFamily(new Date(2021, 2, 25)), 1);
+  expect(get(dateAtomFamily(new Date(2021, 2, 25)))).toBe(1);
+  expect(get(dateAtomFamily(new Date(2021, 2, 26)))).toBe(0);
+});
+
 testRecoil('Works with parameterized fallback', () => {
   const fallbackAtom = atomFamily({
     key: 'parameterized fallback default',

--- a/src/recoil_values/__tests__/Recoil_selectorFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_selectorFamily-test.js
@@ -92,6 +92,25 @@ testRecoil('selectorFamily - object parameter', () => {
   expect(getValue(mySelector({multiplier: 100}))).toBe(200);
 });
 
+testRecoil('selectorFamily - date parameter', () => {
+  const mySelector = selectorFamily({
+    key: 'selectorFamily/date',
+    get: date => ({get}) => {
+      const daysToAdd = get(myAtom);
+      const returnDate = new Date(date);
+
+      returnDate.setDate(returnDate.getDate() + daysToAdd);
+
+      return returnDate;
+    },
+  });
+
+  set(myAtom, 1);
+  expect(getValue(mySelector(new Date(2021, 2, 25))).getDate()).toBe(26);
+  set(myAtom, 2);
+  expect(getValue(mySelector(new Date(2021, 2, 25))).getDate()).toBe(27);
+});
+
 testRecoil('Works with supersets', () => {
   const mySelector = selectorFamily({
     key: 'selectorFamily/supersets',

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -270,7 +270,11 @@ export function isRecoilValue(val: unknown): val is RecoilValue<any>; // eslint-
 // bigint not supported yet
 type Primitive = undefined | null | boolean | number | symbol | string;
 
-export type SerializableParam = Primitive | ReadonlyArray<SerializableParam> | Readonly<{[key: string]: SerializableParam}>;
+export type SerializableParam =
+  | Primitive
+  | {toJSON: () => string }
+  | ReadonlyArray<SerializableParam>
+  | Readonly<{[key: string]: SerializableParam}>;
 
 export interface AtomFamilyOptions<T, P extends SerializableParam> {
   key: NodeKey;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -272,6 +272,12 @@ isRecoilValue(mySelector1);
     get: (param: ReadonlyArray<number>) => () => [...param, 9],
   });
   mySelectorFamArray([1, 2, 3]);
+
+  const myJsonSerializableSelectorFam = selectorFamily({
+    key: 'mySelectorFam1',
+    get: (param: {from: Date, to: Date}) => () => (+param.from) - (+param.to),
+  });
+  myJsonSerializableSelectorFam({ from: new Date(), to: new Date() });
 }
 
 /**


### PR DESCRIPTION
This allows such use cases as using Date as params for a family, e.g. if you want to create a time slice of a range of data.
This fixes #760 