### PR TITLE
add most-recent eviction option to cachePolicy_UNSTABLE

### DIFF
--- a/src/caches/Recoil_CachePolicy.js
+++ b/src/caches/Recoil_CachePolicy.js
@@ -12,11 +12,12 @@
 'use strict';
 
 export type EqualityPolicy = 'reference' | 'value';
-export type EvictionPolicy = 'lru' | 'none';
+export type EvictionPolicy = 'lru' | 'none' | 'most-recent';
 
 export type CachePolicy =
   | {eviction: 'lru', maxSize: number, equality?: EqualityPolicy}
   | {eviction: 'none', equality?: EqualityPolicy}
+  | {eviction: 'most-recent', equality?: EqualityPolicy}
   | {equality: EqualityPolicy};
 
 export type CachePolicyWithoutEviction = {equality: EqualityPolicy};

--- a/src/caches/Recoil_cacheFromPolicy.js
+++ b/src/caches/Recoil_cacheFromPolicy.js
@@ -60,6 +60,9 @@ function getCache<K, V>(
     case 'lru':
       // $FlowFixMe[method-unbinding]
       return new LRUCache<K, V>({mapKey, maxSize: nullthrows(maxSize)});
+    case 'most-recent':
+      // $FlowFixMe[method-unbinding]
+      return new LRUCache<K, V>({mapKey, maxSize: 1});
   }
 
   throw new Error(`Unrecognized eviction policy ${eviction}`);

--- a/src/caches/Recoil_treeCacheFromPolicy.js
+++ b/src/caches/Recoil_treeCacheFromPolicy.js
@@ -59,6 +59,8 @@ function getTreeCache<T>(
       return new TreeCache<T>({mapNodeValue});
     case 'lru':
       return treeCacheLRU<T>(nullthrows(maxSize), mapNodeValue);
+    case 'most-recent':
+      return treeCacheLRU<T>(1, mapNodeValue);
   }
 
   throw new Error(`Unrecognized eviction policy ${eviction}`);

--- a/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
@@ -131,4 +131,71 @@ describe('cacheFromPolicy()', () => {
     expect(cache.get({...obj1})).toBe(true);
     expect(cache.get({...obj3})).toBe(true);
   });
+
+  testRecoil('equality: reference, eviction: most-recent', () => {
+    const policy = {equality: 'reference', eviction: 'most-recent'};
+    const cache = cacheFromPolicy<{[string]: number}, boolean>(policy);
+
+    const obj1 = {a: 1};
+    const obj2 = {b: 2};
+    const obj3 = {c: 3};
+
+    cache.set(obj1, true);
+    cache.set(obj2, true);
+    cache.set(obj3, true);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(obj1)).toBe(undefined);
+    expect(cache.get(obj2)).toBe(undefined);
+
+    expect(cache.get(obj3)).toBe(true);
+
+    cache.set(obj1, true);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(obj2)).toBe(undefined);
+    expect(cache.get(obj3)).toBe(undefined);
+
+    expect(cache.get(obj1)).toBe(true);
+
+    expect(cache.get({...obj2})).toBe(undefined);
+    expect(cache.get({...obj1})).toBe(undefined);
+    expect(cache.get({...obj3})).toBe(undefined);
+  });
+
+  testRecoil('equality: value, eviction: most-recent', () => {
+    const policy = {equality: 'value', eviction: 'most-recent'};
+    const cache = cacheFromPolicy<{[string]: number}, boolean>(policy);
+
+    const obj1 = {a: 1};
+    const obj2 = {b: 2};
+    const obj3 = {c: 3};
+
+    cache.set(obj1, true);
+    cache.set(obj2, true);
+    cache.set(obj3, true);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(obj1)).toBe(undefined);
+    expect(cache.get(obj2)).toBe(undefined);
+
+    expect(cache.get(obj3)).toBe(true);
+
+    cache.set(obj1, true);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(obj2)).toBe(undefined);
+    expect(cache.get(obj3)).toBe(undefined);
+
+    expect(cache.get(obj1)).toBe(true);
+
+    expect(cache.get({...obj2})).toBe(undefined);
+    expect(cache.get({...obj3})).toBe(undefined);
+
+    expect(cache.get({...obj1})).toBe(true);
+  });
 });

