### PR TITLE
Fix TypeScript for getCallback() in selectorFamily()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Memory management
 - Selector cache configuration
 
+## NEXT
+
+- Fix TypeScript typeing for `selectorFamily()` and `getCallback()` (#989)
+
 ## 0.3.1 (2021-5-18)
 
 - Fix TypeScript exports

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -112,7 +112,10 @@ export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-
 
 export interface ReadOnlySelectorOptions<T> {
     key: string;
-    get: (opts: { get: GetRecoilValue, getCallback: GetCallback }) => Promise<T> | RecoilValue<T> | T;
+    get: (opts: {
+      get: GetRecoilValue,
+      getCallback: GetCallback,
+    }) => Promise<T> | RecoilValue<T> | T;
     dangerouslyAllowMutability?: boolean;
 }
 
@@ -301,7 +304,10 @@ export function atomFamily<T, P extends SerializableParam>(
 
 export interface ReadOnlySelectorFamilyOptions<T, P extends SerializableParam> {
   key: string;
-  get: (param: P) => (opts: { get: GetRecoilValue }) => Promise<T> | RecoilValue<T> | T;
+  get: (param: P) => (opts: {
+    get: GetRecoilValue,
+    getCallback: GetCallback,
+  }) => Promise<T> | RecoilValue<T> | T;
   // cacheImplementation_UNSTABLE?: () => CacheImplementation<Loadable<T>>,
   // cacheImplementationForParams_UNSTABLE?: () => CacheImplementation<
   //   RecoilValue<T>,
@@ -311,7 +317,10 @@ export interface ReadOnlySelectorFamilyOptions<T, P extends SerializableParam> {
 
 export interface ReadWriteSelectorFamilyOptions<T, P extends SerializableParam> {
   key: string;
-  get: (param: P) => (opts: { get: GetRecoilValue }) => Promise<T> | RecoilValue<T> | T;
+  get: (param: P) => (opts: {
+    get: GetRecoilValue,
+    getCallback: GetCallback,
+  }) => Promise<T> | RecoilValue<T> | T;
   set: (
       param: P,
   ) => (


### PR DESCRIPTION
Summary:
Add `getCallback()` to the `selectorFamily()` interface consistent with `selector()`.

Fixes #989

Differential Revision: D28904928

