### PR TITLE
Update fbt and recoil to use the ReactDOMLegacy_DEPRECATED entry point

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
         "root": ["./src"],
         "alias": {
           "React": "react",
-          "ReactDOM": "react-dom",
+          "ReactDOMLegacy_DEPRECATED": "react-dom",
           "ReactNative": "react-native",
           "ReactTestUtils": "react-dom/test-utils"
         }

--- a/.flowconfig
+++ b/.flowconfig
@@ -18,7 +18,7 @@ suppress_type=$FlowFixMe
 suppress_type=$FlowOSSFixMe
 
 module.name_mapper='React' -> '<PROJECT_ROOT>/node_modules/react'
-module.name_mapper='ReactDOM' -> '<PROJECT_ROOT>/node_modules/react-dom'
+module.name_mapper='ReactDOMLegacy_DEPRECATED' -> '<PROJECT_ROOT>/node_modules/react-dom'
 module.name_mapper='ReactNative' -> '<PROJECT_ROOT>/node_modules/react-native'
 module.name_mapper='ReactTestUtils' -> '<PROJECT_ROOT>/node_modules/react-dom/test-utils'
 

--- a/flow-typed/npm/ReactDOM_vx.x.x.js
+++ b/flow-typed/npm/ReactDOM_vx.x.x.js
@@ -13,6 +13,6 @@
  * https://github.com/flowtype/flow-typed
  */
 
-declare module 'ReactDOM' {
+declare module 'ReactDOMLegacy_DEPRECATED' {
   declare module.exports: any;
 }

--- a/packages/recoil-devtools/.babelrc
+++ b/packages/recoil-devtools/.babelrc
@@ -7,7 +7,7 @@
           "root": ["./src"],
           "alias": {
             "React": "react",
-            "ReactDOM": "react-dom",
+            "ReactDOMLegacy_DEPRECATED": "react-dom",
             "ReactTestUtils": "react-dom/test-utils"
           }
         }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
-import nodeResolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
+import nodeResolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import {terser} from 'rollup-plugin-terser';
 
@@ -27,7 +27,7 @@ const commonPlugins = [
       if (source === 'React') {
         return {id: 'react', external: true};
       }
-      if (source === 'ReactDOM') {
+      if (source === 'ReactDOMLegacy_DEPRECATED') {
         return {id: 'react-dom', external: true};
       }
       if (source === 'ReactNative') {

--- a/src/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/src/core/__tests__/Recoil_RecoilRoot-test.js
@@ -28,7 +28,7 @@ let React,
 const testRecoil = getRecoilTestFn(() => {
   React = require('react');
   ({useState} = require('react'));
-  ReactDOM = require('ReactDOM');
+  ReactDOM = require('ReactDOMLegacy_DEPRECATED');
   ({act} = require('ReactTestUtils'));
 
   ({useSetRecoilState} = require('../../hooks/Recoil_Hooks'));

--- a/src/core/__tests__/Recoil_batcher-test.js
+++ b/src/core/__tests__/Recoil_batcher-test.js
@@ -15,7 +15,7 @@ const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
 let unstable_batchedUpdates, batchUpdates, getBatcher, setBatcher;
 
 const testRecoil = getRecoilTestFn(() => {
-  ({unstable_batchedUpdates} = require('ReactDOM'));
+  ({unstable_batchedUpdates} = require('ReactDOMLegacy_DEPRECATED'));
   ({batchUpdates, getBatcher, setBatcher} = require('../Recoil_Batching'));
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -25,7 +25,7 @@ let React,
 const testRecoil = getRecoilTestFn(() => {
   React = require('react');
   ({useEffect, useRef} = require('react'));
-  ReactDOM = require('ReactDOM');
+  ReactDOM = require('ReactDOMLegacy_DEPRECATED');
   ({act} = require('ReactTestUtils'));
 
   ({RecoilRoot} = require('../../core/Recoil_RecoilRoot.react'));

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -35,7 +35,7 @@ const testRecoil = getRecoilTestFn(() => {
 
   React = require('react');
   ({useState, Profiler} = require('react'));
-  ReactDOM = require('ReactDOM');
+  ReactDOM = require('ReactDOMLegacy_DEPRECATED');
   ({act} = require('ReactTestUtils'));
 
   ({DEFAULT_VALUE, DefaultValue} = require('../../core/Recoil_Node'));

--- a/src/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -43,7 +43,7 @@ const testRecoil = getRecoilTestFn(() => {
 
   React = require('react');
   ({Profiler, useState} = require('react'));
-  ReactDOM = require('ReactDOM');
+  ReactDOM = require('ReactDOMLegacy_DEPRECATED');
   ({act} = require('ReactTestUtils'));
 
   ({RecoilRoot} = require('../../core/Recoil_RecoilRoot.react'));

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -17,8 +17,8 @@ import type {
 } from '../core/Recoil_RecoilValue';
 import type {Store} from '../core/Recoil_State';
 
-const ReactDOM = require('ReactDOM');
 const ReactDOMComet = require('ReactDOMComet');
+const ReactDOM = require('ReactDOMLegacy_DEPRECATED');
 const {act} = require('ReactTestUtils');
 
 const {graph} = require('../core/Recoil_Graph');

--- a/src/util/polyfill/ReactBatchedUpdates.js
+++ b/src/util/polyfill/ReactBatchedUpdates.js
@@ -12,6 +12,6 @@
  * for our web build
  */
 
-const {unstable_batchedUpdates} = require('ReactDOM');
+const {unstable_batchedUpdates} = require('ReactDOMLegacy_DEPRECATED');
 
 module.exports = {unstable_batchedUpdates};


### PR DESCRIPTION
Summary:
We're updating the internal entry point for the old React API to be ReactDOMLegacy_DEPRECATED. For the requires to keep working internally and externally I need to update the module mapping and the source to use these entry points.

See https://fb.workplace.com/groups/react.fyi/permalink/4411697998840538/ for context.

Differential Revision: D29334366

