### PR TITLE
Add cachePolicy_UNSTABLE to docs

### DIFF
--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -232,3 +232,33 @@ const menuItemState = selectorFamily({
   },
 });
 ```
+
+## Selector Cache Policy Configuration
+
+The `cachePolicy_UNSTABLE` property allows you to configure the caching behavior of a selector's internal cache. This property can be useful for reducing memory in applications that have a large number of selectors that have a large number of changing dependencies. For now the only configurable option is `eviction`, but we may add more in the future.
+
+Below is an example of how you might use this new property:
+
+```jsx
+const clockState = selector({
+  key: 'clockState',
+  get: ({get}) => {
+    const hour = get(hourState);
+    const minute = get(minuteState);
+    const second = get(secondState); // will re-run every second
+    return `${hour}:${minute}:${second}`;
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: 'most-recent', // will only store the most recent set of dependencies and their values
+  },
+});
+```
+
+In the example above, `clockState` recalculates every second, adding a new set of dependency values to the internal cache, which may lead to a memory issue over time as the internal cache grows indefinitely. Using the `most-recent` eviction policy, the internal selector cache will only retain the most recent set of dependencies and their values along with the output of running the selector using those dependencies, thus solving the memory issue. 
+
+Current eviction options are:
+- `lru` - evicts the least-recently-used value from the cache when the cache size exceeds the given `maxSize`
+- `most-recent` - retains only the most recent value and evicts any other values
+- `keep-all` (default) - keeps all entries in the cache and does not evict
+
+> **_NOTE:_** The default eviciton policy (currently `keep-all`) may change in the future.

--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -28,6 +28,8 @@ function selector<T>({
   ) => void,
 
   dangerouslyAllowMutability?: boolean,
+
+  cachePolicy_UNSTABLE?: CachePolicy,
 })
 ```
 
@@ -41,6 +43,11 @@ type GetCallback =
 type GetRecoilValue = <T>(RecoilValue<T>) => T;
 type SetRecoilState = <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
 type ResetRecoilState = <T>(RecoilState<T>) => void;
+
+type CachePolicy = 
+  | {eviction: 'lru', maxSize: number}
+  | {eviction: 'keep-all'}
+  | {eviction: 'most-recent'};
 ```
 
 - `key` - A unique string used to identify the selector internally. This string should be unique with respect to other atoms and selectors in the entire application.  It needs to be stable across executions if used for persistence.
@@ -52,6 +59,10 @@ type ResetRecoilState = <T>(RecoilState<T>) => void;
   - `set()` - a function used to set the values of upstream Recoil state. The first parameter is the Recoil state and the second parameter is the new value.  The new value may be an updater function or a `DefaultValue` object to propagate reset actions.
   - `reset()` - a function used to reset to the default values of upstream Recoil state. The only parameter is the Recoil state.
 - `dangerouslyAllowMutability` - In some cases it may be desireable allow mutating of objects stored in selectors that don't represent state changes.  Use this option to override freezing objects in development mode.
+- `cachePolicy_UNSTABLE` - Defines the behavior of the internal selector cache. Can be useful to control the memory footprint in apps that have selectors with many changing dependencies.
+  - `eviction` - can be set to `lru` (which requires that a `maxSize` is set), `keep-all` (default), or `most-recent`. An `lru` cache will evict the least-recently-used value from the selector cache when the size of the cache exceeds `maxSize`. A `keep-all` policy will mean all selector dependencies and their values will be indefinitely stored in the selector cache. A `most-recent` policy will use a cache of size 1 and will retain only the most recently saved set of dependencies and their values.
+  - Note the cache key in a selector's internal cache is a chain of dependencies and their values, and that key points to the output of the full run of the selector given that chain of dependencies. This means the size of the internal selector cache is a function of both the number of dependencies and the number of values for each dependency.
+  - This is an unstable API and may change in the future.
 
 ---
 

--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -61,8 +61,8 @@ type CachePolicy =
 - `dangerouslyAllowMutability` - In some cases it may be desireable allow mutating of objects stored in selectors that don't represent state changes.  Use this option to override freezing objects in development mode.
 - `cachePolicy_UNSTABLE` - Defines the behavior of the internal selector cache. Can be useful to control the memory footprint in apps that have selectors with many changing dependencies.
   - `eviction` - can be set to `lru` (which requires that a `maxSize` is set), `keep-all` (default), or `most-recent`. An `lru` cache will evict the least-recently-used value from the selector cache when the size of the cache exceeds `maxSize`. A `keep-all` policy will mean all selector dependencies and their values will be indefinitely stored in the selector cache. A `most-recent` policy will use a cache of size 1 and will retain only the most recently saved set of dependencies and their values.
-  - Note the cache key in a selector's internal cache is a chain of dependencies and their values, and that key points to the output of the full run of the selector given that chain of dependencies. This means the size of the internal selector cache is a function of both the number of dependencies and the number of values for each dependency.
-  - This is an unstable API and may change in the future.
+  - Note the cache stores the values of the selector based on a key containing all dependencies and their values. This means the size of the internal selector cache depends on both the size of the selector values as well as the number of unique values of all dependencies.
+  - Note the default eviction policy (currently `keep-all`) may change in the future.
 
 ---
 

--- a/docs/docs/api-reference/utils/selectorFamily.md
+++ b/docs/docs/api-reference/utils/selectorFamily.md
@@ -59,8 +59,9 @@ type CachePolicy =
 - `set?` - An optional function that will produce writeable selectors when provided. It should be a function that takes an object of named callbacks, same as the `selector()` interface. This is again wrapped by another function with gets the parameters from calling the selector family function.
 - `cachePolicy_UNSTABLE` - Defines the behavior of the internal selector cache for **the invidual selectors** that make up the family (it does not control the number of selectors that are stored in the family). Can be useful to control the memory footprint in apps that have selectors with many changing dependencies.
   - `eviction` - can be set to `lru` (which requires that a `maxSize` is set), `keep-all` (default), or `most-recent`. An `lru` cache will evict the least-recently-used value from the selector cache when the size of the cache exceeds `maxSize`. A `keep-all` policy will mean all selector dependencies and their values will be indefinitely stored in the selector cache. A `most-recent` policy will use a cache of size 1 and will retain only the most recently saved set of dependencies and their values.
-  - Note the cache key in a selector's internal cache is a chain of dependencies and their values, and that key points to the output of the full run of the selector given that chain of dependencies. This means the size of the internal selector cache is a function of both the number of dependencies and the number of values for each dependency.
-  - This is an unstable API and may change in the future.
+  - Note the `maxSize` property used alongside `lru` does not control the max size of the family itself, it only controls the eviction policy used in the invidiual selectors that make up the family. 
+  - Note the cache stores the values of the selector based on a key containing all dependencies and their values. This means the size of the internal selector cache depends on both the size of the selector values as well as the number of unique values of all dependencies.
+  - Note the default eviction policy (currently `keep-all`) may change in the future.
 
 ---
 


### PR DESCRIPTION
Adds documentation for the upcoming `cachePolicy_UNSTABLE` API addition to selectors.