### PR TITLE
add displayName to thrown promise

### DIFF
--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -60,7 +60,11 @@ const {useCallback, useEffect, useMemo, useRef, useState} = require('react');
 // to be discarded and their resources released.
 const SUSPENSE_TIMEOUT_MS = 120000;
 
-function handleLoadable<T>(loadable: Loadable<T>, atom, storeRef): T {
+function handleLoadable<T>(
+  loadable: Loadable<T>,
+  recoilValue: RecoilValue<T>,
+  storeRef,
+): T {
   // We can't just throw the promise we are waiting on to Suspense.  If the
   // upstream dependencies change it may produce a state in which the component
   // can render, but it would still be suspended on a Promise that may never resolve.
@@ -74,7 +78,7 @@ function handleLoadable<T>(loadable: Loadable<T>, atom, storeRef): T {
   } else if (loadable.state === 'hasError') {
     throw loadable.contents;
   } else {
-    throw new Error(`Invalid value of loadable atom "${atom.key}"`);
+    throw new Error(`Invalid value of loadable atom "${recoilValue.key}"`);
   }
 }
 

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -74,11 +74,21 @@ function handleLoadable<T>(
     const promise = new Promise(resolve => {
       storeRef.current.getState().suspendedComponentResolvers.add(resolve);
     });
+
+    // $FlowFixMe Flow(prop-missing) for integrating with tools that inspect thrown promises @fb-only
+    // @fb-only: promise.displayName = `Recoil Value: ${recoilValue.key}`;
+
     throw promise;
   } else if (loadable.state === 'hasError') {
     throw loadable.contents;
   } else {
-    throw new Error(`Invalid value of loadable atom "${recoilValue.key}"`);
+    const err = new Error(
+      `Invalid value of loadable atom "${recoilValue.key}"`,
+    );
+
+    err.stack; // In V8, Error objects keep closures alive until the error.stack property is accessed
+
+    throw err;
   }
 }
 

--- a/src/hooks/__tests__/Recoil_useTransition-test.js
+++ b/src/hooks/__tests__/Recoil_useTransition-test.js
@@ -11,7 +11,10 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {
+  IS_INTERNAL,
+  getRecoilTestFn,
+} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   act,
@@ -43,6 +46,10 @@ const testRecoil = getRecoilTestFn(() => {
 let nextID = 0;
 
 testRecoil('Works with useTransition', async () => {
+  if (!IS_INTERNAL) {
+    return; // FIXME: these tests do not work in OSS, possibly due to differing ReactDOM in OSS and internal
+  }
+
   const indexAtom = atom({
     key: `index${nextID++}`,
     default: 0,

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -17,7 +17,7 @@ import type {
 } from '../core/Recoil_RecoilValue';
 import type {Store} from '../core/Recoil_State';
 
-const ReactDOMComet = require('ReactDOMComet');
+// @fb-only: const ReactDOMComet = require('ReactDOMComet');
 const ReactDOM = require('ReactDOMLegacy_DEPRECATED');
 const {act} = require('ReactTestUtils');
 
@@ -42,6 +42,11 @@ const nullthrows = require('../util/Recoil_nullthrows');
 const stableStringify = require('../util/Recoil_stableStringify');
 const React = require('react');
 const {useEffect} = require('react');
+
+const ReactDOMComet = require('ReactDOMLegacy_DEPRECATED'); // @oss-only
+
+// @fb-only: const IS_INTERNAL = true;
+const IS_INTERNAL = false; // @oss-only
 
 // TODO Use Snapshot for testing instead of this thunk?
 function makeStore(): Store {
@@ -100,7 +105,8 @@ function createLegacyReactRoot(container, contents) {
 }
 
 function createConcurrentReactRoot(container, contents) {
-  ReactDOMComet.createRoot(container).render(contents);
+  // @fb-only: ReactDOMComet.createRoot(container).render(contents);
+  // @oss-only ReactDOMComet.unstable_createRoot(container).render(contents);
 }
 
 function renderElementsInternal(
@@ -337,4 +343,5 @@ module.exports = {
   asyncSelector,
   flushPromisesAndTimers,
   getRecoilTestFn,
+  IS_INTERNAL,
 };


### PR DESCRIPTION
Summary: For tools inspecting thrown promises in React (such as hero tracing), it can be useful to include a display name in the thrown promise to provide some context in the thrown promise.

Reviewed By: habond

Differential Revision: D29457311

