### PR TITLE
optimize selector case where async dependency resolves to previously seen value

### DIFF
--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -1429,3 +1429,101 @@ testRecoil('selectors cannot mutate values in get() or set()', () => {
 
   window.__DEV__ = devStatus;
 });
+
+testRecoil(
+  'selector does not re-run to completion when one of its async deps resolves to a previously cached value',
+  async () => {
+    const testSnapshot = freshSnapshot();
+    testSnapshot.retain();
+
+    const atomA = atom({
+      key: 'atomc-rerun-opt-test',
+      default: -3,
+    });
+
+    const selectorB = selector({
+      key: 'selb-rerun-opt-test',
+      get: async ({get}) => {
+        await Promise.resolve();
+
+        return Math.abs(get(atomA));
+      },
+    });
+
+    let numTimesCStartedToRun = 0;
+    let numTimesCRanToCompletion = 0;
+
+    const selectorC = selector({
+      key: 'sela-rerun-opt-test',
+      get: ({get}) => {
+        numTimesCStartedToRun++;
+
+        const ret = get(selectorB);
+
+        /**
+         * The placement of numTimesCRan is important as this optimization
+         * prevents the execution of selectorC _after_ the point where the
+         * selector execution hits a known path of dependencies. In other words,
+         * the lines prior to the get(selectorB) will run twice, but the lines
+         * following get(selectorB) should only run once given that we are
+         * setting up this test so that selectorB resolves to a previously seen
+         * value the second time that it runs.
+         */
+        numTimesCRanToCompletion++;
+
+        return ret;
+      },
+    });
+
+    testSnapshot.getLoadable(selectorC);
+
+    /**
+     * Run selector chain so that selectorC is cached with a dep of selectorB
+     * set to "3"
+     */
+    await flushPromisesAndTimers();
+
+    const loadableA = testSnapshot.getLoadable(selectorC);
+
+    expect(loadableA.contents).toBe(3);
+    expect(numTimesCRanToCompletion).toBe(1);
+
+    /**
+     * It's expected that C started to run twice so far (the first is the first
+     * time that the selector was called and suspended, the second was when B
+     * resolved and C re-ran because of the async dep resolution)
+     */
+    expect(numTimesCStartedToRun).toBe(2);
+
+    const mappedSnapshot = testSnapshot.map(({set}) => {
+      set(atomA, 3);
+    });
+
+    mappedSnapshot.getLoadable(selectorC);
+
+    /**
+     * Run selector chain so that selectorB recalculates as a result of atomA
+     * being changed to "3"
+     */
+    await flushPromisesAndTimers();
+
+    const loadableB = mappedSnapshot.getLoadable(selectorC);
+
+    expect(loadableB.contents).toBe(3);
+
+    /**
+     * If selectors are correctly optimized, selectorC will not re-run because
+     * selectorB resolved to "3", which is a value that selectorC has previously
+     * cached for its selectorB dependency.
+     */
+    expect(numTimesCRanToCompletion).toBe(1);
+
+    /**
+     * TODO:
+     * in the ideal case this should be:
+     *
+     * expect(numTimesCStartedToRun).toBe(2);
+     */
+    expect(numTimesCStartedToRun).toBe(3);
+  },
+);


### PR DESCRIPTION
Summary:
Current behavior:

1) Async selector A depends on B (also an async selector) which depends on atom C
2) C changes, therefore B re-runs, and A re-runs but suspends while B finishes executing
3) It turns out B finishes executing to a value that was previously seen, but **A re-runs** as we don't check to see if the resolved value of a newly suspended dep equals a value previously seen (and cached)

New behavior:

1) Async selector A depends on B (also an async selector) which depends on atom C
2) C changes, therefore B re-runs, and A re-runs but suspends while B finishes executing
3) It turns out B finishes executing to a value that was previously seen, and **before re-running A we re-check the cache in case the resolved dep happens to equal a previously seen value**. Because B resolved to a previously cached value, we don't rerun A. Instead we return the cached result.

====================================

Real world impact: we were seeing CV queries re-running unnecessarily (we noticed dependent recoil state stayed the same but queries still re-ran).

For example (as pointed out by drarmstr: go to https://fburl.com/cv/a3wzvm5w and change between the Call Graph, Call Tree, and Table views and observe that the `AppVersionsQuery` [AppVerionsQuery] is executed again in the debug console.)

Differential Revision: D28501578

