### PR TITLE
Add override prop to RecoilRoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - (Add new changes here as they land)
 - Improved TypeScript and Flow typing for `Loadable`s (#966)
+- Added override prop to RecoilRoot
 
 ## 0.2.0 (2021-3-18)
 

--- a/src/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/src/core/__tests__/Recoil_RecoilRoot-test.js
@@ -12,6 +12,7 @@ import type {Store} from '../Recoil_State';
 const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 
 let React,
+  useState,
   ReactDOM,
   act,
   useSetRecoilState,
@@ -19,12 +20,14 @@ let React,
   constSelector,
   selector,
   ReadsAtom,
+  componentThatReadsAndWritesAtom,
   renderElements,
   RecoilRoot,
   useStoreRef;
 
 const testRecoil = getRecoilTestFn(() => {
   React = require('react');
+  ({useState} = require('react'));
   ReactDOM = require('ReactDOM');
   ({act} = require('ReactTestUtils'));
 
@@ -32,7 +35,11 @@ const testRecoil = getRecoilTestFn(() => {
   atom = require('../../recoil_values/Recoil_atom');
   constSelector = require('../../recoil_values/Recoil_constSelector');
   selector = require('../../recoil_values/Recoil_selector');
-  ({ReadsAtom, renderElements} = require('../../testing/Recoil_TestingUtils'));
+  ({
+    ReadsAtom,
+    componentThatReadsAndWritesAtom,
+    renderElements,
+  } = require('../../testing/Recoil_TestingUtils'));
   ({RecoilRoot} = require('../Recoil_RecoilRoot.react'));
   ({useStoreRef} = require('../Recoil_RecoilRoot.react'));
 });
@@ -222,3 +229,129 @@ testRecoil(
     ).toThrow('pure function');
   },
 );
+
+describe('override prop', () => {
+  testRecoil(
+    'RecoilRoots create a new Recoil scope when override is true or undefined',
+    () => {
+      const myAtom = atom({
+        key: 'RecoilRoot/override/atom',
+        default: 'DEFAULT',
+      });
+
+      const [ReadsWritesAtom, setAtom] = componentThatReadsAndWritesAtom(
+        myAtom,
+      );
+
+      const container = renderElements(
+        <RecoilRoot>
+          <ReadsAtom atom={myAtom} />
+          <RecoilRoot>
+            <ReadsWritesAtom />
+          </RecoilRoot>
+        </RecoilRoot>,
+      );
+
+      expect(container.textContent).toEqual('"DEFAULT""DEFAULT"');
+
+      act(() => setAtom('SET'));
+      expect(container.textContent).toEqual('"DEFAULT""SET"');
+    },
+  );
+
+  testRecoil(
+    'A RecoilRoot performs no function if override is false and it has an ancestor RecoilRoot',
+    () => {
+      const myAtom = atom({
+        key: 'RecoilRoot/override/atom',
+        default: 'DEFAULT',
+      });
+
+      const [ReadsWritesAtom, setAtom] = componentThatReadsAndWritesAtom(
+        myAtom,
+      );
+
+      const container = renderElements(
+        <RecoilRoot>
+          <ReadsAtom atom={myAtom} />
+          <RecoilRoot override={false}>
+            <ReadsAtom atom={myAtom} />
+            <RecoilRoot override={false}>
+              <ReadsWritesAtom />
+            </RecoilRoot>
+          </RecoilRoot>
+        </RecoilRoot>,
+      );
+
+      expect(container.textContent).toEqual('"DEFAULT""DEFAULT""DEFAULT"');
+
+      act(() => setAtom('SET'));
+      expect(container.textContent).toEqual('"SET""SET""SET"');
+    },
+  );
+
+  testRecoil(
+    'Unmounting a nested RecoilRoot with override set to false does not clean up ancestor Recoil atoms',
+    () => {
+      const myAtom = atom({
+        key: 'RecoilRoot/override/atom',
+        default: 'DEFAULT',
+      });
+
+      const [ReadsWritesAtom, setAtom] = componentThatReadsAndWritesAtom(
+        myAtom,
+      );
+
+      let setRenderNestedRoot;
+      const NestedRootContainer = () => {
+        const [renderNestedRoot, _setRenderNestedRoot] = useState(true);
+        setRenderNestedRoot = _setRenderNestedRoot;
+        return (
+          renderNestedRoot && (
+            <RecoilRoot override={false}>
+              <ReadsWritesAtom />
+            </RecoilRoot>
+          )
+        );
+      };
+
+      const container = renderElements(
+        <RecoilRoot>
+          <ReadsAtom atom={myAtom} />
+          <NestedRootContainer />
+        </RecoilRoot>,
+      );
+
+      expect(container.textContent).toEqual('"DEFAULT""DEFAULT"');
+
+      act(() => setAtom('SET'));
+      act(() => setRenderNestedRoot(false));
+      expect(container.textContent).toEqual('"SET"');
+    },
+  );
+
+  testRecoil(
+    'A RecoilRoot functions normally if override is false and it does not have an ancestor RecoilRoot',
+    () => {
+      const myAtom = atom({
+        key: 'RecoilRoot/override/atom',
+        default: 'DEFAULT',
+      });
+
+      const [ReadsWritesAtom, setAtom] = componentThatReadsAndWritesAtom(
+        myAtom,
+      );
+
+      const container = renderElements(
+        <RecoilRoot override={false}>
+          <ReadsWritesAtom />
+        </RecoilRoot>,
+      );
+
+      expect(container.textContent).toEqual('"DEFAULT"');
+
+      act(() => setAtom('SET'));
+      expect(container.textContent).toEqual('"SET"');
+    },
+  );
+});

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -17,9 +17,10 @@ export class DefaultValue {
 }
 
 // recoilRoot.d.ts
-export interface RecoilRootProps {
-  initializeState?: (mutableSnapshot: MutableSnapshot) => void;
-}
+export type RecoilRootProps = {
+  initializeState?: (mutableSnapshot: MutableSnapshot) => void,
+  override?: true,
+} | {override: false}
 
 export const RecoilRoot: React.FC<RecoilRootProps>;
 

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -88,6 +88,8 @@ RecoilRoot({
     set(writeableSelector, new DefaultValue());
   },
 });
+RecoilRoot({override: true});
+RecoilRoot({override: false});
 
 // Loadable
 function loadableTest(loadable: Loadable<number>) {


### PR DESCRIPTION
Summary: If `override` is set to false, a RecoilRoot will perform no function if nested within another RecoilRoot.

Differential Revision: D27737880

