### PR TITLE
Ability for Loadables to map with Loadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UPCOMING
 ***Add new changes here as they land***
+- Ability to map Loadables with other Loadables
 - Memory management
 - useTransition() compatibility
 - Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.

--- a/src/adt/__tests__/Recoil_Loadable-test.js
+++ b/src/adt/__tests__/Recoil_Loadable-test.js
@@ -65,9 +65,9 @@ test('Pending Value Loadable', async () => {
 
 describe('Loadable mapping', () => {
   test('Loadable mapping value', () => {
-    const loadable = loadableWithValue('VALUE').map(x => 'MAPPED_' + x);
+    const loadable = loadableWithValue('VALUE').map(x => 'MAPPED ' + x);
     expect(loadable.state).toBe('hasValue');
-    expect(loadable.contents).toBe('MAPPED_VALUE');
+    expect(loadable.contents).toBe('MAPPED VALUE');
   });
 
   test('Loadable mapping value to error', () => {
@@ -79,11 +79,11 @@ describe('Loadable mapping', () => {
   });
 
   test('Loadable mapping value to Promise', async () => {
-    const loadable = loadableWithValue('VALUE').map(() =>
-      Promise.resolve('MAPPED'),
+    const loadable = loadableWithValue('VALUE').map(value =>
+      Promise.resolve('MAPPED ' + value),
     );
     expect(loadable.state).toBe('loading');
-    await expect(loadable.toPromise()).resolves.toBe('MAPPED');
+    await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
   });
 
   test('Loadable mapping value to reject', async () => {
@@ -104,9 +104,9 @@ describe('Loadable mapping', () => {
     // TODO update API to avoid wrapping
     const loadable = loadableWithPromise(
       Promise.resolve({__value: 'VALUE'}),
-    ).map(x => 'MAPPED_' + x);
+    ).map(x => 'MAPPED ' + x);
     expect(loadable.state).toBe('loading');
-    await expect(loadable.toPromise()).resolves.toBe('MAPPED_VALUE');
+    await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
   });
 
   test('Loadable mapping promise value to reject', async () => {
@@ -134,5 +134,43 @@ describe('Loadable mapping', () => {
     );
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).rejects.toBe(ERROR);
+  });
+
+  test('Loadable mapping to loadable', () => {
+    const loadable = loadableWithValue('VALUE').map(value =>
+      loadableWithValue(value),
+    );
+    expect(loadable.state).toBe('hasValue');
+    expect(loadable.contents).toBe('VALUE');
+  });
+
+  test('Loadable mapping promise to loadable value', async () => {
+    // TODO update API to avoid wrapping
+    const loadable = loadableWithPromise(
+      Promise.resolve({__value: 'VALUE'}),
+    ).map(value => loadableWithValue('MAPPED ' + value));
+    expect(loadable.state).toBe('loading');
+    await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
+  });
+
+  test('Loadable mapping promise to loadable error', async () => {
+    // TODO update API to avoid wrapping
+    const loadable = loadableWithPromise(
+      Promise.resolve({__value: 'VALUE'}),
+    ).map(() => loadableWithError(ERROR));
+    expect(loadable.state).toBe('loading');
+    await expect(loadable.toPromise()).rejects.toBe(ERROR);
+  });
+
+  test('Loadable mapping promise to loadable promise', async () => {
+    // TODO update API to avoid wrapping
+    const loadable = loadableWithPromise(
+      Promise.resolve({__value: 'VALUE'}),
+    ).map(value =>
+      // TODO update API to avoid wrapping
+      loadableWithPromise(Promise.resolve({__value: 'MAPPED ' + value})),
+    );
+    expect(loadable.state).toBe('loading');
+    await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
   });
 });

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -264,7 +264,7 @@ interface BaseLoadable<T> {
   errorOrThrow: () => any;
   promiseOrThrow: () => Promise<T>;
   is: (other: Loadable<any>) => boolean;
-  map: <S>(map: (from: T) => Promise<S> | S) => Loadable<S>;
+  map: <S>(map: (from: T) => Loadable<S> | Promise<S> | S) => Loadable<S>;
 }
 
 interface ValueLoadable<T> extends BaseLoadable<T> {


### PR DESCRIPTION
Summary:
Add the ability for a `Loadable` to map by providing a `Loadable`.  This is similar to the ability for a `Promise` to resolve to another `Promise` and eventually resolve to the resolved value of the provided `Promise`.

Examples resolve to `MAPPED_VALUE`
```
loadableWithValue('VALUE').map(value => loadableWithValue('MAPPED_'+value));
```
```
Promise.resolve('VALUE').then(value => Promise.resolve('MAPPED_'+value));
```

This functionality may be useful for the persistence library.

Differential Revision: D30466024

