### PR TITLE
Enable `recoil_suppress_rerender_in_callback` GK for OSS

### DIFF
--- a/src/testing/Recoil_TestingUtils.js
+++ b/src/testing/Recoil_TestingUtils.js
@@ -292,17 +292,18 @@ const testGKs = (
   });
 };
 
+// TODO Remove the recoil_suppress_rerender_in_callback GK checks
 const WWW_GKS_TO_TEST = [
-  [],
-  ['recoil_early_rendering_2021'],
   ['recoil_suppress_rerender_in_callback'],
-  ['recoil_early_rendering_2021', 'recoil_suppress_rerender_in_callback'],
-  ['recoil_hamt_2020'],
+  ['recoil_suppress_rerender_in_callback', 'recoil_early_rendering_2021'],
+  ['recoil_suppress_rerender_in_callback', 'recoil_hamt_2020'],
   [
+    'recoil_suppress_rerender_in_callback',
     'recoil_memory_managament_2020',
     'recoil_release_on_cascading_update_killswitch_2021',
   ],
   [
+    'recoil_suppress_rerender_in_callback',
     'recoil_hamt_2020',
     'recoil_memory_managament_2020',
     'recoil_release_on_cascading_update_killswitch_2021',

--- a/src/util/Recoil_gkx.js
+++ b/src/util/Recoil_gkx.js
@@ -8,14 +8,14 @@
  * @flow strict
  * @format
  */
-
 'use strict';
 
 const {mutableSourceExists} = require('./Recoil_mutableSource');
 
 const gks = new Map()
   .set('recoil_hamt_2020', true)
-  .set('recoil_memory_managament_2020', true);
+  .set('recoil_memory_managament_2020', true)
+  .set('recoil_suppress_rerender_in_callback', true);
 
 function Recoil_gkx(gk: string): boolean {
   if (gk === 'recoil_early_rendering_2021' && !mutableSourceExists()) {


### PR DESCRIPTION
Summary: Enable `recoil_suppress_rerender_in_callback` GK for optimization for Open Source package of Recoil.

Reviewed By: csantos42

Differential Revision: D30523459

