### PR TITLE
Allow JSON serializable objects for family params

### DIFF
--- a/src/recoil_values/Recoil_atomFamily.js
+++ b/src/recoil_values/Recoil_atomFamily.js
@@ -31,8 +31,9 @@ const selectorFamily = require('./Recoil_selectorFamily');
 type Primitive = void | null | boolean | number | string;
 export type Parameter =
   | Primitive
+  | {toJSON: () => string, ...}
   | $ReadOnlyArray<Parameter>
-  | $ReadOnly<{[string]: Parameter, ...}>;
+  | $ReadOnly<{[string]: Parameter}>;
 
 // flowlint unclear-type:off
 export type ParameterizedScopeRules<P> = $ReadOnlyArray<

--- a/src/recoil_values/Recoil_selectorFamily.js
+++ b/src/recoil_values/Recoil_selectorFamily.js
@@ -32,14 +32,13 @@ const selector = require('./Recoil_selector');
 
 // Keep in mind the parameter needs to be serializable as a cahche key
 // using Recoil_stableStringify
+type Primitive = void | null | boolean | number | string;
 export type Parameter =
-  | void
-  | null
-  | boolean
-  | number
-  | string
-  | $ReadOnly<{...}>
-  | $ReadOnlyArray<mixed>;
+  | Primitive
+  | {toJSON: () => string, ...}
+  | $ReadOnlyArray<Parameter>
+  | $ReadOnly<{...}>;
+// | $ReadOnly<{[string]: Parameter}>; // TODO Better enforce object is serializable
 
 type ReadOnlySelectorFamilyOptions<T, P: Parameter> = $ReadOnly<{
   key: string,


### PR DESCRIPTION
Summary:
Update the Flow typing to allow for JSON-serializable objects (via a `toJSON()` method) to be used for `atomFamily()` and `selectorFamliy()`.  This allows for `Date` objects to be used for family parameters.

NOTE: This extends #896 which was for TypeScript for Flow.

Differential Revision: D26651027

