### PR TITLE
Fix case for Recoil repository in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "native",
     "index.d.ts"
   ],
-  "repository": "https://github.com/facebookexperimental/recoil.git",
+  "repository": "https://github.com/facebookexperimental/Recoil.git",
   "license": "MIT",
   "scripts": {
     "prepare": "install-peers",


### PR DESCRIPTION
Summary: Our `package.json` files were referring to `recoil.git` while our GitHub repository is `Recoil.git`.  We started getting an error with the nightly package, so try updating the case to match.

Differential Revision: D28838834

