### PR TITLE
Add getCallback() to selector interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - On initial render when not using React Concurrent Mode (#820)
 - Improved TypeScript and Flow typing for `Loadable`s (#966)
 - Added override prop to RecoilRoot
+- Add getCallback() to selector evaluation interface
 - Fix not calling onSet() handler triggered from a setSelf() in onSet() for Atom Effects (#974, #979)
 
 ## 0.2.0 (2021-3-18)

--- a/src/recoil_values/Recoil_selectorFamily.js
+++ b/src/recoil_values/Recoil_selectorFamily.js
@@ -19,6 +19,7 @@ import type {
 } from '../core/Recoil_RecoilValue';
 import type {RetainedBy} from '../core/Recoil_RetainedBy';
 import type {
+  GetCallback,
   GetRecoilValue,
   ResetRecoilState,
   SetRecoilState,
@@ -41,7 +42,10 @@ export type Parameter =
 
 type ReadOnlySelectorFamilyOptions<T, P: Parameter> = $ReadOnly<{
   key: string,
-  get: P => ({get: GetRecoilValue}) => Promise<T> | RecoilValue<T> | T,
+  get: P => ({get: GetRecoilValue, getCallback: GetCallback}) =>
+    | Promise<T>
+    | RecoilValue<T>
+    | T,
   cachePolicyForParams_UNSTABLE?: CachePolicy,
   cachePolicy_UNSTABLE?: CachePolicy,
   dangerouslyAllowMutability?: boolean,

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -24,70 +24,6 @@ export type RecoilRootProps = {
 
 export const RecoilRoot: React.FC<RecoilRootProps>;
 
-// Effect is called the first time a node is used with a <RecoilRoot>
-export type AtomEffect<T> = (param: {
-  node: RecoilState<T>,
-  trigger: 'set' | 'get',
-
-  // Call synchronously to initialize value or async to change it later
-  setSelf: (param:
-    | T
-    | DefaultValue
-    | Promise<T | DefaultValue>
-    | ((param: T | DefaultValue) => T | DefaultValue),
-  ) => void,
-  resetSelf: () => void,
-
-  // Subscribe callbacks to events.
-  // Atom effect observers are called before global transaction observers
-  onSet: (
-    param: (newValue: T | DefaultValue, oldValue: T | DefaultValue) => void,
-  ) => void,
-}) => void | (() => void);
-
-// atom.d.ts
-export interface AtomOptions<T> {
-  key: NodeKey;
-  default: RecoilValue<T> | Promise<T> | T;
-  effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
-  dangerouslyAllowMutability?: boolean;
-}
-
-/**
- * Creates an atom, which represents a piece of writeable state
- */
-export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
-
-// selector.d.ts
-export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
-
-export type SetRecoilState = <T>(
-    recoilVal: RecoilState<T>,
-    newVal: T | DefaultValue | ((prevValue: T) => T | DefaultValue),
-) => void;
-
-export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-export interface ReadOnlySelectorOptions<T> {
-    key: string;
-    get: (opts: { get: GetRecoilValue }) => Promise<T> | RecoilValue<T> | T;
-    dangerouslyAllowMutability?: boolean;
-}
-
-export interface ReadWriteSelectorOptions<T> extends ReadOnlySelectorOptions<T> {
-  set: (
-    opts: {
-      set: SetRecoilState;
-      get: GetRecoilValue;
-      reset: ResetRecoilState;
-    },
-    newValue: T | DefaultValue,
-  ) => void;
-}
-
-export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<T>;
-export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
-
 // Snapshot.d.ts
 declare const SnapshotID_OPAQUE: unique symbol;
 export interface SnapshotID {
@@ -125,6 +61,73 @@ export class MutableSnapshot extends Snapshot {
   set: SetRecoilState;
   reset: ResetRecoilState;
 }
+
+// Effect is called the first time a node is used with a <RecoilRoot>
+export type AtomEffect<T> = (param: {
+  node: RecoilState<T>,
+  trigger: 'set' | 'get',
+
+  // Call synchronously to initialize value or async to change it later
+  setSelf: (param:
+    | T
+    | DefaultValue
+    | Promise<T | DefaultValue>
+    | ((param: T | DefaultValue) => T | DefaultValue),
+  ) => void,
+  resetSelf: () => void,
+
+  // Subscribe callbacks to events.
+  // Atom effect observers are called before global transaction observers
+  onSet: (
+    param: (newValue: T | DefaultValue, oldValue: T | DefaultValue) => void,
+  ) => void,
+}) => void | (() => void);
+
+// atom.d.ts
+export interface AtomOptions<T> {
+  key: NodeKey;
+  default: RecoilValue<T> | Promise<T> | T;
+  effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
+  dangerouslyAllowMutability?: boolean;
+}
+
+/**
+ * Creates an atom, which represents a piece of writeable state
+ */
+export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
+
+// selector.d.ts
+export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
+export type GetCallback = <Args extends ReadonlyArray<unknown>, Return>(
+  fn: (interface: Readonly<{snapshot: Snapshot}>) => (...args: Args) => Return,
+) => (...args: Args) => Return;
+
+export type SetRecoilState = <T>(
+    recoilVal: RecoilState<T>,
+    newVal: T | DefaultValue | ((prevValue: T) => T | DefaultValue),
+) => void;
+
+export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export interface ReadOnlySelectorOptions<T> {
+    key: string;
+    get: (opts: { get: GetRecoilValue, getCallback: GetCallback }) => Promise<T> | RecoilValue<T> | T;
+    dangerouslyAllowMutability?: boolean;
+}
+
+export interface ReadWriteSelectorOptions<T> extends ReadOnlySelectorOptions<T> {
+  set: (
+    opts: {
+      set: SetRecoilState;
+      get: GetRecoilValue;
+      reset: ResetRecoilState;
+    },
+    newValue: T | DefaultValue,
+  ) => void;
+}
+
+export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<T>;
+export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
 
 // hooks.d.ts
 export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -75,6 +75,16 @@ const writeableSelector = selector({
   },
 });
 
+const callbackSelector = selector({
+  key: 'CallbackSelector',
+  get: ({ getCallback }) => {
+    return getCallback(({snapshot}) => () => {
+      return snapshot.getPromise(mySelector1); // $ExpectType Promise<number>
+    });
+  }
+});
+useRecoilValue(callbackSelector); // $ExpectType () => Promise<number>
+
 // RecoilRoot
 RecoilRoot({});
 RecoilRoot({


### PR DESCRIPTION
Summary:
Occasionally, one would like a selector to return an object that contains callbacks which can access Recoil state.  Add a `getCallback()` callback to the selector evaluation interface in addition to `get()` in order to support this.

When evaluating a selector `get()` will synchronously get the value of the dependency and subscribe the selector to update if that dependency changes.  `getCallback()`, will return a callback which has access to a snapshot of Recoil state at the time the snapshot was executed.  This means there is no subscription to re-evaluate the selector.  This matches the convention established by `useRecoilCallback()`, only within a selector.  Similarly, callback cannot be called while the selector is being evaluated.  It can only be used later asynchronously to get a `Promise` or `Loadable` of the value at the time of the callback.

An example when this is useful is if a user would like to use a selector to generate object which represent menu items.  The menu items may then have callbacks which access Recoil state.

```
const menuItemState = selectorFamily(
  'MenuItem',
  (itemID: number) => ({get, getCallback}) => {
    const name = get(itemNameQuery(itemID));
    const onClick = getCallback(({snapshot}) => async () => {
      const info = await snapshot.getPromise(itemInfoQuery(itemID));
      displayInfoModal(info);
    });
    return {
      title: `Show Info for ${name}`,
      onClick,
    };
  },
});
```

It is left as an exercise to the future if we would like to allow these callbacks to also set Recoil state.

Please refer to the original [RFC](https://fb.quip.com/si45AN3C6vpm) from habond

Differential Revision: D27985112

