### PR TITLE
Avoid error when ending batch without previous state

### DIFF
--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -26,7 +26,7 @@ const {
 const expectationViolation = require('../util/Recoil_expectationViolation');
 const gkx = require('../util/Recoil_gkx');
 const nullthrows = require('../util/Recoil_nullthrows');
-// @fb-only: const recoverableViolation = require('../util/Recoil_recoverableViolation');
+const recoverableViolation = require('../util/Recoil_recoverableViolation');
 const unionSets = require('../util/Recoil_unionSets');
 const {
   cleanUpNode,
@@ -217,8 +217,14 @@ function endBatch(storeRef) {
 
     sendEndOfBatchNotifications(storeRef.current);
 
-    const discardedVersion = nullthrows(storeState.previousTree).version;
-    storeState.graphsByVersion.delete(discardedVersion);
+    if (storeState.previousTree != null) {
+      storeState.graphsByVersion.delete(storeState.previousTree.version);
+    } else {
+      recoverableViolation(
+        'Ended batch with no previous state, which is unexpected',
+        'recoil',
+      );
+    }
     storeState.previousTree = null;
 
     if (gkx('recoil_memory_managament_2020')) {


### PR DESCRIPTION
Summary:
Avoid error when Recoil ends a batch and there is no previous state present.

Not sure what is causing this condition, but may have something to do with reentry.  All it was doing was cleaning up the previous graph, so may be safe to ignore the error.

Reviewed By: davidmccabe

Differential Revision: D29528816

