### PR TITLE
rename eviction policy option name from 'none' to 'keep-all' to be more explicit

### DIFF
--- a/src/caches/Recoil_CachePolicy.js
+++ b/src/caches/Recoil_CachePolicy.js
@@ -12,11 +12,11 @@
 'use strict';
 
 export type EqualityPolicy = 'reference' | 'value';
-export type EvictionPolicy = 'lru' | 'none' | 'most-recent';
+export type EvictionPolicy = 'lru' | 'keep-all' | 'most-recent';
 
 export type CachePolicy =
   | {eviction: 'lru', maxSize: number, equality?: EqualityPolicy}
-  | {eviction: 'none', equality?: EqualityPolicy}
+  | {eviction: 'keep-all', equality?: EqualityPolicy}
   | {eviction: 'most-recent', equality?: EqualityPolicy}
   | {equality: EqualityPolicy};
 

--- a/src/caches/Recoil_cacheFromPolicy.js
+++ b/src/caches/Recoil_cacheFromPolicy.js
@@ -54,7 +54,7 @@ function getCache<K, V>(
   mapKey: mixed => mixed,
 ): CacheImplementation<K, V> {
   switch (eviction) {
-    case 'none':
+    case 'keep-all':
       // $FlowFixMe[method-unbinding]
       return new MapCache<K, V>({mapKey});
     case 'lru':

--- a/src/caches/Recoil_treeCacheFromPolicy.js
+++ b/src/caches/Recoil_treeCacheFromPolicy.js
@@ -22,7 +22,7 @@ const treeCacheLRU = require('./Recoil_treeCacheLRU');
 
 const defaultPolicy = {
   equality: 'reference',
-  eviction: 'none',
+  eviction: 'keep-all',
   maxSize: Infinity,
 };
 
@@ -54,7 +54,7 @@ function getTreeCache<T>(
   mapNodeValue: mixed => mixed,
 ): TreeCacheImplementation<T> {
   switch (eviction) {
-    case 'none':
+    case 'keep-all':
       // $FlowFixMe[method-unbinding]
       return new TreeCache<T>({mapNodeValue});
     case 'lru':

--- a/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
@@ -20,8 +20,8 @@ const testRecoil = getRecoilTestFn(() => {
 });
 
 describe('cacheFromPolicy()', () => {
-  testRecoil('equality: reference, eviction: none', () => {
-    const policy = {equality: 'reference', eviction: 'none'};
+  testRecoil('equality: reference, eviction: keep-all', () => {
+    const policy = {equality: 'reference', eviction: 'keep-all'};
     const cache = cacheFromPolicy<{[string]: number}, boolean>(policy);
 
     const obj1 = {a: 1};
@@ -43,8 +43,8 @@ describe('cacheFromPolicy()', () => {
     expect(cache.get({...obj3})).toBe(undefined);
   });
 
-  testRecoil('equality: value, eviction: none', () => {
-    const policy = {equality: 'value', eviction: 'none'};
+  testRecoil('equality: value, eviction: keep-all', () => {
+    const policy = {equality: 'value', eviction: 'keep-all'};
     const cache = cacheFromPolicy<{[string]: number}, boolean>(policy);
 
     const obj1 = {a: 1};

--- a/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
@@ -24,8 +24,8 @@ const valGetterFromPath = path => nodeKey =>
 const clonePath = path => JSON.parse(JSON.stringify(path));
 
 describe('treeCacheFromPolicy()', () => {
-  testRecoil('equality: reference, eviction: none', () => {
-    const policy = {equality: 'reference', eviction: 'none'};
+  testRecoil('equality: reference, eviction: keep-all', () => {
+    const policy = {equality: 'reference', eviction: 'keep-all'};
     const cache = treeCacheFromPolicy<{[string]: number}>(policy);
 
     const path1 = [
@@ -58,8 +58,8 @@ describe('treeCacheFromPolicy()', () => {
     expect(cache.get(valGetterFromPath(clonePath(path3)))).toBe(undefined);
   });
 
-  testRecoil('equality: value, eviction: none', () => {
-    const policy = {equality: 'value', eviction: 'none'};
+  testRecoil('equality: value, eviction: keep-all', () => {
+    const policy = {equality: 'value', eviction: 'keep-all'};
     const cache = treeCacheFromPolicy<{[string]: number}>(policy);
 
     const path1 = [

--- a/src/recoil_values/Recoil_atomFamily.js
+++ b/src/recoil_values/Recoil_atomFamily.js
@@ -83,7 +83,7 @@ function atomFamily<T, P: Parameter>(
 ): P => RecoilState<T> {
   const atomCache = cacheFromPolicy<P, RecoilState<T>>({
     equality: options.cachePolicyForParams_UNSTABLE?.equality ?? 'value',
-    eviction: 'none',
+    eviction: 'keep-all',
   });
 
   // Simple atomFamily implementation to cache individual atoms based

--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -205,7 +205,7 @@ function selector<T>(
   const cache: TreeCacheImplementation<Loadable<T>> = treeCacheFromPolicy(
     cachePolicy ?? {
       equality: 'reference',
-      eviction: 'none',
+      eviction: 'keep-all',
     },
   );
 

--- a/src/recoil_values/Recoil_selectorFamily.js
+++ b/src/recoil_values/Recoil_selectorFamily.js
@@ -101,7 +101,7 @@ function selectorFamily<T, Params: Parameter>(
     RecoilState<T> | RecoilValueReadOnly<T>,
   >({
     equality: options.cachePolicyForParams_UNSTABLE?.equality ?? 'value',
-    eviction: 'none',
+    eviction: 'keep-all',
   });
 
   return (params: Params) => {

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -112,7 +112,7 @@ export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-
 
 // export type EqualityPolicy = 'reference' | 'value'; TODO: removing while we discuss long term API
 
-export type EvictionPolicy = 'lru' | 'none';
+export type EvictionPolicy = 'lru' | 'keep-all' | 'most-recent';
 
 // TODO: removing while we discuss long term API
 // export type CachePolicy =
@@ -125,7 +125,7 @@ export type EvictionPolicy = 'lru' | 'none';
 //   equality: EqualityPolicy;
 // }
 
-export type CachePolicyWithoutEquality = {eviction: 'lru', maxSize: number} | {eviction: 'none'} | {eviction: 'most-recent'};
+export type CachePolicyWithoutEquality = {eviction: 'lru', maxSize: number} | {eviction: 'keep-all'} | {eviction: 'most-recent'};
 
 export interface ReadOnlySelectorOptions<T> {
     key: string;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -604,7 +604,7 @@ isRecoilValue(mySelector1);
     key: 'ReadOnlySelectorSel_cachePolicy2',
     get: () => {},
     cachePolicy_UNSTABLE: {
-      eviction: 'none',
+      eviction: 'keep-all',
     }
   });
 
@@ -635,7 +635,7 @@ isRecoilValue(mySelector1);
     key: 'ReadOnlySelectorFSel_cachePolicy2',
     get: () => () => {},
     cachePolicy_UNSTABLE: {
-      eviction: 'none',
+      eviction: 'keep-all',
     }
   });
 


### PR DESCRIPTION
Summary: Per Doug's suggestion, renaming to `keep-all` to be more explicit as an eviction policy of `none` sounds ambiguous / confusing.

Reviewed By: drarmstr

Differential Revision: D29981607

