### PR TITLE
Fix multiple atom effect cleanup handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fix TypeScript typing for `selectorFamily()`, `getCallback()`, `useGetRecoilValueInfo()`, and `Snapshot#getNodes()` (#1060, #1116, #1123)
 - Fix onSet() handler to get the proper new value when atom is reset or has an async default Promise that resolves (#1059, #1050, #738) (Slightly breaking change)
+- Fix support for multiple Atom effects cleanup handlers
 - useRecoilTransaction_UNSTABLE
 - useTransition compatibility
 - Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -789,16 +789,23 @@ describe('Effects', () => {
   });
 
   testRecoil('Cleanup Handlers - when root unmounted', () => {
-    const refCounts = [0, 0];
+    const refCountsA = [0, 0];
+    const refCountsB = [0, 0];
 
     const atomA = atom({
       key: 'atom effect cleanup - A',
       default: 'A',
       effects_UNSTABLE: [
         () => {
-          refCounts[0]++;
+          refCountsA[0]++;
           return () => {
-            refCounts[0]--;
+            refCountsA[0]--;
+          };
+        },
+        () => {
+          refCountsA[1]++;
+          return () => {
+            refCountsA[1]--;
           };
         },
       ],
@@ -809,9 +816,15 @@ describe('Effects', () => {
       default: 'B',
       effects_UNSTABLE: [
         () => {
-          refCounts[1]++;
+          refCountsB[0]++;
           return () => {
-            refCounts[1]--;
+            refCountsB[0]--;
+          };
+        },
+        () => {
+          refCountsB[1]++;
+          return () => {
+            refCountsB[1]--;
           };
         },
       ],
@@ -841,23 +854,28 @@ describe('Effects', () => {
     });
 
     expect(c.textContent).toBe('');
-    expect(refCounts).toEqual([0, 0]);
+    expect(refCountsA).toEqual([0, 0]);
+    expect(refCountsB).toEqual([0, 0]);
 
     act(() => setNumRoots(1));
     expect(c.textContent).toBe('"A""B"');
-    expect(refCounts).toEqual([1, 1]);
+    expect(refCountsA).toEqual([1, 1]);
+    expect(refCountsB).toEqual([1, 1]);
 
     act(() => setNumRoots(2));
     expect(c.textContent).toBe('"A""B""A""B"');
-    expect(refCounts).toEqual([2, 2]);
+    expect(refCountsA).toEqual([2, 2]);
+    expect(refCountsB).toEqual([2, 2]);
 
     act(() => setNumRoots(1));
     expect(c.textContent).toBe('"A""B"');
-    expect(refCounts).toEqual([1, 1]);
+    expect(refCountsA).toEqual([1, 1]);
+    expect(refCountsB).toEqual([1, 1]);
 
     act(() => setNumRoots(0));
     expect(c.textContent).toBe('');
-    expect(refCounts).toEqual([0, 0]);
+    expect(refCountsA).toEqual([0, 0]);
+    expect(refCountsB).toEqual([0, 0]);
   });
 
   // Test that effects can initialize state when an atom is first used after an


### PR DESCRIPTION
Summary: Fix support for multiple atom effect cleanup handlers in the same atom.  Related to D24722151.

Reviewed By: davidmccabe

Differential Revision: D29888811

