### PR TITLE
Fix async subscriptions to have priority for newer keys

### DIFF
--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -81,6 +81,9 @@ function TestRecoilSync({
   return null;
 }
 
+///////////////////////
+// Tests
+///////////////////////
 test('Write to storage', async () => {
   const atomA = atom({
     key: 'recoil-sync write A',

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -66,9 +66,12 @@ function TestRecoilSync({
       }
       return storage.get(itemKey);
     },
-    write: ({diff}) => {
+    write: ({diff, items}) => {
       for (const [key, loadable] of diff.entries()) {
         loadable != null ? storage.set(key, loadable) : storage.delete(key);
+      }
+      for (const [itemKey, loadable] of diff) {
+        expect(items.get(itemKey)?.contents).toEqual(loadable?.contents);
       }
     },
     listen: update => {

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -510,6 +510,11 @@ test('Listen to storage', async () => {
   expect(storage1.get('KEY A')?.getValue()).toBe('B');
   expect(storage1.get('KEY B')?.getValue()).toBe(undefined);
 
+  // TODO
+  // // Updating older key won't override newer key
+  // act(() => update1(new Map([['KEY A', loadableWithValue('IGNORE')]])));
+  // expect(container.textContent).toBe('"AA""BBB""C2"');
+
   // Subscribe to new value from different storage
   act(() =>
     update1(
@@ -586,6 +591,31 @@ test('Listen to storage', async () => {
   );
   expect(container.textContent).toBe('"AAA""DEFAULT""DEFAULT"');
 
+  // Update All Items
+  // Setting older Key while newer Key is blank will take value instead of default
+  act(() =>
+    updateAll1(
+      new Map([
+        ['recoil-sync listen', loadableWithValue('AAA')],
+        ['KEY A', loadableWithValue('BBB')],
+      ]),
+    ),
+  );
+  expect(container.textContent).toBe('"AAA""BBB""DEFAULT"');
+
+  // Update All Items
+  // Setting an older and newer key will take the newer key value
+  act(() =>
+    updateAll1(
+      new Map([
+        ['recoil-sync listen', loadableWithValue('AAA')],
+        ['KEY A', loadableWithValue('IGNORE')],
+        ['KEY B', loadableWithValue('BBBB')],
+      ]),
+    ),
+  );
+  expect(container.textContent).toBe('"AAA""BBBB""DEFAULT"');
+
   // TODO Async Atom support
   // act(() =>
   //   update1(
@@ -598,7 +628,7 @@ test('Listen to storage', async () => {
   //   ),
   // );
   // await flushPromisesAndTimers();
-  // expect(container.textContent).toBe('"ASYNC""DEFAULT""DEFAULT"');
+  // expect(container.textContent).toBe('"ASYNC""BBBB""DEFAULT"');
 
   // act(() =>
   //   update1(

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+// TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
+// TODO PUBLIC LOADABLE INTERFACE
+
+// import type {Loadable} from '../../../adt/Recoil_Loadable';
+import type {LocationOption} from '../recoil-url-sync';
+
+const {act} = require('ReactTestUtils');
+
+const {loadableWithValue} = require('../../../adt/Recoil_Loadable');
+const atom = require('../../../recoil_values/Recoil_atom');
+const {
+  componentThatReadsAndWritesAtom,
+  renderElements,
+} = require('../../../testing/Recoil_TestingUtils');
+const {syncEffect} = require('../recoil-sync');
+const {urlSyncEffect, useRecoilURLSync} = require('../recoil-url-sync');
+const React = require('react');
+
+let atomIndex = 0;
+const nextKey = () => `recoil-url-sync/${atomIndex++}`;
+
+////////////////////////////
+// Mock validation library
+////////////////////////////
+const validateAny = loadableWithValue;
+// const validateString = x =>
+//   typeof x === 'string' ? loadableWithValue(x) : null;
+// const validateNumber = x =>
+//   typeof x === 'number' ? loadableWithValue(x) : null;
+// function upgrade<From, To>(
+//   validate: mixed => ?Loadable<From>,
+//   upgrade: From => To,
+// ): mixed => ?Loadable<To> {
+//   return x => validate(x)?.map(upgrade);
+// }
+
+// ////////////////////////////
+// // Mock Serialization
+// ////////////////////////////
+// Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
+const mapToObj = map => {
+  const obj = {};
+  for (const [key, value] of map.entries()) {
+    obj[key] = value;
+  }
+  return obj;
+};
+function TestURLSync({
+  syncKey,
+  location,
+}: {
+  syncKey?: string,
+  location: LocationOption,
+}) {
+  useRecoilURLSync({
+    syncKey,
+    location,
+    serialize: items =>
+      `${location.part === 'href' ? '/TEST#' : ''}${encodeURI(
+        JSON.stringify(mapToObj(items)),
+      )}`,
+  });
+  return null;
+}
+
+function encodeState(obj) {
+  return `${encodeURI(JSON.stringify(obj))}`;
+}
+
+function encodeURL(loc, obj) {
+  const encoded = encodeState(obj);
+  const url = new URL(window.location);
+  switch (loc.part) {
+    case 'href':
+      url.pathname = '/TEST';
+      url.hash = encoded;
+      break;
+    case 'hash':
+      url.hash = encoded;
+      break;
+    case 'search': {
+      const {queryParam} = loc;
+      if (queryParam == null) {
+        url.search = encoded;
+      } else {
+        // const searchParams = new URLSearchParams(location.search);
+        const searchParams = url.searchParams;
+        searchParams.set(queryParam, encoded);
+        url.search = searchParams.toString();
+      }
+      break;
+    }
+  }
+  return url.href;
+}
+
+function expectURL(loc, obj) {
+  expect(window.location.href).toBe(encodeURL(loc, obj));
+}
+
+///////////////////////
+// Tests
+///////////////////////
+describe('Test URL Persistence', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', '/path/page.html?foo=bar#anchor');
+  });
+
+  function testWriteToURL(loc, remainder) {
+    const atomA = atom({
+      key: nextKey(),
+      default: 'DEFAULT',
+      effects_UNSTABLE: [urlSyncEffect({key: 'a', restore: validateAny})],
+    });
+    const atomB = atom({
+      key: nextKey(),
+      default: 'DEFAULT',
+      effects_UNSTABLE: [urlSyncEffect({key: 'b', restore: validateAny})],
+    });
+    const ignoreAtom = atom({
+      key: nextKey(),
+      default: 'DEFAULT',
+    });
+
+    const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);
+    const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
+    const [IgnoreAtom, setIgnore] = componentThatReadsAndWritesAtom(ignoreAtom);
+    const container = renderElements(
+      <>
+        <TestURLSync location={loc} />
+        <AtomA />
+        <AtomB />
+        <IgnoreAtom />
+      </>,
+    );
+
+    expectURL(loc, {});
+    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+
+    act(() => setA('A'));
+    act(() => setB('B'));
+    act(() => setIgnore('IGNORE'));
+    expect(container.textContent).toBe('"A""B""IGNORE"');
+    expectURL(loc, {a: 'A', b: 'B'});
+
+    act(() => resetA());
+    act(() => setB('BB'));
+    expect(container.textContent).toBe('"DEFAULT""BB""IGNORE"');
+    expectURL(loc, {b: 'BB'});
+
+    remainder();
+  }
+
+  test('Write to URL', () =>
+    testWriteToURL({part: 'href'}, () => {
+      expect(location.search).toBe('');
+      expect(location.pathname).toBe('/TEST');
+    }));
+  test('Write to URL - Anchor Hash', () =>
+    testWriteToURL({part: 'hash'}, () => {
+      expect(location.search).toBe('?foo=bar');
+    }));
+  test('Write to URL - Query Search', () =>
+    testWriteToURL({part: 'search'}, () => {
+      expect(location.hash).toBe('#anchor');
+    }));
+  test('Write to URL - Query Search Param', () =>
+    testWriteToURL({part: 'search', queryParam: 'bar'}, () => {
+      expect(location.hash).toBe('#anchor');
+      expect(new URL(location.href).searchParams.get('foo')).toBe('bar');
+    }));
+
+  test('Write to multiple params', async () => {
+    const atomA = atom({
+      key: 'recoil-url-sync multiple param A',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        syncEffect({syncKey: 'A', key: 'x', restore: validateAny}),
+      ],
+    });
+    const atomB = atom({
+      key: 'recoil-url-sync multiple param B',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        syncEffect({syncKey: 'B', key: 'x', restore: validateAny}),
+      ],
+    });
+
+    const [AtomA, setA] = componentThatReadsAndWritesAtom(atomA);
+    const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
+    renderElements(
+      <>
+        <TestURLSync
+          syncKey="A"
+          location={{part: 'search', queryParam: 'foo'}}
+        />
+        <TestURLSync
+          syncKey="B"
+          location={{part: 'search', queryParam: 'bar'}}
+        />
+        <AtomA />
+        <AtomB />
+      </>,
+    );
+
+    act(() => setA('A'));
+    act(() => setB('B'));
+    const url = new URL(location.href);
+    url.searchParams.set('foo', encodeState({x: 'A'}));
+    url.searchParams.set('bar', encodeState({x: 'B'}));
+    expect(location.href).toBe(url.href);
+  });
+});

--- a/src/contrib/recoil-sync/recoil-sync.js
+++ b/src/contrib/recoil-sync/recoil-sync.js
@@ -199,12 +199,7 @@ function useRecoilSync({
 ///////////////////////
 // syncEffect()
 ///////////////////////
-function syncEffect<T>({
-  syncKey,
-  key,
-  restore,
-  syncDefault,
-}: {
+export type SyncEffectOptions<T> = {
   syncKey?: SyncKey,
   key?: ItemKey,
 
@@ -215,7 +210,14 @@ function syncEffect<T>({
 
   // Sync default value instead of empty when atom is indefault state
   syncDefault?: boolean,
-}): AtomEffect<T> {
+};
+
+function syncEffect<T>({
+  syncKey,
+  key,
+  restore,
+  syncDefault,
+}: SyncEffectOptions<T>): AtomEffect<T> {
   return ({node, setSelf, getLoadable, getInfo_UNSTABLE}) => {
     const itemKey = key ?? node.key;
 

--- a/src/contrib/recoil-sync/recoil-sync.js
+++ b/src/contrib/recoil-sync/recoil-sync.js
@@ -28,8 +28,8 @@ type NodeKey = string;
 export type ItemKey = string;
 export type SyncKey = string | void;
 
-export type ItemDiff = Map<ItemKey, ?Loadable<mixed>>;
-export type ItemSnapshot = Map<ItemKey, ?Loadable<mixed>>;
+export type ItemDiff = Map<ItemKey, ?Loadable<mixed>>; // null means reset
+export type ItemSnapshot = Map<ItemKey, ?Loadable<mixed>>; // null means default
 export type ReadItem = ItemKey => ?Loadable<mixed>;
 export type WriteItems = ({diff: ItemDiff, items: ItemSnapshot}) => void;
 export type UpdateItems = ItemDiff => void;

--- a/src/contrib/recoil-sync/recoil-url-sync.js
+++ b/src/contrib/recoil-sync/recoil-url-sync.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {AtomEffect} from '../../recoil_values/Recoil_atom';
+import type {ItemKey, SyncEffectOptions, SyncKey} from './recoil-sync';
+
+const {syncEffect, useRecoilSync} = require('./recoil-sync');
+const React = require('react');
+
+type NodeKey = string;
+type AtomRegistration = {
+  history: HistoryOption,
+};
+
+const registries: Map<SyncKey, Map<NodeKey, AtomRegistration>> = new Map();
+
+function updateURL(loc: LocationOption, serialization): string {
+  switch (loc.part) {
+    case 'href':
+      return serialization;
+    case 'hash':
+      return `#${serialization}`;
+    case 'search': {
+      const {queryParam} = loc;
+      if (queryParam == null) {
+        return `?${serialization}${location.hash}`;
+      }
+      const searchParams = new URLSearchParams(location.search);
+      searchParams.set(queryParam, serialization);
+      return `?${searchParams.toString()}${location.hash}`;
+    }
+  }
+  throw new Error(`Unknown URL location part: "${loc.part}"`);
+}
+
+///////////////////////
+// useRecoilURLSync()
+///////////////////////
+export type LocationOption =
+  | {part: 'href'}
+  | {part: 'hash'}
+  | {part: 'search', queryParam?: string};
+export type ItemState = Map<ItemKey, mixed>;
+type RecoilURLSyncOptions = {
+  syncKey?: SyncKey,
+  location: LocationOption,
+  serialize: ItemState => string,
+};
+
+function useRecoilURLSync({
+  syncKey,
+  location,
+  serialize,
+}: RecoilURLSyncOptions): void {
+  function read() {}
+
+  function write({items}) {
+    // Only serialize atoms in a non-default value state.
+    const state = new Map(
+      Array.from(items.entries())
+        .filter(([, loadable]) => loadable?.state === 'hasValue')
+        .map(([key, loadable]) => [key, loadable?.contents]),
+    );
+
+    // TODO Support History Push vs Replace
+    const newURL = updateURL(location, serialize(state));
+    history.replaceState(null, '', newURL);
+  }
+
+  function listen() {}
+
+  useRecoilSync({syncKey, read, write, listen});
+}
+
+function RecoilURLSync(props: RecoilURLSyncOptions): React.Node {
+  useRecoilURLSync(props);
+  return null;
+}
+
+///////////////////////
+// urlSyncEffect()
+///////////////////////
+type HistoryOption = 'push' | 'replace';
+
+function urlSyncEffect<T>({
+  history = 'replace',
+  ...options
+}: {
+  ...SyncEffectOptions<T>,
+  history?: HistoryOption,
+}): AtomEffect<T> {
+  const atomEffect = syncEffect<T>(options);
+  return effectArgs => {
+    // Register URL sync options
+    if (!registries.has(options.syncKey)) {
+      registries.set(options.syncKey, new Map());
+    }
+    const atomRegistry = registries.get(options.syncKey);
+    if (atomRegistry == null) {
+      throw new Error('Error with atom registration');
+    }
+    atomRegistry.set(effectArgs.node.key, {history});
+
+    // Wrap syncEffect() atom effect
+    const cleanup = atomEffect(effectArgs);
+
+    // Cleanup atom option registration
+    return () => {
+      atomRegistry.delete(effectArgs.node.key);
+      cleanup?.();
+    };
+  };
+}
+
+module.exports = {
+  useRecoilURLSync,
+  RecoilURLSync,
+  urlSyncEffect,
+};


### PR DESCRIPTION
Summary:
Fix async subscriptions when listening to storage updates so that newer keys take precedence over older keys when using `updateAllItems()`.  This allows us to update URLs with new and old keys and use the same precedence as the original page load initialization.  Precedence is set based on the order of `syncEffect()` calls for the same storage with different keys.

Note that effects for independent storages can still have lower-priority effects update the value regardless of their order.

Reviewed By: davidmccabe

Differential Revision: D30885982

