### PR TITLE
Documentation for 0.4

### DIFF
--- a/docs/blog/2021-03-22-0.2.0-released.md
+++ b/docs/blog/2021-03-22-0.2.0-released.md
@@ -1,5 +1,5 @@
 ---
-title: Recoil 0.2.0
+title: Recoil 0.2
 ---
 
 We are pleased to announce the release of Recoil 0.2.0. This release has a new, more reliable implementation of async selectors, greatly improved performance, and many bug fixes and improvements.

--- a/docs/blog/2021-05-14-0.3.0-released.md
+++ b/docs/blog/2021-05-14-0.3.0-released.md
@@ -1,8 +1,10 @@
 ---
-title: Recoil 0.3.0
+title: Recoil 0.3
 ---
 
-We are pleased to announce the release of Recoil 0.3.0.
+We are pleased to announce the release of Recoil 0.3 with more flexible RecoilRoot nesting, callback generation, preparation for memory management, optimizations, and bug fixes.
+
+<!--truncate-->
 
 ## New Features
 

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -6,7 +6,7 @@ We are pleased to announce the release of Recoil 0.4 with initial Recoil Transac
 
 ## Recoil Transactions
 
-Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allow for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace the need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API most of the time.
+Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allows for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace the need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API most of the time.
 
 *This is the initial implementation of the hook.  There are various limitations and future plans for transactions, please [read the docs](/docs/api-reference/core/useRecoilTransaction#current-limitations-and-future-vision).*
 

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -6,7 +6,7 @@ We are pleased to announce the release of Recoil 0.4 with initial Recoil Transac
 
 ## Recoil Transactions
 
-Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allow for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace most need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API.  It is still preliminary, however, so read the docs for current limitations.
+Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allow for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace the need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API most of the time.  It is still preliminary, however, so read the docs for current limitations.
 
 **Example**
 
@@ -25,7 +25,7 @@ const goForward = useRecoilTransaction_UNSTABLE(({get, set}) => (distance) => {
 
 Then you can execute the transaction by just calling `goForward(distance)` in an event handler.  This will update state based on the *current* values, not the state when the components rendered.  You can also read the values of previous writes during a transaction.  Because no other updates will be committed while the updater is executing, you will see a consistent store of state.
 
-the previous approach using `useRecoilCallback()` might have looked like the following:
+the previous approach using [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) might have looked like the following:
 
 ```jsx
 const goForward = useRecoilCallback(({snapshot, gotoSnapshot}) => (distance) => {

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -71,9 +71,34 @@ const reducer = useRecoilTransaction_UNSTABLE(({get, set}) => action => {
 
 ## Selector Cache Policy Configuration
 
-***TODO***
+The new `cachePolicy_UNSTABLE` property in [selectors](/docs/api-reference/core/selector) and [selector families](/docs/api-reference/utils/selectorFamily) allows you to configure the caching behavior of a selector's internal cache. This property can be useful for reducing memory in applications that have a large number of selectors that have a large number of changing dependencies. For now the only configurable option is `eviction`, but we may add more in the future.
 
-TODO NOTE: Default may change in the future.
+Below is an example of how you might use this new property:
+
+```jsx
+const clockState = selector({
+  key: 'clockState',
+  get: ({get}) => {
+    const hour = get(hourState);
+    const minute = get(minuteState);
+    const second = get(secondState); // will re-run every second
+
+    return `${hour}:${minute}:${second}`;
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: 'most-recent', // will only store the most recent set of dependencies and their values
+  },
+});
+```
+
+In the example above, `clockState` recalculates every second, adding a new set of dependency values to the internal cache, which may lead to a memory issue over time as the internal cache grows indefinitely. Using the `most-recent` eviction policy, the internal selector cache will only retain the most recent set of dependencies and their values along with the output of running the selector using those dependencies, thus solving the memory issue. 
+
+Current eviction options are:
+- `lru` - evicts the least-recently-used value from the cache when the cache size exceeds the given `maxSize`
+- `most-recent` - retains only the most recent value and evicts any other values
+- `keep-all` (default) - keeps all entries in the cache and does not evict
+
+> **_NOTE:_** The default eviciton policy (currently `keep-all`) may change in the future.
 
 ## Fixes and Optimizations
 

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -1,0 +1,87 @@
+---
+title: Recoil 0.4
+---
+
+We are pleased to announce the release of Recoil 0.4 with initial Recoil Transactions, selector cache configuration, and other optimizations and fixes.
+
+## Recoil Transactions
+
+Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allow for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace most need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API.  It is still preliminary, however, so read the docs for current limitations.
+
+**Example**
+
+Suppose we have two atoms, `positionState` and `headingState`, and we'd like to update them together as part of a single action, where the new value of `positionState` is a function of *both* the current value of `positionState` and `headingState`.  You can accomplish this with a transaction, which must be a pure function without side-effects:
+
+```jsx
+const goForward = useRecoilTransaction_UNSTABLE(({get, set}) => (distance) => {
+  const heading = get(headingState);
+  const position = get(positionState);
+  set(positionAtom, {
+    x: position.x + cos(heading) * distance,
+    y: position.y + sin(heading) * distance,
+  });
+});
+```
+
+Then you can execute the transaction by just calling `goForward(distance)` in an event handler.  This will update state based on the *current* values, not the state when the components rendered.  You can also read the values of previous writes during a transaction.  Because no other updates will be committed while the updater is executing, you will see a consistent store of state.
+
+the previous approach using `useRecoilCallback()` might have looked like the following:
+
+```jsx
+const goForward = useRecoilCallback(({snapshot, gotoSnapshot}) => (distance) => {
+  const mutatedSnapshot = snapshot.map(({get, set}) => {
+    const heading = get(headingState);
+    const position = get(positonState);
+    set(positionState, {
+      x: position.x + cos(heading) * distance,
+      y: position.y + sin(heading) * distance,
+    });
+  });
+  gotoSnapshot(mutatedSnapshot);
+});
+```
+
+This has the following drawbacks:
+* There is performance overhead for managing the full generality of snapshots.
+* There is more opportunity for bugs:  The snapshot might be retained and used in the future.  Since a snapshot contains the complete set of Recoil state, not just a changeset, that could accidentally rewind changes that occurred between creating and committing the snapshot.
+
+**Reducer Example**
+
+You can also use this hook to create a reducer pattern of executing actions over multiple atoms:
+
+```jsx
+const reducer = useRecoilTransaction_UNSTABLE(({get, set}) => action => {
+  switch(action.type) {
+    case 'goForward':
+      const heading = get(headingState);
+      set(positionState, position => {
+        x: position.x + cos(heading) * action.distance,
+        y: position.y + sin(heading) * action.distance,
+      });
+      break;
+
+    case 'turn':
+      set(headingState, action.heading);
+      break;
+  }
+});
+```
+
+*There are various limitations and future plans for transactions, please [read the docs](/docs/api-reference/core/useRecoilTransaction#current-limitations-and-future-vision).*
+
+## Selector Cache Policy Configuration
+
+***TODO***
+
+TODO NOTE: Default may change in the future.
+
+## Fixes and Optimizations
+
+- Fix TypeScript typing for `selectorFamily()`, `getCallback()`, `useGetRecoilValueInfo()`, and `Snapshot#getNodes()` (#1060, #1116, #1123)
+- Allow mutable values in selectors (enabled via the `dangerouslyAllowMutability` selector option) to be used with `waitFor*()` helpers such as [`waitForAll()`](/docs/api-reference/utils/waitForAll) (#1074, #1096)
+- [Atom Effects](/docs/guides/atom-effects) fixes:
+  - Fix `onSet()` handler to get the proper new value when an atom is reset or has an async default Promise that resolves (#1059, #1050, #738) (This is a slightly breaking change because the actual new value will be provided to the handler instead of a `DefaultValue` placeholder)
+  - Fix support for multiple Atom Effects cleanup handlers (#1125)
+  - Fix selector subscriptions when atoms with effects are initialized via a `Snapshot` (#1135, #1107)
+- Optimization for async selectors when dependencies resolve to cached values (#1037)
+- Remove unnecessary warning message (#1034, #1062)

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -77,11 +77,11 @@ TODO NOTE: Default may change in the future.
 
 ## Fixes and Optimizations
 
-- Fix TypeScript typing for `selectorFamily()`, `getCallback()`, `useGetRecoilValueInfo()`, and `Snapshot#getNodes()` (#1060, #1116, #1123)
-- Allow mutable values in selectors (enabled via the `dangerouslyAllowMutability` selector option) to be used with `waitFor*()` helpers such as [`waitForAll()`](/docs/api-reference/utils/waitForAll) (#1074, #1096)
+- Fix TypeScript typing for `selectorFamily()`, `getCallback()`, `useGetRecoilValueInfo()`, and `Snapshot#getNodes()` ([#1060](https://github.com/facebookexperimental/Recoil/pull/1060), [#1116](https://github.com/facebookexperimental/Recoil/pull/1116), [#1123](https://github.com/facebookexperimental/Recoil/pull/1123))
+- Allow mutable values in selectors (enabled via the `dangerouslyAllowMutability` selector option) to be used with `waitFor*()` helpers such as [`waitForAll()`](/docs/api-reference/utils/waitForAll) ([#1074](https://github.com/facebookexperimental/Recoil/pull/1074), [#1096](https://github.com/facebookexperimental/Recoil/pull/1096))
 - [Atom Effects](/docs/guides/atom-effects) fixes:
-  - Fix `onSet()` handler to get the proper new value when an atom is reset or has an async default Promise that resolves (#1059, #1050, #738) (This is a slightly breaking change because the actual new value will be provided to the handler instead of a `DefaultValue` placeholder)
-  - Fix support for multiple Atom Effects cleanup handlers (#1125)
-  - Fix selector subscriptions when atoms with effects are initialized via a `Snapshot` (#1135, #1107)
-- Optimization for async selectors when dependencies resolve to cached values (#1037)
-- Remove unnecessary warning message (#1034, #1062)
+  - Fix `onSet()` handler to get the proper new value when an atom is reset or has an async default Promise that resolves ([#1059](https://github.com/facebookexperimental/Recoil/pull/1059), [#1050](https://github.com/facebookexperimental/Recoil/pull/1050), [#738](https://github.com/facebookexperimental/Recoil/pull/738)) (This is a slightly breaking change because the actual new value will be provided to the handler instead of a `DefaultValue` placeholder)
+  - Fix support for multiple Atom Effects cleanup handlers ([#1125](https://github.com/facebookexperimental/Recoil/pull/1125))
+  - Fix selector subscriptions when atoms with effects are initialized via a `Snapshot` ([#1135](https://github.com/facebookexperimental/Recoil/pull/1135), [#1107](https://github.com/facebookexperimental/Recoil/pull/1107))
+- Optimization for async selectors when dependencies resolve to cached values ([#1037](https://github.com/facebookexperimental/Recoil/pull/1037))
+- Remove unnecessary warning message ([#1034](https://github.com/facebookexperimental/Recoil/pull/1034), [#1062](https://github.com/facebookexperimental/Recoil/pull/1062))

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -6,7 +6,7 @@ We are pleased to announce the release of Recoil 0.4 with configurable selector 
 
 ## Configurable selector caches
 
-The new `cachePolicy_UNSTABLE` property in [selectors](/docs/api-reference/core/selector) and [selector families](/docs/api-reference/utils/selectorFamily) allows you to configure the caching behavior of a selector's internal cache.  This property can be useful for reducing memory in applications that have a large number of selectors or selectors that have a large number of changing dependencies.
+The new [`cachePolicy_UNSTABLE`](/docs/api-reference/core/selector#cache-policy-configuration) property in [selectors](/docs/api-reference/core/selector) and [selector families](/docs/api-reference/utils/selectorFamily) allows you to configure the caching behavior of a selector's internal cache.  This property can be useful for reducing memory in applications that have a large number of selectors or selectors that have a large number of changing dependencies.
 
 Below is an example of how you might use this new property:
 

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -6,7 +6,9 @@ We are pleased to announce the release of Recoil 0.4 with initial Recoil Transac
 
 ## Recoil Transactions
 
-Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allow for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace the need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API most of the time.  It is still preliminary, however, so read the docs for current limitations.
+Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allow for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace the need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API most of the time.
+
+*This is the initial implementation of the hook.  There are various limitations and future plans for transactions, please [read the docs](/docs/api-reference/core/useRecoilTransaction#current-limitations-and-future-vision).*
 
 **Example**
 
@@ -66,8 +68,6 @@ const reducer = useRecoilTransaction_UNSTABLE(({get, set}) => action => {
   }
 });
 ```
-
-*There are various limitations and future plans for transactions, please [read the docs](/docs/api-reference/core/useRecoilTransaction#current-limitations-and-future-vision).*
 
 ## Selector Cache Policy Configuration
 

--- a/docs/blog/2021-07-30-0.4.0-release.md
+++ b/docs/blog/2021-07-30-0.4.0-release.md
@@ -2,15 +2,45 @@
 title: Recoil 0.4
 ---
 
-We are pleased to announce the release of Recoil 0.4 with initial Recoil Transactions, selector cache configuration, and other optimizations and fixes.
+We are pleased to announce the release of Recoil 0.4 with configurable selector caches, improved API for transactions with multiple atoms, and other optimizations and fixes.
 
-## Recoil Transactions
+## Configurable selector caches
 
-Introducing Recoil Transactions!  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) API allows for an easier, more performant, and safer way to atomically update multiple atoms together.  For the simple case this could be thought of as similar to the "updater" form of setting Recoil state, but over multiple atoms.  This new hook is easier to use and should replace the need to use the [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) API most of the time.
+The new `cachePolicy_UNSTABLE` property in [selectors](/docs/api-reference/core/selector) and [selector families](/docs/api-reference/utils/selectorFamily) allows you to configure the caching behavior of a selector's internal cache.  This property can be useful for reducing memory in applications that have a large number of selectors or selectors that have a large number of changing dependencies.
 
-*This is the initial implementation of the hook.  There are various limitations and future plans for transactions, please [read the docs](/docs/api-reference/core/useRecoilTransaction#current-limitations-and-future-vision).*
+Below is an example of how you might use this new property:
 
-**Example**
+```jsx
+const clockState = selector({
+  key: 'clockState',
+  get: ({get}) => {
+    const hour = get(hourState);
+    const minute = get(minuteState);
+    const second = get(secondState); // will re-run every second
+
+    return `${hour}:${minute}:${second}`;
+  },
+  cachePolicy_UNSTABLE: {
+    // Only store the most recent set of dependencies and their values
+    eviction: 'most-recent',
+  },
+});
+```
+
+In the example above, `clockState` recalculates every second, adding a new set of dependency values to the internal cache, which may lead to a memory issue over time as the internal cache grows indefinitely. Using the `most-recent` eviction policy, the internal selector cache will only retain the most recent set of dependencies and their values, along with the actual selector value based on those dependencies, thus solving the memory issue.
+
+Current eviction options are:
+- `lru` - evicts the least-recently-used value from the cache when the size exceeds `maxSize`.
+- `most-recent` - retains only the most recent value.
+- `keep-all` (default) - keeps all entries in the cache and does not evict.
+
+> **_NOTE:_** *The default eviction policy (currently `keep-all`) may change in the future.*
+
+## Transactions with multiple atoms
+
+Introducing an improved API for updating multiple atoms together as a single transaction.  The new [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) hook is easier, more efficient, and safer than before.  This new hook should eventually replace most uses of [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback), however this release is only an initial implementation with [certain limitations](/docs/api-reference/core/useRecoilTransaction#current-limitations-and-future-vision) that will be addressed in future releases.
+
+### Example
 
 Suppose we have two atoms, `positionState` and `headingState`, and we'd like to update them together as part of a single action, where the new value of `positionState` is a function of *both* the current value of `positionState` and `headingState`.  You can accomplish this with a transaction, which must be a pure function without side-effects:
 
@@ -33,7 +63,7 @@ the previous approach using [`useRecoilCallback()`](/docs/api-reference/core/use
 const goForward = useRecoilCallback(({snapshot, gotoSnapshot}) => (distance) => {
   const mutatedSnapshot = snapshot.map(({get, set}) => {
     const heading = get(headingState);
-    const position = get(positonState);
+    const position = get(positionState);
     set(positionState, {
       x: position.x + cos(heading) * distance,
       y: position.y + sin(heading) * distance,
@@ -47,7 +77,7 @@ This has the following drawbacks:
 * There is performance overhead for managing the full generality of snapshots.
 * There is more opportunity for bugs:  The snapshot might be retained and used in the future.  Since a snapshot contains the complete set of Recoil state, not just a changeset, that could accidentally rewind changes that occurred between creating and committing the snapshot.
 
-**Reducer Example**
+### Reducer Example
 
 You can also use this hook to create a reducer pattern of executing actions over multiple atoms:
 
@@ -68,37 +98,6 @@ const reducer = useRecoilTransaction_UNSTABLE(({get, set}) => action => {
   }
 });
 ```
-
-## Selector Cache Policy Configuration
-
-The new `cachePolicy_UNSTABLE` property in [selectors](/docs/api-reference/core/selector) and [selector families](/docs/api-reference/utils/selectorFamily) allows you to configure the caching behavior of a selector's internal cache. This property can be useful for reducing memory in applications that have a large number of selectors that have a large number of changing dependencies. For now the only configurable option is `eviction`, but we may add more in the future.
-
-Below is an example of how you might use this new property:
-
-```jsx
-const clockState = selector({
-  key: 'clockState',
-  get: ({get}) => {
-    const hour = get(hourState);
-    const minute = get(minuteState);
-    const second = get(secondState); // will re-run every second
-
-    return `${hour}:${minute}:${second}`;
-  },
-  cachePolicy_UNSTABLE: {
-    eviction: 'most-recent', // will only store the most recent set of dependencies and their values
-  },
-});
-```
-
-In the example above, `clockState` recalculates every second, adding a new set of dependency values to the internal cache, which may lead to a memory issue over time as the internal cache grows indefinitely. Using the `most-recent` eviction policy, the internal selector cache will only retain the most recent set of dependencies and their values along with the output of running the selector using those dependencies, thus solving the memory issue. 
-
-Current eviction options are:
-- `lru` - evicts the least-recently-used value from the cache when the cache size exceeds the given `maxSize`
-- `most-recent` - retains only the most recent value and evicts any other values
-- `keep-all` (default) - keeps all entries in the cache and does not evict
-
-> **_NOTE:_** The default eviciton policy (currently `keep-all`) may change in the future.
 
 ## Fixes and Optimizations
 

--- a/docs/docs/api-reference/core/selector.md
+++ b/docs/docs/api-reference/core/selector.md
@@ -44,7 +44,7 @@ type GetRecoilValue = <T>(RecoilValue<T>) => T;
 type SetRecoilState = <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
 type ResetRecoilState = <T>(RecoilState<T>) => void;
 
-type CachePolicy = 
+type CachePolicy =
   | {eviction: 'lru', maxSize: number}
   | {eviction: 'keep-all'}
   | {eviction: 'most-recent'};
@@ -233,7 +233,7 @@ const menuItemState = selectorFamily({
 });
 ```
 
-## Selector Cache Policy Configuration
+## Cache policy configuration
 
 The `cachePolicy_UNSTABLE` property allows you to configure the caching behavior of a selector's internal cache. This property can be useful for reducing memory in applications that have a large number of selectors that have a large number of changing dependencies. For now the only configurable option is `eviction`, but we may add more in the future.
 
@@ -246,19 +246,21 @@ const clockState = selector({
     const hour = get(hourState);
     const minute = get(minuteState);
     const second = get(secondState); // will re-run every second
+
     return `${hour}:${minute}:${second}`;
   },
   cachePolicy_UNSTABLE: {
-    eviction: 'most-recent', // will only store the most recent set of dependencies and their values
+    // Only store the most recent set of dependencies and their values
+    eviction: 'most-recent',
   },
 });
 ```
 
-In the example above, `clockState` recalculates every second, adding a new set of dependency values to the internal cache, which may lead to a memory issue over time as the internal cache grows indefinitely. Using the `most-recent` eviction policy, the internal selector cache will only retain the most recent set of dependencies and their values along with the output of running the selector using those dependencies, thus solving the memory issue. 
+In the example above, `clockState` recalculates every second, adding a new set of dependency values to the internal cache, which may lead to a memory issue over time as the internal cache grows indefinitely. Using the `most-recent` eviction policy, the internal selector cache will only retain the most recent set of dependencies and their values, along with the actual selector value based on those dependencies, thus solving the memory issue.
 
 Current eviction options are:
-- `lru` - evicts the least-recently-used value from the cache when the cache size exceeds the given `maxSize`
-- `most-recent` - retains only the most recent value and evicts any other values
-- `keep-all` (default) - keeps all entries in the cache and does not evict
+- `lru` - evicts the least-recently-used value from the cache when the size exceeds `maxSize`.
+- `most-recent` - retains only the most recent value.
+- `keep-all` (*default*) - keeps all entries in the cache and does not evict.
 
-> **_NOTE:_** The default eviciton policy (currently `keep-all`) may change in the future.
+> **_NOTE:_** *The default eviction policy (currently `keep-all`) may change in the future.*

--- a/docs/docs/api-reference/core/useRecoilCallback.md
+++ b/docs/docs/api-reference/core/useRecoilCallback.md
@@ -20,6 +20,7 @@ type CallbackInterface = {
   gotoSnapshot: Snapshot => void,
   set: <T>(RecoilState<T>, (T => T) | T) => void,
   reset: <T>(RecoilState<T>) => void,
+  transact_UNSTABLE: ((TransactionInterface) => void) => void,
 };
 
 function useRecoilCallback<Args, ReturnValue>(
@@ -36,6 +37,7 @@ Callback Interface:
 * **`gotoSnapshot`** - Enqueue updating the global state to match the provided [`Snapshot`](/docs/api-reference/core/Snapshot).
 * **`set`** - Enqueue setting the value of an atom or selector.  Like elsewhere, you may either provide the new value directly or an updater function that returns the new value and takes the current value as a parameter.  The current value represents all other enqueued state changes to date in the current transaction.
 * **`reset`** - Reset the value of an atom or selector to its default.
+* **`transact_UNSTABLE`** - Execute a transaction.  See the [`useRecoilTransaction_UNSTABLE()` documentation](/docs/api-reference/core/useRecoilTransaction).
 
 ### Lazy Read Example
 

--- a/docs/docs/api-reference/core/useRecoilTransaction.md
+++ b/docs/docs/api-reference/core/useRecoilTransaction.md
@@ -1,0 +1,113 @@
+---
+title: useRecoilTransaction_UNSTABLE(callback, deps)
+sidebar_label: useRecoilTransaction()
+---
+
+pending dependencies
+selectors
+selector set
+async
+useRecoilCallback transact
+Promise return value
+
+Create a transaction callback which can be used to atomically update multiple atoms in a safe, easy, and performant way.  Provide a callback which executes the transaction and can `get()` or `set()` multiple atoms.  A transaction is similar to the "updater" form of setting Recoil state, but over multiple atoms.  Writes are visible to subsequent reads from within the same transaction.
+
+In addition to transactions, this hook is also useful to:
+* Implement reducer patterns to perform actions on multiple atoms.
+* Dynamically updating an atom where we may not know at render-time which atom or selector we will want to update, so we can't use [`useSetRecoilState()`](/docs/api-reference/core/useSetRecoilState).
+* [Pre-fetching](/docs/guides/asynchronous-data-queries#pre-fetching) data before rendering.
+
+---
+
+```jsx
+interface TransactionInterface {
+  get: <T>(RecoilValue<T>) => T;
+  set: <T>(RecoilState<T>,  (T => T) | T) => void;
+  reset: <T>(RecoilState<T>) => void;
+}
+
+function useRecoilTransaction_UNSTABLE<Args>(
+  callback: TransactionInterface => (...Args) => void,
+  deps?: $ReadOnlyArray<mixed>,
+): (...Args) => void
+```
+
+* **`callback`** - User callback function with a wrapper function that provides the transaction interface.  ***This function must be pure without any side-effects.***
+* **`deps`** - An optional set of dependencies for memoizing the callback.  Like `useCallback()`, the produced transaction callback will not be memoized by default and will produce a new function with each render.  You can pass an empty array to always return the same function instance.  If you pass values in the `deps` array, a new function will be used if the reference equality of any dep changes.  Those values can then be used from within the body of your callback without getting stale.  (See [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback))  You can [update eslint](/docs/introduction/installation#eslint) to help ensure this is used correctly.
+
+Transaction Interface:
+* **`get`** - Get the current value for the requested Recoil state, reflecting any writes performed earlier in the transaction.  This currently only supports synchronous atoms.
+* **`set`** - Set the value of an atom.  You may either provide the new value directly or an updater function that returns the new value and takes the current value as a parameter.  The current value represents all other pending state changes to date in the current transaction.
+* **`reset`** - Reset the value of an atom to its default.
+
+### Transaction Example
+
+Suppose we have two atoms, `positionState` and `headingState`, and we'd like to update them together as part of a single action, where the new value of `positionState` is a function of *both* the current value of `positionState` and `headingState`.
+
+```jsx
+const goForward = useRecoilTransaction_UNSTABLE(({get, set}) => (distance) => {
+  const heading = get(headingState);
+  const position = get(positionState);
+  set(positionAtom, {
+    x: position.x + cos(heading) * distance,
+    y: position.y + sin(heading) * distance,
+  });
+});
+```
+
+Then you can execute the transaction by just calling `goForward(distance)` in an event handler.  This will update state based on the *current* values, not the state when the components rendered.
+
+You can also read the values of previous writes during a transaction.  Because no other updates will be committed while the updater is executing, you will see a consistent store of state.
+
+```jsx
+const moveInAnL = useRecoilTransaction_UNSTABLE(({get, set}) => () => {
+  // Move Forward 1
+  const heading = get(headingState);
+  const position = get(positionState);
+  set(positionState, {
+    x: position.x + cos(heading),
+    y: position.y + sin(heading),
+  });
+
+  // Turn Right
+  set(headingState, heading => heading + 90);
+
+  // Move Forward 1
+  const newHeading = get(headingState);
+  const newPosition = get(positionState);
+  set(positionState, {
+    x: newPosition.x + cos(newHeading),
+    y: newPosition.y + sin(newHeading),
+  });
+});
+```
+
+### Reducer Example
+
+This hook is also useful for implementing reducer patterns to execute actions over multiple atoms:
+
+```jsx
+const reducer = useRecoilTransaction_UNSTABLE(({get, set}) => action => {
+  switch(action.type) {
+    case 'goForward':
+      const heading = get(headingState);
+      set(positionState, position => {
+        x: position.x + cos(heading) * action.distance,
+        y: position.y + sin(heading) * action.distance,
+      });
+      break;
+
+    case 'turn':
+      set(headingState, action.heading);
+      break;
+  }
+});
+```
+
+### Current Limitations and Future Vision
+
+* Transactions currently only support atoms, not yet selectors.  This support can be added in the future.
+* Atoms that are read must have a synchronous value.  If it is in an error state or an asynchronous pending state, then the transaction will throw an error.  It would be possible to support pending dependencies by aborting the transaction if a dependency is pending and then re-starting the transaction when it is available.  This is consistent with how the selector `get()` is implemented.
+* Transactions do not have a return value.  If we want to have some notification a transaction completes, or use transactions to request slow data, or to request data from event handlers, then we could have a transaction return a `Promise` to a return value.
+* Transactions must be synchronous.  There is a proposal to allow asynchronous transactions.  The user could provide an `async` transaction callback function which could use `await`.  The atomic update of all sets would not be applied, however, until the `Promise` returned by the transaction is fully resolved.
+* Transactions must not have any side-effects.  If you require side-effects, then use [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback) instead.

--- a/docs/docs/api-reference/core/useRecoilTransaction.md
+++ b/docs/docs/api-reference/core/useRecoilTransaction.md
@@ -3,14 +3,7 @@ title: useRecoilTransaction_UNSTABLE(callback, deps)
 sidebar_label: useRecoilTransaction()
 ---
 
-pending dependencies
-selectors
-selector set
-async
-useRecoilCallback transact
-Promise return value
-
-Create a transaction callback which can be used to atomically update multiple atoms in a safe, easy, and performant way.  Provide a callback which executes the transaction and can `get()` or `set()` multiple atoms.  A transaction is similar to the "updater" form of setting Recoil state, but over multiple atoms.  Writes are visible to subsequent reads from within the same transaction.
+Create a transaction callback which can be used to atomically update multiple atoms in a safe, easy, and efficient way.  Provide a callback for the transaction as a pure function which can `get()` or `set()` multiple atoms.  A transaction is similar to the "updater" form of setting Recoil state, but can operate over multiple atoms.  Writes are visible to subsequent reads from within the same transaction.
 
 In addition to transactions, this hook is also useful to:
 * Implement reducer patterns to perform actions on multiple atoms.

--- a/docs/docs/api-reference/utils/selectorFamily.md
+++ b/docs/docs/api-reference/utils/selectorFamily.md
@@ -48,7 +48,7 @@ type GetRecoilValue = <T>(RecoilValue<T>) => T;
 type SetRecoilValue = <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
 type ResetRecoilValue = <T>(RecoilState<T>) => void;
 
-type CachePolicy = 
+type CachePolicy =
   | {eviction: 'lru', maxSize: number}
   | {eviction: 'keep-all'}
   | {eviction: 'most-recent'};
@@ -59,7 +59,7 @@ type CachePolicy =
 - `set?` - An optional function that will produce writeable selectors when provided. It should be a function that takes an object of named callbacks, same as the `selector()` interface. This is again wrapped by another function with gets the parameters from calling the selector family function.
 - `cachePolicy_UNSTABLE` - Defines the behavior of the internal selector cache for **the invidual selectors** that make up the family (it does not control the number of selectors that are stored in the family). Can be useful to control the memory footprint in apps that have selectors with many changing dependencies.
   - `eviction` - can be set to `lru` (which requires that a `maxSize` is set), `keep-all` (default), or `most-recent`. An `lru` cache will evict the least-recently-used value from the selector cache when the size of the cache exceeds `maxSize`. A `keep-all` policy will mean all selector dependencies and their values will be indefinitely stored in the selector cache. A `most-recent` policy will use a cache of size 1 and will retain only the most recently saved set of dependencies and their values.
-  - Note the `maxSize` property used alongside `lru` does not control the max size of the family itself, it only controls the eviction policy used in the invidiual selectors that make up the family. 
+  - Note the `maxSize` property used alongside `lru` does not control the max size of the family itself, it only controls the eviction policy used in the invidiual selectors that make up the family.
   - Note the cache stores the values of the selector based on a key containing all dependencies and their values. This means the size of the internal selector cache depends on both the size of the selector values as well as the number of unique values of all dependencies.
   - Note the default eviction policy (currently `keep-all`) may change in the future.
 
@@ -157,35 +157,6 @@ const Component2 = () => {
 }
 ```
 
-## Selector Cache Policy Configuration
+## Cache policy configuration
 
-The `cachePolicy_UNSTABLE` property allows you to configure the caching behavior of **individual selectors** that make up the family. This property can be useful for reducing memory in applications that have a large number of selectors that have a large number of changing dependencies. For now the only configurable option is `eviction`, but we may add more in the future.
-
-Below is an example of how you might use this new property:
-
-```jsx
-const clockStateFamily = selectorFamily({
-  key: 'clockState',
-  get: (clockName) => ({get}) => {
-    const hour = get(hourState);
-    const minute = get(minuteState);
-    const second = get(secondState); // will re-run every second
-
-    return `${clockName} - ${hour}:${minute}:${second}`;
-  },
-  cachePolicy_UNSTABLE: {
-    eviction: 'most-recent', // will only store the most recent set of dependencies and their values
-  },
-});
-```
-
-In the example above, each selector in the `clockStateFamily` recalculates every second (the number of selectors in the family will be dictated by the number of times the family is called with distinct `clockName`s). Each seccond, a new set of dependency values is added to the internal cache for each selector in the family, which may lead to a memory issue over time as the internal cache grows indefinitely. Using the `most-recent` eviction policy, the internal selector cache for each selector will only retain the most recent set of dependencies and their values, thus solving the memory issue.
-
-Current eviction options are:
-- `lru` - evicts the least-recently-used value from the cache when the cache size exceeds the given `maxSize`
-- `most-recent` - retains only the most recent value and evicts any other values
-- `keep-all` (default) - keeps all entries in the cache and does not evict
-
-> **_NOTE:_** In this example, we used an eviction policy to control the cache of each selector in the family. This policy will not control the size of the family itself, so if you were to call `clockStateFamily()` with 10 million names, the family size will be 10 million regardless of the internal cache size of each individual selector.
-
-> **_NOTE:_** The default eviciton policy (currently `keep-all`) may change in the future.
+The `cachePolicy_UNSTABLE` property allows you to configure the caching behavior of **individual selectors** that make up the family. This property can be useful for reducing memory in applications that have a large number of selectors that have a large number of changing dependencies.  Please see the [selector cache policy configuration documentation](/docs/api-reference/core/selector#cache-policy-configuration).

--- a/docs/docs/guides/asynchronous-data-queries.md
+++ b/docs/docs/guides/asynchronous-data-queries.md
@@ -279,7 +279,7 @@ function CurrentUserInfo() {
 }
 ```
 
-Note that this pre-fetching works by triggering the `selectorFamily()` to initiate an async query and populate the selector's cache.  If the `selectorFamily()` has caching disabled, pre-fetching like this will not do anything.  Also, if you are using an `atomFamily()` instead of a `selectorFamily()`, by either setting the atoms or relying on atom effects to initialize, then it will also not work with `useRecoilCallback()` as trying to set the state of the provided `Snapshot` will have no effect on the live state in the host `<RecoilRoot>`.
+Note that this pre-fetching works by triggering the `selectorFamily()` to initiate an async query and populate the selector's cache.  If you are using an `atomFamily()` instead, by either setting the atoms or relying on atom effects to initialize, then you should use [`useRecoilTransaction_UNSTABLE()`](/docs/api-reference/core/useRecoilTransaction) instead of [`useRecoilCallback()](/docs/api-reference/core/useRecoilCallback), as trying to set the state of the provided `Snapshot` will have no effect on the live state in the host `<RecoilRoot>`.
 
 ## Query Default Atom Values
 

--- a/docs/docs/guides/atom-effects.md
+++ b/docs/docs/guides/atom-effects.md
@@ -32,7 +32,7 @@ type AtomEffect<T> = ({
   // Subscribe to changes in the atom value.
   // The callback is not called due to changes from this effect's own setSelf().
   onSet: (
-    (newValue: T | DefaultValue, oldValue: T | DefaultValue) => void,
+    (newValue: T, oldValue: T | DefaultValue) => void,
   ) => void,
 
 }) => void | () => void; // Optionally return a cleanup handler
@@ -262,11 +262,7 @@ const localForageEffect = key => ({setSelf, onSet}) => {
   ));
 
   onSet(newValue => {
-    if (newValue instanceof DefaultValue) {
-      localStorage.removeItem(key);
-    } else {
-      localStorage.setItem(key, JSON.stringify(newValue));
-    }
+    localStorage.setItem(key, JSON.stringify(newValue));
   });
 };
 
@@ -286,7 +282,7 @@ With this approach, you can asynchronously call `setSelf()` when the value is av
 
 ```jsx
 const localForageEffect = key => ({setSelf, onSet}) => {
-  /** If there's a persisted value - set it on load  */
+  // If there's a persisted value - set it on load
   const loadPersisted = async () => {
     const savedValue = await localForage.getItem(key);
 
@@ -298,12 +294,9 @@ const localForageEffect = key => ({setSelf, onSet}) => {
   // Load the persisted data
   loadPersisted();
 
+  // Subscribe to state changes and persist them to localForage
   onSet(newValue => {
-    if (newValue instanceof DefaultValue) {
-      localForage.removeItem(key);
-    } else {
-      localForage.setItem(key, JSON.stringify(newValue));
-    }
+    localForage.setItem(key, JSON.stringify(newValue));
   });
 };
 
@@ -333,11 +326,7 @@ const localStorageEffect = <T>(options: PersistenceOptions<T>) => ({setSelf, onS
   }
 
   onSet(newValue => {
-    if (newValue instanceof DefaultValue) {
-      localStorage.removeItem(options.key);
-    } else {
-      localStorage.setItem(options.key, JSON.stringify(newValue));
-    }
+    localStorage.setItem(options.key, JSON.stringify(newValue));
   });
 };
 
@@ -377,11 +366,7 @@ const localStorageEffect = <T>(options: PersistenceOptions<T>) => ({setSelf, onS
   );
 
   onSet(newValue => {
-    if (newValue instanceof DefaultValue) {
-      localStorage.removeItem(options.key);
-    } else {
-      localStorage.setItem(options.key, JSON.stringify(newValue));
-    }
+    localStorage.setItem(options.key, JSON.stringify(newValue));
   });
 };
 

--- a/docs/docs/introduction/installation.md
+++ b/docs/docs/introduction/installation.md
@@ -65,7 +65,7 @@ It is recommended to add [`'useRecoilCallback'`](/docs/api-reference/core/useRec
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [
       "warn", {
-        "additionalHooks": "useRecoilCallback"
+        "additionalHooks": "useRecoilCallback|useRecoilTransaction_UNSTABLE"
       }
     ]
   }

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -54,9 +54,6 @@ module.exports = {
           'api-reference/core/isRecoilValue',
           // 'api-reference/core/DefaultValue',
         ],
-      },
-      'api-reference/core/useRecoilCallback',
-      {
         Utils: [
           'api-reference/utils/atomFamily',
           'api-reference/utils/selectorFamily',
@@ -68,6 +65,10 @@ module.exports = {
           'api-reference/utils/waitForNone',
           'api-reference/utils/waitForAny',
         ],
+      },
+      'api-reference/core/useRecoilTransaction',
+      'api-reference/core/useRecoilCallback',
+      {
         Snapshots: [
           'api-reference/core/Snapshot',
           'api-reference/core/useRecoilTransactionObserver',


### PR DESCRIPTION
* Release notes
* `useRecoilTransaction_UNSTABLE()`
* Breaking changes for Atom Effect `onSet()`
* `cachePolicy_UNSTABLE` - See also #1139