### PR TITLE
Fix newValue option in ReadWriteSelectorOptions<T>

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -122,7 +122,7 @@ export interface ReadWriteSelectorOptions<T> extends ReadOnlySelectorOptions<T> 
       get: GetRecoilValue;
       reset: ResetRecoilState;
     },
-    newValue: T | DefaultValue,
+    newValue: T | (T & DefaultValue),
   ) => void;
 }
 


### PR DESCRIPTION
Currently, the type for `newValue` is specified as `T | DefaultValue`; however, T is defined as a tagging interface:

```tsx
export class DefaultValue {
  private __tag: 'DefaultValue';
}
```

This effectively forces consumers to do unnecessary type refinement at the usage site because TS thinks that the DefaultValue is _just_ the tag, and not the data as well.

This proposed change will address this particular case.

In order to address this anywhere else it occurs, perhaps DefaultValue should be redefined as:

```tsx
export type DefaultValue<T> = T & {
  private __tag: 'DefaultValue';
}
```