### PR TITLE
[Docs]: Add missing 'const' in 'userRefreshInfo' function

### DIFF
--- a/docs/docs/guides/asynchronous-data-queries.md
+++ b/docs/docs/guides/asynchronous-data-queries.md
@@ -341,7 +341,7 @@ const userInfoQuery = selectorFamily({
 });
 
 function useRefreshUserInfo(userID) {
-  setUserInfoQueryRequestID = useSetRecoilState(userInfoQueryRequestIDState(userID));
+  const setUserInfoQueryRequestID = useSetRecoilState(userInfoQueryRequestIDState(userID));
   return () => {
     setUserInfoQueryRequestID(requestID => requestID + 1);
   };


### PR DESCRIPTION
The missing, declaration is in the Use a Request Id section of the docs.