--- a/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
@@ -177,4 +177,93 @@ describe('treeCacheFromPolicy()', () => {
     expect(cache.get(valGetterFromPath(clonePath(path1)))).toBe(obj1);
     expect(cache.get(valGetterFromPath(clonePath(path3)))).toBe(obj3);
   });
+
+  testRecoil('equality: reference, eviction: most-recent', () => {
+    const policy = {equality: 'reference', eviction: 'most-recent'};
+    const cache = treeCacheFromPolicy<{[string]: number}>(policy);
+
+    const path1 = [
+      ['a', [1]],
+      ['b', [2]],
+    ];
+    const obj1 = {a: 1};
+
+    const path2 = [['a', [2]]];
+    const obj2 = {b: 2};
+
+    const path3 = [
+      ['a', [3]],
+      ['c', [4]],
+    ];
+    const obj3 = {c: 3};
+
+    cache.set(path1, obj1);
+    cache.set(path2, obj2);
+    cache.set(path3, obj3);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(valGetterFromPath(path1))).toBe(undefined);
+    expect(cache.get(valGetterFromPath(path2))).toBe(undefined);
+
+    expect(cache.get(valGetterFromPath(path3))).toBe(obj3);
+
+    cache.set(path1, obj1);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(valGetterFromPath(path2))).toBe(undefined);
+    expect(cache.get(valGetterFromPath(path3))).toBe(undefined);
+
+    expect(cache.get(valGetterFromPath(path1))).toBe(obj1);
+
+    expect(cache.get(valGetterFromPath(clonePath(path1)))).toBe(undefined);
+    expect(cache.get(valGetterFromPath(clonePath(path2)))).toBe(undefined);
+    expect(cache.get(valGetterFromPath(clonePath(path3)))).toBe(undefined);
+  });
+
+  testRecoil('equality: value, eviction: most-recent', () => {
+    const policy = {equality: 'value', eviction: 'most-recent'};
+    const cache = treeCacheFromPolicy<{[string]: number}>(policy);
+
+    const path1 = [
+      ['a', [1]],
+      ['b', [2]],
+    ];
+    const obj1 = {a: 1};
+
+    const path2 = [['a', [2]]];
+    const obj2 = {b: 2};
+
+    const path3 = [
+      ['a', [3]],
+      ['c', [4]],
+    ];
+    const obj3 = {c: 3};
+
+    cache.set(path1, obj1);
+    cache.set(path2, obj2);
+    cache.set(path3, obj3);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(valGetterFromPath(path1))).toBe(undefined);
+    expect(cache.get(valGetterFromPath(path2))).toBe(undefined);
+
+    expect(cache.get(valGetterFromPath(path3))).toBe(obj3);
+
+    cache.set(path1, obj1);
+
+    expect(cache.size()).toBe(1);
+
+    expect(cache.get(valGetterFromPath(path2))).toBe(undefined);
+    expect(cache.get(valGetterFromPath(path3))).toBe(undefined);
+
+    expect(cache.get(valGetterFromPath(path1))).toBe(obj1);
+
+    expect(cache.get(valGetterFromPath(clonePath(path1)))).toBe(obj1);
+
+    expect(cache.get(valGetterFromPath(clonePath(path2)))).toBe(undefined);
+    expect(cache.get(valGetterFromPath(clonePath(path3)))).toBe(undefined);
+  });
 });


### PR DESCRIPTION
Summary: Although users can simulate a most-recent cache using an LRU of size 1, having an explicit `most-recent` option for this common use case is a much more clear and readable way of defining that behavior.

Differential Revision: D29981366

