### PR TITLE
Add getLoadable() and getPromise() for Atom Effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Ability to map Loadables with other Loadables
 - Allow class instances in family parameters for Flow
+- Add `getLoadable()` and `getPromise()` to Atom Effects interface for reading other atoms.
 
 ### Pending
 - Memory management


### PR DESCRIPTION
Summary:
Add the ability for atom effects to get the value of other atoms.  It can either get the values at the time of the atom initialization when the effect executes or it can get the values later during some async callback from the effect.

```
export type AtomEffect<T> = ({
  ...

  // Accessors to read other atoms/selectors
  getPromise: <T>(RecoilValue<T>) => Promise<T>,
  getLoadable: <T>(RecoilValue<T>) => Loadable<T>,
}) => void | (() => void);
```

It is important to note that getting other atom values does not establish any subscription to re-evaluate anything if the upstream atoms may change.

Alternative APIs to consider was exposing a transaction.  But, we don't want to write to other atoms during initialization and it would be a stretch to create a read-only transaction type, especially as transactions don't currently have a return value.  Another alternative would be offering to get a `Snapshot`.  This would be a convenient API and nicely consistent and makes it very explicit that no subscription is established.  However, retention for garbage collection is a concern.  We could release the `Snapshot` after initialization, which would be straight-forward, but there isn't a clear please to automatically release or explicitly retain for async obtained snapshots.  This proposed API mirrors the Snapshot interface for getting values to try to maximize consistency.

Example use-cases for this functionality:
* Use of other atom values to compute initial value.  e.g. another atom may store some query mode to use.
* Effects for data-loggers for multiple atoms
* "Persist on set" - The ability to use an atom effect to initialize an atom based on other atom values and have the initial value persisted based on observing by other atom effects or the recoil sync library.  This is in contrast to using a default selector for an atom for a dynamic default based on other atoms.  That creates a wrapper selector, remains dynamic until set, and doesn't cause the atom to persist until it is explicitly set.

Differential Revision: D30691374

