### PR TITLE
Prevent notifyBatcherOfChange from updating state after a Batcher is unmounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added useGetRecoilValueInfo_UNSTABLE() hook for dev tools. (#713, #714)
 - Bug Fix: Ensuring that throwing non Error (and non Promise) objects is supported and puts the selector into a hasError state
 - Changed semantics of waitForAny() such that it will always return loadables unless everything is loading. This better aligns behaviour of waitForAny() and waitForNone()
+- Bug Fix: Ensured that the Batcher (within RecoilRoot) cannot have its state updated after it is unmounted. (#917)
 
 ## 0.1.2 (2020-10-30)
 


### PR DESCRIPTION
Summary:
This sets `notifyBatcherOfChange` to an empty function when Batcher unmounts.

Previously, if you unmounted RecoilRoot when an asynchronous selector was still pending, `notifyBatcherOfChange` on line 383 would be called after Batcher was already unmounted, causing the following error to be thrown: "Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application."

Fixes #897

Differential Revision: D26895327

