### PR TITLE
Avoid awaiting result of act()

### DIFF
--- a/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -67,7 +67,7 @@ testRecoil(
     }
 
     const container = document.createElement('div');
-    await act(() => {
+    act(() => {
       ReactDOM.render(
         <RecoilRoot initializeState={initializeState}>
           <ReadWriteAtom />


### PR DESCRIPTION
Summary: Avoid `await` of the result of calling `act()` for Jest unit test, which is not valid.

Differential Revision: D31086786

