### PR TITLE
Remove unneeded logging

### DIFF
--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -860,11 +860,6 @@ function useRetain_ACTUAL(toRetain: ToRetain): void {
       window.clearTimeout(timeoutID.current);
       timeoutID.current = null;
     } else {
-      // Log this since it's not clear that there's any scenario where it should happen.
-      recoverableViolation(
-        'Did not retain recoil value on render, or committed after timeout elapsed. This is fine, but odd.',
-        'recoil',
-      );
       for (const r of retainables) {
         updateRetainCount(store, r, 1);
       }


### PR DESCRIPTION
Summary: Remove a log now that our question about whether this actually happens is answered. This form of logging is much more intrusive in OSS where we don't have infra to gather stats on these, but just have to spew them to the console.

Reviewed By: drarmstr

Differential Revision: D28939979

