### PR TITLE
Remove non-top-level function declaration in selector to conform to ES5 strict mode

### DIFF
--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -993,7 +993,11 @@ function selector<T>(
   }
 
   if (set != null) {
-    function selectorSet(store, state, newValue): AtomWrites {
+    /**
+     * ES5 strict mode prohibits defining non-top-level function declarations,
+     * so don't use function declaration syntax here
+     */
+    const selectorSet = (store, state, newValue): AtomWrites => {
       let syncSelectorSetFinished = false;
       const writes: AtomWrites = new Map();
 
@@ -1065,7 +1069,7 @@ function selector<T>(
       syncSelectorSetFinished = true;
 
       return writes;
-    }
+    };
 
     return registerNode<T>({
       key,

--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -588,6 +588,8 @@ function selector<T>(
         ? getNodeLoadable(store, state, depKey)
         : getCachedNodeLoadable(store, state, depKey);
 
+      maybeFreezeLoadableContents(depLoadable);
+
       depValues.set(depKey, depLoadable);
 
       if (depLoadable.state === 'hasValue') {
@@ -1003,6 +1005,8 @@ function selector<T>(
         }
 
         const loadable = getCachedNodeLoadable(store, state, key);
+
+        maybeFreezeLoadableContents(loadable);
 
         if (loadable.state === 'hasValue') {
           return loadable.contents;

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -1306,3 +1306,60 @@ testRecoil(
     expect(val).toBe('AB');
   },
 );
+
+testRecoil('selectors cannot mutate values in get() or set()', () => {
+  const devStatus = window.__DEV__;
+  window.__DEV__ = true;
+
+  const userState = atom({
+    key: 'userState',
+    default: {
+      name: 'john',
+      address: {
+        road: '103 road',
+        nested: {
+          value: 'someNestedValue',
+        },
+      },
+    },
+  });
+
+  const userSelector = selector({
+    key: 'userSelector',
+    get: ({get}) => {
+      const user = get(userState);
+
+      user.address.road = '301 road';
+
+      return user;
+    },
+    set: ({set, get}) => {
+      const user = get(userState);
+
+      user.address.road = 'narrow road';
+
+      return set(userState, user);
+    },
+  });
+
+  const testSnapshot = freshSnapshot();
+  testSnapshot.retain();
+
+  // expect(() =>
+  //   testSnapshot.map(({set}) => {
+  //     set(userSelector, {
+  //       name: 'matt',
+  //       address: {
+  //         road: '103 road',
+  //         nested: {
+  //           value: 'someNestedValue',
+  //         },
+  //       },
+  //     });
+  //   }),
+  // ).toThrow();
+
+  expect(testSnapshot.getLoadable(userSelector).state).toBe('hasError');
+
+  window.__DEV__ = devStatus;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -995,10 +995,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
-  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
+"@types/react@>=16.13.1":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
+  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -4022,7 +4022,7 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-react-dom@^17.0.0:
+react-dom@>=16.13.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
   integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
@@ -4035,7 +4035,7 @@ react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
 
-"react@^16.13.1 || ^17.0.0":
+react@>=16.13.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==


### PR DESCRIPTION
Summary:
Fixes #609

ES5 strict mode prohibits the use of function declarations in non-top-level positions. This was causing an error for user in #609

Differential Revision: D26773510

