### PR TITLE
Ensure components in useTransation() unit tests return value

### DIFF
--- a/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -67,7 +67,7 @@ testRecoil(
     }
 
     const container = document.createElement('div');
-    await act(() => {
+    act(() => {
       ReactDOM.render(
         <RecoilRoot initializeState={initializeState}>
           <ReadWriteAtom />

--- a/src/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/src/hooks/__tests__/Recoil_useTransaction-test.js
@@ -55,6 +55,8 @@ testRecoil(
       useRecoilValue(atomWithEffect);
 
       expect(numTimesEffectInit).toBe(1);
+
+      return null;
     };
 
     renderElements(<Component />);
@@ -94,6 +96,8 @@ testRecoil(
       readAtomFromSnapshot();
 
       expect(numTimesEffectInit).toBe(1);
+
+      return null;
     };
 
     renderElements(<Component />);


### PR DESCRIPTION
Summary: Fix unit tests for `useTransaction()` to return `null` instead of `undefined` to avoid errors with OSS React version for unit testing.

Differential Revision: D31086925

