### PR TITLE
add unit tests for expected behavior of atom effects with snapshots and with transactions

### DIFF
--- a/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -21,6 +21,7 @@ let React,
   atomFamily,
   selector,
   useRecoilCallback,
+  useRecoilValue,
   useSetRecoilState,
   ReadsAtom,
   flushPromisesAndTimers,
@@ -39,6 +40,7 @@ const testRecoil = getRecoilTestFn(() => {
     selector,
     useRecoilCallback,
     useSetRecoilState,
+    useRecoilValue,
   } = require('../../Recoil_index'));
   ({
     ReadsAtom,
@@ -363,3 +365,77 @@ testRecoil('Consistent callback function', () => {
   act(() => setIteration(1)); // Force a re-render of the Component
   expect(out.textContent).toBe('1');
 });
+
+testRecoil(
+  'Atom effects are initialized twice if first seen on snapshot and then on root store',
+  () => {
+    let numTimesEffectInit = 0;
+
+    const atomWithEffect = atom({
+      key: 'atomWithEffect',
+      default: 0,
+      effects_UNSTABLE: [
+        () => {
+          numTimesEffectInit++;
+        },
+      ],
+    });
+
+    const Component = () => {
+      const prefetch = useRecoilCallback(({snapshot}) => () => {
+        snapshot.getLoadable(atomWithEffect);
+      });
+
+      prefetch(); // first initialization
+
+      expect(numTimesEffectInit).toBe(1);
+
+      useRecoilValue(atomWithEffect); // second initialization
+
+      expect(numTimesEffectInit).toBe(2);
+    };
+
+    renderElements(<Component />);
+
+    expect(numTimesEffectInit).toBe(2);
+  },
+);
+
+testRecoil(
+  'Atom effects are initialized once if first seen on root store and then on snapshot',
+  () => {
+    let numTimesEffectInit = 0;
+
+    const atomWithEffect = atom({
+      key: 'atomWithEffect2',
+      default: 0,
+      effects_UNSTABLE: [
+        () => {
+          numTimesEffectInit++;
+        },
+      ],
+    });
+
+    const Component = () => {
+      const prefetch = useRecoilCallback(({snapshot}) => () => {
+        snapshot.getLoadable(atomWithEffect);
+      });
+
+      useRecoilValue(atomWithEffect); // first initialization
+
+      expect(numTimesEffectInit).toBe(1);
+
+      /**
+       * should not re-initialize b/c snapshot should inherit from latest state,
+       * wherein atom was already initialized
+       */
+      prefetch();
+
+      expect(numTimesEffectInit).toBe(1);
+    };
+
+    renderElements(<Component />);
+
+    expect(numTimesEffectInit).toBe(1);
+  },
+);

--- a/src/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/src/hooks/__tests__/Recoil_useTransaction-test.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+
+let React, atom, useRecoilValue, useRecoilTransaction, renderElements;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({
+    atom,
+    useRecoilTransaction_UNSTABLE: useRecoilTransaction,
+    useRecoilValue,
+  } = require('../../Recoil_index'));
+  ({renderElements} = require('../../testing/Recoil_TestingUtils'));
+});
+
+testRecoil(
+  'Atom effects are initialized once if first seen on transaction and then on root store',
+  () => {
+    let numTimesEffectInit = 0;
+
+    const atomWithEffect = atom({
+      key: 'atomWithEffect',
+      default: 0,
+      effects_UNSTABLE: [
+        () => {
+          numTimesEffectInit++;
+        },
+      ],
+    });
+
+    const Component = () => {
+      const prefetch = useRecoilTransaction(({get}) => () => {
+        get(atomWithEffect);
+      });
+
+      prefetch(); // first initialization
+
+      expect(numTimesEffectInit).toBe(1);
+
+      /**
+       * Transactions do not use a snapshot under the hood, so any initialized
+       * effects from a transaction will be reflected in root store
+       */
+      useRecoilValue(atomWithEffect);
+
+      expect(numTimesEffectInit).toBe(1);
+    };
+
+    renderElements(<Component />);
+
+    expect(numTimesEffectInit).toBe(1);
+  },
+);
+
+testRecoil(
+  'Atom effects are initialized once if first seen on root store and then on snapshot',
+  () => {
+    let numTimesEffectInit = 0;
+
+    const atomWithEffect = atom({
+      key: 'atomWithEffect2',
+      default: 0,
+      effects_UNSTABLE: [
+        () => {
+          numTimesEffectInit++;
+        },
+      ],
+    });
+
+    const Component = () => {
+      const prefetch = useRecoilTransaction(({get}) => () => {
+        get(atomWithEffect);
+      });
+
+      useRecoilValue(atomWithEffect); // first initialization
+
+      expect(numTimesEffectInit).toBe(1);
+
+      /**
+       * Transactions do not use a snapshot under the hood, so any initialized
+       * effects from a transaction will be reflected in root store
+       */
+      prefetch();
+
+      expect(numTimesEffectInit).toBe(1);
+    };
+
+    renderElements(<Component />);
+
+    expect(numTimesEffectInit).toBe(1);
+  },
+);


### PR DESCRIPTION
Summary:
Addresses #1107 item 2 (this behavior is expected).

TLDR; an atom effect may run multiple times if a snapshot is used to read the atom before root store is aware of the atom, but if that atom is read using transactions it will only run once regardless of whether the root store has already come across that atom.

When an atom is initialized for the first time in a snapshot, knowledge of that initialization will not make its way to the global store as snapshots are independent and do not communicate with the global store. This means an atom effect may initialize multiple times when an atom is read for the **first time** in that snapshot (or more specifically before the global store has knowledge that the atom initialized). If the global store is already aware of the atom, then subsequent snapshots that are created from the global store will not result in the effect being called multiple times.

When an atom is initialized for the first time from a transaction, the global store will be made aware of this initialization as transactions are not backed by snapshots and will mutate the root store. So if for whatever reason it's critical that the effect only runs once per root, transactions should be preferred over snapshots (although this is not officially recommended as transactions are not meant to be used for side effects).

Differential Revision: D29949089

