### PR TITLE
Failing testcase for sync setSelf bug

### DIFF
--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -164,6 +164,46 @@ testRecoil('selector reset', () => {
   expect(get(selectorRW)).toEqual('DEFAULT');
 });
 
+testRecoil(
+  'selector get - sync setSelf dependency after async dependency',
+  async () => {
+    const syncSetSelfAtom = atom({
+      key: 'selector/get/syncSetSelf',
+      default: false,
+      effects_UNSTABLE: [
+        ({trigger, setSelf}) => {
+          if (trigger === 'get') {
+            setSelf(true);
+          }
+        },
+      ],
+    });
+
+    const asyncSelector = selector({
+      key: 'selector/get/asyncDep',
+      get: () => {
+        return Promise.resolve(null);
+      },
+    });
+
+    const selectorRO = selector({
+      key: 'selector/get',
+      get: async ({get}) => {
+        const async = get(asyncSelector);
+        const syncSetSelf = get(syncSetSelfAtom);
+        return !async && syncSetSelf;
+      },
+    });
+
+    const c = renderElements(<ReadsAtom atom={selectorRO} />);
+    expect(c.textContent).toEqual('loading');
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    expect(c.textContent).toEqual('true');
+  },
+);
+
 testRecoil('useRecoilState - resolved async selector', async () => {
   const resolvingSel = resolvingAsyncSelector('HELLO');
   const c = renderElements(<ReadsAtom atom={resolvingSel} />);


### PR DESCRIPTION
Even after the new 0.2.0 release including a fix for #774 I'm still seeing a problem with a synchronous setSelf call not taking effect immediately.  I've narrowed it down to a fairly small testcase that demonstrates the problem.

There are two code tweaks you can make to the testcase that will cause it to pass, and they might highlight where the underlying bug is:
1. If you remove the `async` modifier [here](https://github.com/facebookexperimental/Recoil/compare/master...mdlavin:sync-setSelf-after-async-dependency?expand=1#diff-1d5cf4e2e9b5f144d17cf87d8ec6ad1e46adea67bcf6a54303b7267c3ca01931R191) the test passes
2. If you flip the order of the dependencies [here](https://github.com/facebookexperimental/Recoil/compare/master...mdlavin:sync-setSelf-after-async-dependency?expand=1#diff-1d5cf4e2e9b5f144d17cf87d8ec6ad1e46adea67bcf6a54303b7267c3ca01931R192-R193), then the test passes