### PR TITLE
Fix up some Typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## NEXT
 
-- Fix TypeScript typeing for `selectorFamily()` and `getCallback()` (#1060)
+- Fix TypeScript typing for `selectorFamily()`, `getCallback()`, `useGetRecoilValueInfo()`, and `Snapshot#getNodes()` (#1060, #1116)
 - Fix onSet() handler to get the proper new value when atom is reset or has an async default Promise that resolves (#1059, #1050, #738) (Slightly breaking change)
 - useRecoilTransaction_UNSTABLE
 - useTransition compatibility

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -51,7 +51,7 @@ export class Snapshot {
   getID(): SnapshotID;
   getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
   getPromise<T>(recoilValue: RecoilValue<T>): Promise<T>;
-  getNodes_UNSTABLE(opts?: { isModified?: boolean }): Iterable<RecoilValue<unknown>>;
+  getNodes_UNSTABLE(opts?: { isModified?: boolean, isInitialized?: boolean }): Iterable<RecoilValue<unknown>>;
   getInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): AtomInfo<T>;
   map(cb: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
   asyncMap(cb: (mutableSnapshot: MutableSnapshot) => Promise<void>): Promise<Snapshot>;
@@ -109,7 +109,6 @@ export type SetRecoilState = <T>(
 ) => void;
 
 export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
-
 
 // export type EqualityPolicy = 'reference' | 'value'; TODO: removing while we discuss long term API
 
@@ -210,7 +209,7 @@ export function useResetRecoilState(recoilState: RecoilState<any>): Resetter; //
 /**
  * Returns current info about an atom
  */
-export function useGetRecoilValueInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): AtomInfo<T>;
+export function useGetRecoilValueInfo_UNSTABLE(): <T>(recoilValue: RecoilValue<T>) => AtomInfo<T>;
 
 /**
  * Returns a function that will run the callback that was passed when

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -213,9 +213,10 @@ useResetRecoilState(writeableSelector); // $ExpectType Resetter
 useResetRecoilState(readOnlySelectorSel); // $ExpectError
 useResetRecoilState({}); // $ExpectError
 
-useGetRecoilValueInfo_UNSTABLE(myAtom); // $ExpectType AtomInfo<number>
-useGetRecoilValueInfo_UNSTABLE(mySelector2); // $ExpectType AtomInfo<string>
-useGetRecoilValueInfo_UNSTABLE({}); // $ExpectError
+useGetRecoilValueInfo_UNSTABLE(myAtom); // $ExpectError
+useGetRecoilValueInfo_UNSTABLE()(myAtom); // $ExpectType AtomInfo<number>
+useGetRecoilValueInfo_UNSTABLE()(mySelector2); // $ExpectType AtomInfo<string>
+useGetRecoilValueInfo_UNSTABLE()({}); // $ExpectError
 
 useRecoilCallback(({ snapshot, set, reset, gotoSnapshot, transact_UNSTABLE }) => async () => {
   snapshot; // $ExpectType Snapshot
@@ -610,9 +611,7 @@ isRecoilValue(mySelector1);
   selector({
     key: 'ReadOnlySelectorSel_cachePolicy3',
     get: () => {},
-    cachePolicy_UNSTABLE: {
-      eviction: 'lru', // $ExpectError
-    }
+    cachePolicy_UNSTABLE: { eviction: 'lru' }, // $ExpectError
   });
 
   selector({
@@ -635,9 +634,7 @@ isRecoilValue(mySelector1);
   selectorFamily({
     key: 'ReadOnlySelectorFSel_cachePolicy3',
     get: () => () => {},
-    cachePolicy_UNSTABLE: {
-      eviction: 'lru', // $ExpectError
-    }
+    cachePolicy_UNSTABLE: { eviction: 'lru' }, // $ExpectError
   });
 
   selectorFamily({


### PR DESCRIPTION
Summary: Fix up some TypeScript exports.  Based on #1116 from @AssafKr and fix up tests.  Also drive-by some changes so we work with both TypeScript 3.8 and 3.9 which had some minor changes in formatting and which lines errors show up on.

Differential Revision: D29863364

