### PR TITLE
Remove non-top-level function declaration in selector to conform to ES5 strict mode

### DIFF
--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -995,7 +995,11 @@ function selector<T>(
   }
 
   if (set != null) {
-    function selectorSet(store, state, newValue): AtomWrites {
+    /**
+     * ES5 strict mode prohibits defining non-top-level function declarations,
+     * so don't use function declaration syntax here
+     */
+    const selectorSet = (store, state, newValue): AtomWrites => {
       let syncSelectorSetFinished = false;
       const writes: AtomWrites = new Map();
 
@@ -1065,7 +1069,7 @@ function selector<T>(
       syncSelectorSetFinished = true;
 
       return writes;
-    }
+    };
 
     return registerNode<T>({
       key,


### PR DESCRIPTION
Summary:
Fixes #609
ES5 strict mode prohibits the use of function declarations in non-top-level positions. This was causing an error for user in #609

Reviewed By: drarmstr

Differential Revision: D27758899

