### PR TITLE
Add item snapshot to sync write callback

### DIFF
--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -66,9 +66,12 @@ function TestRecoilSync({
       }
       return storage.get(itemKey);
     },
-    write: ({diff}) => {
+    write: ({diff, items}) => {
       for (const [key, loadable] of diff.entries()) {
         loadable != null ? storage.set(key, loadable) : storage.delete(key);
+      }
+      for (const [itemKey, loadable] of diff) {
+        expect(items.get(itemKey)?.contents).toEqual(loadable?.contents);
       }
     },
     listen: update => {


### PR DESCRIPTION
Summary:
Add an `items` snapshot of the state for all items registered with this storage syncKey as a parameter of the `write()` callback.  This allows storage implementations to deal with all known atoms for transactions.

Current RFC API (*in flux based on ongoing feedback*):
```
type AtomDiff = Map<ItemKey, ?Loadable<mixed>>; // null entry means reset
type ItemSnapshot = Map<ItemKey, ?Loadable<mixed>>; // null entry means default value

useRecoilSync({
  syncKey?: SyncKey,  // key to match with syncEffect()

  write?: ({diff: ItemDiff, items: ItemSnapshot}) => void,
  read?: ItemKey => ?Loadable<mixed>,
  listen?: (AtomDiff => void) => (() => void),
}) => void;
```
```
function syncEffect<T>(params: {
  syncKey?: SyncKey,  // key to match with useRecoilSync()
  key?: ItemKey,  // defaults to Atom key

  restore: mixed => ?Loadable<T>,

  // For advanced use-cases
  read?: ({read: ItemKey => ?Loadable<mixed>}) => Loadable<mixed>,
  write?: (Loadable<T>, {read: ItemKey => ?Loadable<mixed>}) => ItemDiff,
}): AtomEffect<T>
```

Differential Revision: D30830678

