### PR TITLE
fix build script error of docs site

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -146,5 +146,4 @@ module.exports = {
       },
     ],
   ],
-  plugins: ['@docusaurus/plugin-google-analytics'],
 };


### PR DESCRIPTION
Got this message from `yarn build`

```
error building locale=en
Error: Plugin docusaurus-plugin-google-analytics is used 2 times with id=default.
To use the same plugin multiple times on a Docusaurus site, you need to assign a unique id to each plugin instance.
    at /Users/mengdi/workspace/github/Recoil/docs/node_modules/@docusaurus/core/lib/server/plugins/pluginIds.js:20:23
```

We didn't have this before -- might be a result of upgrading docusaurus in #932 

According to https://github.com/facebook/docusaurus/issues/3632#issuecomment-716596075
> If you use the classic preset with googleAnalytics themeConfig, you already use the google analytics plugin, as it's included in the preset.
we should remove the GA plugin from our config file to resolve this.
After removing this line, the build is successful, and we can still find GA script in index.html output.
