### PR TITLE
Avoid calling onSet() when setSelf() initializes with a Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - (Add new changes here as they land)
 - Improved TypeScript and Flow typing for `Loadable`s (#966)
 - Added override prop to RecoilRoot
+- Fix not calling onSet() handler triggered from a setSelf() in onSet() for Atom Effects (#974, #979)
 
 ## 0.2.0 (2021-3-18)
 

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -258,6 +258,13 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
               ? // cast to any because we can't restrict T from being a function without losing support for opaque types
                 (valueOrUpdater: any)(currentValue) // flowlint-line unclear-type:off
               : valueOrUpdater;
+          // Avoid calling onSet() when setSelf() initializes with a Promise
+          if (isPromise(initValue)) {
+            initValue = initValue.then(value => {
+              pendingSetSelf = {effect, value};
+              return value;
+            });
+          }
         } else {
           if (isPromise(valueOrUpdater)) {
             throw new Error(

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -322,10 +322,9 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
               pendingSetSelf?.value !== newValue
             ) {
               handler(newValue, oldValue);
+            } else if (pendingSetSelf?.effect === effect) {
+              pendingSetSelf = null;
             }
-          }
-          if (pendingSetSelf?.effect === effect) {
-            pendingSetSelf = null;
           }
         }, key);
       };

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -418,6 +418,12 @@ describe('Effects', () => {
               resolveAtom = resolve;
             }),
           );
+          onSet(() => {
+            // onSet() should not be called for this hook's setSelf()
+            expect(false).toBe(true);
+          });
+        },
+        ({onSet}) => {
           onSet(value => {
             expect(value).toEqual('RESOLVE');
             validated = true;
@@ -435,6 +441,38 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('"RESOLVE"');
     expect(validated).toEqual(true);
   });
+
+  testRecoil(
+    'when setSelf is called in onSet, then onSet is not triggered again',
+    () => {
+      let set1 = false;
+      const valueToSet1 = 'value#1';
+      const transformedBySetSelf = 'transformed after value#1';
+
+      const myAtom = atom({
+        key: 'atom setSelf with set-updater',
+        default: 'DEFAULT',
+        effects_UNSTABLE: [
+          ({setSelf, onSet}) => {
+            onSet(newValue => {
+              expect(set1).toBe(false);
+              if (newValue === valueToSet1) {
+                setSelf(transformedBySetSelf);
+                set1 = true;
+              }
+            });
+          },
+        ],
+      });
+
+      const [ReadsWritesAtom, set] = componentThatReadsAndWritesAtom(myAtom);
+
+      const c = renderElements(<ReadsWritesAtom />);
+      expect(c.textContent).toEqual('"DEFAULT"');
+      act(() => set(valueToSet1));
+      expect(c.textContent).toEqual(`"${transformedBySetSelf}"`);
+    },
+  );
 
   // NOTE: This test throws an expected error
   testRecoil('reject promise', async () => {
@@ -708,38 +746,6 @@ describe('Effects', () => {
     act(() => history.pop()());
     expect(c.textContent).toEqual('"DEFAULT_A""DEFAULT_B"');
   });
-
-  testRecoil(
-    'when setSelf is called in onSet, then onSet is not triggered again',
-    () => {
-      let set1 = false;
-      const valueToSet1 = 'value#1';
-      const transformedBySetSelf = 'transformed after value#1';
-
-      const myAtom = atom({
-        key: 'atom setSelf with set-updater',
-        default: 'DEFAULT',
-        effects_UNSTABLE: [
-          ({setSelf, onSet}) => {
-            onSet(newValue => {
-              expect(set1).toBe(false);
-              if (newValue === valueToSet1) {
-                setSelf(transformedBySetSelf);
-                set1 = true;
-              }
-            });
-          },
-        ],
-      });
-
-      const [ReadsWritesAtom, set] = componentThatReadsAndWritesAtom(myAtom);
-
-      const c = renderElements(<ReadsWritesAtom />);
-      expect(c.textContent).toEqual('"DEFAULT"');
-      act(() => set(valueToSet1));
-      expect(c.textContent).toEqual(`"${transformedBySetSelf}"`);
-    },
-  );
 
   testRecoil('Cleanup Handlers - when root unmounted', () => {
     const refCounts = [0, 0];

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -709,6 +709,38 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('"DEFAULT_A""DEFAULT_B"');
   });
 
+  testRecoil(
+    'when setSelf is called in onSet, then onSet is not triggered again',
+    () => {
+      let set1 = false;
+      const valueToSet1 = 'value#1';
+      const transformedBySetSelf = 'transformed after value#1';
+
+      const myAtom = atom({
+        key: 'atom setSelf with set-updater',
+        default: 'DEFAULT',
+        effects_UNSTABLE: [
+          ({setSelf, onSet}) => {
+            onSet(newValue => {
+              expect(set1).toBe(false);
+              if (newValue === valueToSet1) {
+                setSelf(transformedBySetSelf);
+                set1 = true;
+              }
+            });
+          },
+        ],
+      });
+
+      const [ReadsWritesAtom, set] = componentThatReadsAndWritesAtom(myAtom);
+
+      const c = renderElements(<ReadsWritesAtom />);
+      expect(c.textContent).toEqual('"DEFAULT"');
+      act(() => set(valueToSet1));
+      expect(c.textContent).toEqual(`"${transformedBySetSelf}"`);
+    },
+  );
+
   testRecoil('Cleanup Handlers - when root unmounted', () => {
     const refCounts = [0, 0];
 

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -60,7 +60,9 @@ function makeStore(): Store {
       return newGraph;
     },
     subscribeToTransactions: () => {
-      throw new Error('not tested at this level');
+      throw new Error(
+        'This functionality, should not tested at this level. Use a component to test this functionality: e.g. componentThatReadsAndWritesAtom',
+      );
     },
     addTransactionMetadata: () => {
       throw new Error('not implemented');


### PR DESCRIPTION
Summary:
Fixes #953

Avoid calling onSet() when setSelf() initializes with a Promise.

Differential Revision: D27975202

