### PR TITLE
Fix OSS build, enable hamt in OSS

### DIFF
--- a/src/caches/Recoil_LRUCache.js
+++ b/src/caches/Recoil_LRUCache.js
@@ -154,4 +154,4 @@ class LRUCache<K = mixed, V = mixed> {
   }
 }
 
-module.exports = LRUCache;
+module.exports = {LRUCache};

--- a/src/caches/Recoil_MapCache.js
+++ b/src/caches/Recoil_MapCache.js
@@ -46,4 +46,4 @@ class MapCache<K, V> {
   }
 }
 
-module.exports = MapCache;
+module.exports = {MapCache};

--- a/src/caches/Recoil_TreeCache.js
+++ b/src/caches/Recoil_TreeCache.js
@@ -256,4 +256,4 @@ const countDownstreamLeaves = <T>(node: TreeCacheNode<T>): number =>
         0,
       );
 
-module.exports = TreeCache;
+module.exports = {TreeCache};

--- a/src/caches/Recoil_cacheFromPolicy.js
+++ b/src/caches/Recoil_cacheFromPolicy.js
@@ -17,8 +17,8 @@ import type {
 
 const nullthrows = require('../util/Recoil_nullthrows');
 const stableStringify = require('../util/Recoil_stableStringify');
-const LRUCache = require('./Recoil_LRUCache');
-const MapCache = require('./Recoil_MapCache');
+const {LRUCache} = require('./Recoil_LRUCache');
+const {MapCache} = require('./Recoil_MapCache');
 
 const defaultPolicy = {
   equality: 'reference',

--- a/src/caches/Recoil_treeCacheFromPolicy.js
+++ b/src/caches/Recoil_treeCacheFromPolicy.js
@@ -17,7 +17,7 @@ import type {TreeCacheImplementation} from './Recoil_TreeCacheImplementationType
 
 const nullthrows = require('../util/Recoil_nullthrows');
 const stableStringify = require('../util/Recoil_stableStringify');
-const TreeCache = require('./Recoil_TreeCache');
+const {TreeCache} = require('./Recoil_TreeCache');
 const treeCacheLRU = require('./Recoil_treeCacheLRU');
 
 const defaultPolicy = {

--- a/src/caches/Recoil_treeCacheLRU.js
+++ b/src/caches/Recoil_treeCacheLRU.js
@@ -10,8 +10,8 @@
 
 import type {TreeCacheImplementation} from './Recoil_TreeCacheImplementationType';
 
-const LRUCache = require('./Recoil_LRUCache');
-const TreeCache = require('./Recoil_TreeCache');
+const {LRUCache} = require('./Recoil_LRUCache');
+const {TreeCache} = require('./Recoil_TreeCache');
 
 function treeCacheLRU<T>(
   maxSize: number,

--- a/src/caches/__tests__/Recoil_LRUCache-test.js
+++ b/src/caches/__tests__/Recoil_LRUCache-test.js
@@ -16,7 +16,7 @@ const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 let LRUCache;
 
 const testRecoil = getRecoilTestFn(() => {
-  LRUCache = require('../Recoil_LRUCache');
+  ({LRUCache} = require('../Recoil_LRUCache'));
 });
 
 describe('LRUCache', () => {

--- a/src/caches/__tests__/Recoil_MapCache-test.js
+++ b/src/caches/__tests__/Recoil_MapCache-test.js
@@ -13,7 +13,7 @@ const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 let MapCache;
 
 const testRecoil = getRecoilTestFn(() => {
-  MapCache = require('../Recoil_MapCache');
+  ({MapCache} = require('../Recoil_MapCache'));
 });
 
 describe('MapCache', () => {

--- a/src/caches/__tests__/Recoil_TreeCache-test.js
+++ b/src/caches/__tests__/Recoil_TreeCache-test.js
@@ -16,7 +16,7 @@ const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 let TreeCache, loadableWithValue, nullthrows;
 
 const testRecoil = getRecoilTestFn(() => {
-  TreeCache = require('../Recoil_TreeCache');
+  ({TreeCache} = require('../Recoil_TreeCache'));
   nullthrows = require('../../util/Recoil_nullthrows');
   ({loadableWithValue} = require('../../adt/Recoil_Loadable'));
 });

--- a/src/util/Recoil_gkx.js
+++ b/src/util/Recoil_gkx.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const gks = new Map();
+const gks = new Map().set('recoil_hamt_2020', true);
 
 function Recoil_gkx(gk: string): boolean {
   return gks.get(gk) ?? false;


### PR DESCRIPTION
Summary:
Fix OSS build by removing default exports of classes.

Turn on HAMT GK in OSS for 0.2 release.

Differential Revision: D27235843

