### PR TITLE
useRecoilTransaction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 - Fix TypeScript typeing for `selectorFamily()` and `getCallback()` (#1060)
 - Fix onSet() handler to get the proper new value when atom is reset or has an async default Promise that resolves (#1059, #1050, #738) (Slightly breaking change)
+- useRecoilTransaction_UNSTABLE
+- useTransition compatibility
+- Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.
 
 ## 0.3.1 (2021-5-18)
 

--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -31,6 +31,7 @@ export type {
   AtomEffect,
   PersistenceSettings,
 } from './recoil_values/Recoil_atom';
+export type {TransactionInterface} from './core/Recoil_AtomicUpdates';
 export type {
   GetRecoilValue,
   SetRecoilState,
@@ -53,6 +54,7 @@ const {
   useRecoilSnapshot,
   useRecoilState,
   useRecoilStateLoadable,
+  useRecoilTransaction,
   useRecoilTransactionObserver,
   useRecoilValue,
   useRecoilValueLoadable,
@@ -111,8 +113,9 @@ module.exports = {
   useGetRecoilValueInfo_UNSTABLE: useGetRecoilValueInfo,
   useRetain,
 
-  // Hooks for asynchronous Recoil
+  // Hooks for complex operations with RecoilValues
   useRecoilCallback,
+  useRecoilTransaction_UNSTABLE: useRecoilTransaction,
 
   // Hooks for Snapshots
   useGotoRecoilSnapshot,

--- a/src/core/Recoil_AtomicUpdates.js
+++ b/src/core/Recoil_AtomicUpdates.js
@@ -23,17 +23,17 @@ const {
   writeLoadableToTreeState,
 } = require('../core/Recoil_RecoilValueInterface');
 
-export interface AtomicUpdateInterface {
-  get<T>(RecoilValue<T>): T;
-  set<T>(RecoilState<T>, T): void;
-  reset<T>(RecoilState<T>): void;
+export interface TransactionInterface {
+  get: <T>(RecoilValue<T>) => T;
+  set: <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
+  reset: <T>(RecoilState<T>) => void;
 }
 
 function isAtom<T>(recoilValue: RecoilValue<T>): boolean {
   return getNode(recoilValue.key).nodeType === 'atom';
 }
 
-class AtomicUpdateInterfaceImpl {
+class TransactionInterfaceImpl {
   _store: Store;
   _treeState: TreeState;
   _changes: Map<NodeKey, mixed>;
@@ -106,12 +106,10 @@ class AtomicUpdateInterfaceImpl {
   }
 }
 
-function atomicUpdater(
-  store: Store,
-): ((AtomicUpdateInterface) => void) => void {
+function atomicUpdater(store: Store): ((TransactionInterface) => void) => void {
   return fn => {
     store.replaceState(treeState => {
-      const changeset = new AtomicUpdateInterfaceImpl(store, treeState);
+      const changeset = new TransactionInterfaceImpl(store, treeState);
       fn(changeset);
       return changeset.newTreeState_INTERNAL();
     });

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -136,7 +136,7 @@ export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueRea
 // hooks.d.ts
 export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
 export type Resetter = () => void;
-export interface AtomicUpdateInterface_UNSTABLE {
+export interface TransactionInterface_UNSTABLE {
   get<T>(a: RecoilValue<T>): T;
   set<T>(s: RecoilState<T>, u: ((currVal: T) => T) | T): void;
   reset<T>(s: RecoilState<T>): void;
@@ -146,7 +146,7 @@ export type CallbackInterface = Readonly<{
   reset: (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
   snapshot: Snapshot,
   gotoSnapshot: (snapshot: Snapshot) => void,
-  atomicUpdate_UNSTABLE: (cb: (i: AtomicUpdateInterface_UNSTABLE) => void) => void;
+  transact_UNSTABLE: (cb: (i: TransactionInterface_UNSTABLE) => void) => void;
 }>;
 
 /**
@@ -202,6 +202,11 @@ export function useRecoilCallback<Args extends ReadonlyArray<unknown>, Return>(
   fn: (interface: CallbackInterface) => (...args: Args) => Return,
   deps?: ReadonlyArray<unknown>,
 ): (...args: Args) => Return;
+
+export function useRecoilTransaction_UNSTABLE<Args extends ReadonlyArray<unknown>>(
+  fn: (interface: TransactionInterface_UNSTABLE) => (...args: Args) => void,
+  deps?: ReadonlyArray<unknown>,
+): (...args: Args) => void;
 
 export function useRecoilTransactionObserver_UNSTABLE(
   callback: (opts: {

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -18,6 +18,7 @@ import {
   useResetRecoilState, useSetRecoilState,
   waitForAll, waitForAllSettled, waitForAny, waitForNone,
   Loadable,
+  useRecoilTransaction_UNSTABLE,
 } from 'recoil';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -216,7 +217,7 @@ useGetRecoilValueInfo_UNSTABLE(myAtom); // $ExpectType AtomInfo<number>
 useGetRecoilValueInfo_UNSTABLE(mySelector2); // $ExpectType AtomInfo<string>
 useGetRecoilValueInfo_UNSTABLE({}); // $ExpectError
 
-useRecoilCallback(({ snapshot, set, reset, gotoSnapshot, atomicUpdate_UNSTABLE }) => async () => {
+useRecoilCallback(({ snapshot, set, reset, gotoSnapshot, transact_UNSTABLE }) => async () => {
   snapshot; // $ExpectType Snapshot
   snapshot.getID(); // $ExpectType SnapshotID
   await snapshot.getPromise(mySelector1); // $ExpectType number
@@ -237,12 +238,20 @@ useRecoilCallback(({ snapshot, set, reset, gotoSnapshot, atomicUpdate_UNSTABLE }
   const release = snapshot.retain(); // $ExpectType () => void
   release(); // $ExpectType void
 
-  atomicUpdate_UNSTABLE(({get, set, reset}) => {
+  transact_UNSTABLE(({get, set, reset}) => {
     const x: number = get(myAtom); // eslint-disable-line @typescript-eslint/no-unused-vars
     set(myAtom, 1);
     set(myAtom, x => x + 1);
     reset(myAtom);
   })
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, reset}) => (p: number) => {
+  const x: number = get(myAtom); // eslint-disable-line @typescript-eslint/no-unused-vars
+  set(myAtom, 1);
+  set(myAtom, x => x + 1);
+  reset(myAtom);
 });
 
 /**


### PR DESCRIPTION
Summary:
Nicer API for atomic updates. Since this obviates the need for most uses of useRecoilCallback, we can make it its own hook to make it much less cumbersome to use, as well as having less overhead in various ways. Per discussion, rename from 'atomic update' to 'transaction' (internal modules still keep the old name to avoid overlap with transactions generally).

The intention is that this API would potentially allow support for async transactions in the future, if we add such support.

Reviewed By: drarmstr

Differential Revision: D29312126

