### PR TITLE
fix bug with selectors reading atoms with effects in snapshots from GitHub issue #1107

### DIFF
--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -280,11 +280,17 @@ function selector<T>(
     state: TreeState,
     key: NodeKey,
   ): Loadable<T> {
-    if (state.atomValues.has(key)) {
+    const isKeyPointingToSelector = store.getState().knownSelectors.has(key);
+
+    /**
+     * It's important that we don't bypass calling getNodeLoadable for atoms
+     * as getNodeLoadable has side effects in state
+     */
+    if (isKeyPointingToSelector && state.atomValues.has(key)) {
       return nullthrows(state.atomValues.get(key));
     }
+
     const loadable = getNodeLoadable(store, state, key);
-    const isKeyPointingToSelector = store.getState().knownSelectors.has(key);
 
     if (loadable.state !== 'loading' && isKeyPointingToSelector) {
       state.atomValues.set(key, loadable);


### PR DESCRIPTION
Summary:
Description of setup:
- A selector is read from a snapshot, and the selector depends on an atom that has an atom effect which calls `setSelf()` synchronously and adds some code to call `setSelf()` asynchronously later on, and the first time the app is reading the atom is in that snapshot (to reproduce it's important that the app has not read the atom before and therefore the atom has not initialized before, meaning the effects for that atom have not run yet). Then, the selector is read using a hook.

Expected behavior
- The atom effect runs twice as it is first initialized by the snapshot and then by the root store via a hook. The async calls to `setSelf()` should lead to re-renders with an updated selector value as its dependent atom has changed in value.

Issue:
- The atom effect only initializes once, so only the snapshot is aware of the asynchronous `setSelf()` calls but the root store is not, which results in the async calls to `setSelf()` being ignored and the UI does not update.

Differential Revision: D29886554

