### PR TITLE
Test error handling in Atom Effects

### DIFF
--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -237,6 +237,31 @@ testRecoil("Updating with same value doesn't rerender", () => {
 });
 
 describe('Effects', () => {
+  testRecoil('effect error', () => {
+    const ERROR = new Error('ERROR');
+    const myAtom = atom({
+      key: 'atom effect error',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        () => {
+          throw ERROR;
+        },
+      ],
+    });
+    const mySelector = selector({
+      key: 'atom effect error selector',
+      get: ({get}) => {
+        try {
+          return get(myAtom);
+        } catch (e) {
+          return e.message;
+        }
+      },
+    });
+    const container = renderElements(<ReadsAtom atom={mySelector} />);
+    expect(container.textContent).toEqual('"ERROR"');
+  });
+
   testRecoil('initialization', () => {
     let inited = false;
     const myAtom = atom({


### PR DESCRIPTION
Summary: Confirm that errors that occur in Atom effects will put the atom in an error state with that error.

Differential Revision: D30465257

