### PR TITLE
enable dangerouslyAllowMutability in waitFor utils

### DIFF
--- a/src/hooks/__tests__/Recoil_useTransition-test.js
+++ b/src/hooks/__tests__/Recoil_useTransition-test.js
@@ -11,7 +11,10 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {
+  IS_INTERNAL,
+  getRecoilTestFn,
+} = require('../../testing/Recoil_TestingUtils');
 
 let React,
   act,
@@ -43,6 +46,10 @@ const testRecoil = getRecoilTestFn(() => {
 let nextID = 0;
 
 testRecoil('Works with useTransition', async () => {
+  if (!IS_INTERNAL) {
+    return; // FIXME: these tests do not work in OSS, possibly due to differing ReactDOM in OSS and internal
+  }
+
   const indexAtom = atom({
     key: `index${nextID++}`,
     default: 0,

--- a/src/recoil_values/Recoil_WaitFor.js
+++ b/src/recoil_values/Recoil_WaitFor.js
@@ -148,10 +148,10 @@ const waitForNone: <
     // Issue requests for all dependencies in parallel.
     const deps = unwrapDependencies(dependencies);
     const [results, exceptions] = concurrentRequests(get, deps);
-
     // Always return the current status of the results; never block.
     return wrapLoadables(dependencies, results, exceptions);
   },
+  dangerouslyAllowMutability: true,
 });
 
 // Selector that requests all dependencies in parallel and waits for at least
@@ -203,6 +203,7 @@ const waitForAny: <
       }
     });
   },
+  dangerouslyAllowMutability: true,
 });
 
 // Selector that requests all dependencies in parallel and waits for all to be
@@ -249,6 +250,7 @@ const waitForAll: <
       ),
     );
   },
+  dangerouslyAllowMutability: true,
 });
 
 const waitForAllSettled: <
@@ -298,6 +300,7 @@ const waitForAllSettled: <
         .then(() => wrapLoadables(dependencies, results, exceptions))
     );
   },
+  dangerouslyAllowMutability: true,
 });
 
 const noWait: (
@@ -314,6 +317,7 @@ const noWait: (
         : loadableWithError(exception);
     }
   },
+  dangerouslyAllowMutability: true,
 });
 
 module.exports = {

--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -17,7 +17,7 @@ import type {
 } from '../core/Recoil_RecoilValue';
 import type {Store} from '../core/Recoil_State';
 
-const ReactDOMComet = require('ReactDOMComet');
+// @fb-only: const ReactDOMComet = require('ReactDOMComet');
 const ReactDOM = require('ReactDOMLegacy_DEPRECATED');
 const {act} = require('ReactTestUtils');
 
@@ -42,6 +42,11 @@ const nullthrows = require('../util/Recoil_nullthrows');
 const stableStringify = require('../util/Recoil_stableStringify');
 const React = require('react');
 const {useEffect} = require('react');
+
+const ReactDOMComet = require('ReactDOMLegacy_DEPRECATED'); // @oss-only
+
+// @fb-only: const IS_INTERNAL = true;
+const IS_INTERNAL = false; // @oss-only
 
 // TODO Use Snapshot for testing instead of this thunk?
 function makeStore(): Store {
@@ -100,7 +105,8 @@ function createLegacyReactRoot(container, contents) {
 }
 
 function createConcurrentReactRoot(container, contents) {
-  ReactDOMComet.createRoot(container).render(contents);
+  // @fb-only: ReactDOMComet.createRoot(container).render(contents);
+  // @oss-only ReactDOMComet.unstable_createRoot(container).render(contents);
 }
 
 function renderElementsInternal(
@@ -337,4 +343,5 @@ module.exports = {
   asyncSelector,
   flushPromisesAndTimers,
   getRecoilTestFn,
+  IS_INTERNAL,
 };


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebookexperimental/Recoil/issues/1074

Adds `dangerouslyAllowMutability` by default to the waitFor helpers to unblock users that need that prop enabled in the returned selectors.

Differential Revision: D29461447

