### PR TITLE
Refactor tests to avoid URL conflicts

### DIFF
--- a/src/contrib/recoil-sync/__test_utils__/recoil-sync_mockValidation.js
+++ b/src/contrib/recoil-sync/__test_utils__/recoil-sync_mockValidation.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+// TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
+// TODO PUBLIC LOADABLE INTERFACE
+
+import type {Loadable} from '../../../adt/Recoil_Loadable';
+
+const {loadableWithValue} = require('../../../adt/Recoil_Loadable');
+
+////////////////////////////
+// Mock validation library
+////////////////////////////
+const validateAny = loadableWithValue;
+const validateString = (x: mixed): ?Loadable<string> =>
+  typeof x === 'string' ? loadableWithValue<string>(x) : null;
+const validateNumber = (x: mixed): ?Loadable<number> =>
+  typeof x === 'number' ? loadableWithValue<number>(x) : null;
+function upgrade<From, To>(
+  validate: mixed => ?Loadable<From>,
+  upgrader: From => To,
+): mixed => ?Loadable<To> {
+  return x => validate(x)?.map(upgrader);
+}
+
+module.exports = {
+  validateAny,
+  validateString,
+  validateNumber,
+  upgrade,
+};

--- a/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
+++ b/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+// TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
+
+import type {LocationOption} from '../recoil-url-sync';
+
+const {
+  flushPromisesAndTimers,
+} = require('../../../testing/Recoil_TestingUtils');
+const {useRecoilURLSync} = require('../recoil-url-sync');
+const React = require('react');
+
+// ////////////////////////////
+// // Mock Serialization
+// ////////////////////////////
+// Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
+const mapToObj = map => {
+  const obj = {};
+  for (const [key, value] of map.entries()) {
+    obj[key] = value;
+  }
+  return obj;
+};
+function TestURLSync({
+  syncKey,
+  location,
+}: {
+  syncKey?: string,
+  location: LocationOption,
+}): React.Node {
+  useRecoilURLSync({
+    syncKey,
+    location,
+    serialize: items =>
+      `${location.part === 'href' ? '/TEST#' : ''}${encodeURI(
+        JSON.stringify(mapToObj(items)),
+      )}`,
+    deserialize: str => {
+      const stateStr = location.part === 'href' ? str.split('#')[1] : str;
+      // Skip the default URL parts which don't conform to the serialized standard
+      if (
+        stateStr == null ||
+        stateStr === 'anchor' ||
+        stateStr === 'foo=bar' ||
+        stateStr === 'bar'
+      ) {
+        return new Map();
+      }
+      try {
+        return new Map(Object.entries(JSON.parse(decodeURI(stateStr))));
+      } catch (e) {
+        // eslint-disable-next-line fb-www/no-console
+        console.error('Error parsing: ', location, decodeURI(stateStr));
+        throw e;
+      }
+    },
+  });
+  return null;
+}
+
+function encodeState(obj) {
+  return `${encodeURI(JSON.stringify(obj))}`;
+}
+
+function encodeURLPart(href: string, loc: LocationOption, obj): string {
+  const encoded = encodeState(obj);
+  const url = new URL(href);
+  switch (loc.part) {
+    case 'href':
+      url.pathname = '/TEST';
+      url.hash = encoded;
+      break;
+    case 'hash':
+      url.hash = encoded;
+      break;
+    case 'search': {
+      const {queryParam} = loc;
+      if (queryParam == null) {
+        url.search = encoded;
+      } else {
+        const searchParams = url.searchParams;
+        searchParams.set(queryParam, encoded);
+        url.search = searchParams.toString();
+      }
+      break;
+    }
+  }
+  return url.href;
+}
+
+function encodeURL(parts: Array<[LocationOption, {...}]>): string {
+  let href = window.location.href;
+  for (const [loc, obj] of parts) {
+    href = encodeURLPart(href, loc, obj);
+  }
+  return href;
+}
+
+function expectURL(parts: Array<[LocationOption, {...}]>) {
+  expect(window.location.href).toBe(encodeURL(parts));
+}
+
+async function gotoURL(parts: Array<[LocationOption, {...}]>) {
+  history.pushState(null, '', encodeURL(parts));
+  history.pushState(null, '', '/POPSTATE');
+  history.back();
+  await flushPromisesAndTimers();
+}
+
+module.exports = {
+  TestURLSync,
+  encodeURL,
+  expectURL,
+  gotoURL,
+};

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -81,6 +81,9 @@ function TestRecoilSync({
   return null;
 }
 
+///////////////////////
+// Tests
+///////////////////////
 test('Write to storage', async () => {
   const atomA = atom({
     key: 'recoil-sync write A',

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -66,9 +66,12 @@ function TestRecoilSync({
       }
       return storage.get(itemKey);
     },
-    write: ({diff}) => {
+    write: ({diff, items}) => {
       for (const [key, loadable] of diff.entries()) {
         loadable != null ? storage.set(key, loadable) : storage.delete(key);
+      }
+      for (const [itemKey, loadable] of diff) {
+        expect(items.get(itemKey)?.contents).toEqual(loadable?.contents);
       }
     },
     listen: update => {

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -510,6 +510,11 @@ test('Listen to storage', async () => {
   expect(storage1.get('KEY A')?.getValue()).toBe('B');
   expect(storage1.get('KEY B')?.getValue()).toBe(undefined);
 
+  // TODO
+  // // Updating older key won't override newer key
+  // act(() => update1(new Map([['KEY A', loadableWithValue('IGNORE')]])));
+  // expect(container.textContent).toBe('"AA""BBB""C2"');
+
   // Subscribe to new value from different storage
   act(() =>
     update1(
@@ -586,6 +591,31 @@ test('Listen to storage', async () => {
   );
   expect(container.textContent).toBe('"AAA""DEFAULT""DEFAULT"');
 
+  // Update All Items
+  // Setting older Key while newer Key is blank will take value instead of default
+  act(() =>
+    updateAll1(
+      new Map([
+        ['recoil-sync listen', loadableWithValue('AAA')],
+        ['KEY A', loadableWithValue('BBB')],
+      ]),
+    ),
+  );
+  expect(container.textContent).toBe('"AAA""BBB""DEFAULT"');
+
+  // Update All Items
+  // Setting an older and newer key will take the newer key value
+  act(() =>
+    updateAll1(
+      new Map([
+        ['recoil-sync listen', loadableWithValue('AAA')],
+        ['KEY A', loadableWithValue('IGNORE')],
+        ['KEY B', loadableWithValue('BBBB')],
+      ]),
+    ),
+  );
+  expect(container.textContent).toBe('"AAA""BBBB""DEFAULT"');
+
   // TODO Async Atom support
   // act(() =>
   //   update1(
@@ -598,7 +628,7 @@ test('Listen to storage', async () => {
   //   ),
   // );
   // await flushPromisesAndTimers();
-  // expect(container.textContent).toBe('"ASYNC""DEFAULT""DEFAULT"');
+  // expect(container.textContent).toBe('"ASYNC""BBBB""DEFAULT"');
 
   // act(() =>
   //   update1(

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+// TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
+
+const {act} = require('ReactTestUtils');
+
+const {validateAny} = require('../__test_utils__/recoil-sync_mockValidation');
+const {
+  TestURLSync,
+  encodeURL,
+  expectURL,
+  gotoURL,
+} = require('../__test_utils__/recoil-url-sync_mockSerialization');
+const atom = require('../../../recoil_values/Recoil_atom');
+const {
+  ReadsAtom,
+  renderElements,
+} = require('../../../testing/Recoil_TestingUtils');
+const {syncEffect} = require('../recoil-sync');
+const React = require('react');
+
+describe('Test URL Persistence', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', '/path/page.html?foo=bar#anchor');
+  });
+
+  test('Listen to URL changes', async () => {
+    const locFoo = {part: 'search', queryParam: 'foo'};
+    const locBar = {part: 'search', queryParam: 'bar'};
+
+    const atomA = atom({
+      key: 'recoil-url-sync listen',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [syncEffect({syncKey: 'foo', restore: validateAny})],
+    });
+    const atomB = atom({
+      key: 'recoil-url-sync listen to multiple keys',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        syncEffect({syncKey: 'foo', key: 'KEY A', restore: validateAny}),
+        syncEffect({syncKey: 'foo', key: 'KEY B', restore: validateAny}),
+      ],
+    });
+    const atomC = atom({
+      key: 'recoil-url-sync listen to multiple storage',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        syncEffect({syncKey: 'foo', restore: validateAny}),
+        syncEffect({syncKey: 'bar', restore: validateAny}),
+      ],
+    });
+
+    history.replaceState(
+      null,
+      '',
+      encodeURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen': 'A',
+            'KEY A': 'B',
+            'recoil-url-sync listen to multiple storage': 'C',
+          },
+        ],
+      ]),
+    );
+
+    const container = renderElements(
+      <>
+        <TestURLSync syncKey="foo" location={locFoo} />
+        <TestURLSync syncKey="bar" location={locBar} />
+        <ReadsAtom atom={atomA} />
+        <ReadsAtom atom={atomB} />
+        <ReadsAtom atom={atomC} />
+      </>,
+    );
+
+    // Initial load will use the fallback storage for C
+    expect(container.textContent).toBe('"A""B""C"');
+    expectURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen': 'A',
+          'KEY A': 'B',
+          'recoil-url-sync listen to multiple storage': 'C',
+        },
+      ],
+    ]);
+
+    // Subscribe to new value
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen': 'AA',
+            'KEY A': 'B',
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+      ]),
+    );
+    expect(container.textContent).toBe('"AA""B""C1"');
+    // Changing value of C caused it to sync with locBar
+    expectURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen': 'AA',
+          'KEY A': 'B',
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+      [
+        locBar,
+        {
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+    ]);
+
+    // Subscribe to new value from different key
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen': 'AA',
+            'KEY A': 'BB',
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+      ]),
+    );
+    expectURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen': 'AA',
+          'KEY A': 'BB',
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+      [
+        locBar,
+        {
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+    ]);
+    expect(container.textContent).toBe('"AA""BB""C1"');
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen': 'AA',
+            'KEY A': 'BB',
+            'KEY B': 'BBB',
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+      ]),
+    );
+    expect(container.textContent).toBe('"AA""BBB""C1"');
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen': 'AA',
+            'KEY A': 'IGNORE',
+            'KEY B': 'BBB',
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+      ]),
+    );
+    expect(container.textContent).toBe('"AA""BBB""C1"');
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen': 'AA',
+            'KEY A': 'BBBB',
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+      ]),
+    );
+    expect(container.textContent).toBe('"AA""BBBB""C1"');
+
+    // Subscribe to reset
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+      ]),
+    );
+    expect(container.textContent).toBe('"DEFAULT""DEFAULT""C1"');
+
+    // Subscribe to new value from different storage
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen': 'AA',
+            'KEY A': 'B',
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+        [locBar, {}],
+      ]),
+    );
+    expect(container.textContent).toBe('"AA""B""DEFAULT"');
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+        [
+          locBar,
+          {
+            'recoil-url-sync listen to multiple storage': 'CC2',
+          },
+        ],
+      ]),
+    );
+    expect(container.textContent).toBe('"DEFAULT""DEFAULT""CC2"');
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen to multiple storage': 'C1',
+          },
+        ],
+        [locBar, {}],
+      ]),
+    );
+    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+    act(() =>
+      gotoURL([
+        [
+          locFoo,
+          {
+            'recoil-url-sync listen to multiple storage': 'CC1',
+          },
+        ],
+        [locBar, {}],
+      ]),
+    );
+    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  });
+});

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
@@ -8,14 +8,20 @@
 'use strict';
 
 // TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
-// TODO PUBLIC LOADABLE INTERFACE
-
-import type {Loadable} from '../../../adt/Recoil_Loadable';
-import type {LocationOption} from '../recoil-url-sync';
 
 const {act} = require('ReactTestUtils');
 
-const {loadableWithValue} = require('../../../adt/Recoil_Loadable');
+const {
+  upgrade,
+  validateAny,
+  validateNumber,
+  validateString,
+} = require('../__test_utils__/recoil-sync_mockValidation');
+const {
+  TestURLSync,
+  encodeURL,
+  expectURL,
+} = require('../__test_utils__/recoil-url-sync_mockSerialization');
 const atom = require('../../../recoil_values/Recoil_atom');
 const {
   ReadsAtom,
@@ -24,126 +30,12 @@ const {
   renderElements,
 } = require('../../../testing/Recoil_TestingUtils');
 const {syncEffect} = require('../recoil-sync');
-const {urlSyncEffect, useRecoilURLSync} = require('../recoil-url-sync');
+const {urlSyncEffect} = require('../recoil-url-sync');
 const React = require('react');
 
 let atomIndex = 0;
 const nextKey = () => `recoil-url-sync/${atomIndex++}`;
 
-////////////////////////////
-// Mock validation library
-////////////////////////////
-const validateAny = loadableWithValue;
-const validateString = x =>
-  typeof x === 'string' ? loadableWithValue(x) : null;
-const validateNumber = x =>
-  typeof x === 'number' ? loadableWithValue(x) : null;
-function upgrade<From, To>(
-  validate: mixed => ?Loadable<From>,
-  upgrader: From => To,
-): mixed => ?Loadable<To> {
-  return x => validate(x)?.map(upgrader);
-}
-
-// ////////////////////////////
-// // Mock Serialization
-// ////////////////////////////
-// Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
-const mapToObj = map => {
-  const obj = {};
-  for (const [key, value] of map.entries()) {
-    obj[key] = value;
-  }
-  return obj;
-};
-function TestURLSync({
-  syncKey,
-  location,
-}: {
-  syncKey?: string,
-  location: LocationOption,
-}) {
-  useRecoilURLSync({
-    syncKey,
-    location,
-    serialize: items =>
-      `${location.part === 'href' ? '/TEST#' : ''}${encodeURI(
-        JSON.stringify(mapToObj(items)),
-      )}`,
-    deserialize: str => {
-      const stateStr = location.part === 'href' ? str.split('#')[1] : str;
-      // Skip the default URL parts which don't conform to the serialized standard
-      if (
-        stateStr == null ||
-        stateStr === 'anchor' ||
-        stateStr === 'foo=bar' ||
-        stateStr === 'bar'
-      ) {
-        return new Map();
-      }
-      try {
-        return new Map(Object.entries(JSON.parse(decodeURI(stateStr))));
-      } catch (e) {
-        console.error('Error parsing: ', location, decodeURI(stateStr));
-        throw e;
-      }
-    },
-  });
-  return null;
-}
-
-function encodeState(obj) {
-  return `${encodeURI(JSON.stringify(obj))}`;
-}
-
-function encodeURLPart(href: string, loc: LocationOption, obj): string {
-  const encoded = encodeState(obj);
-  const url = new URL(href);
-  switch (loc.part) {
-    case 'href':
-      url.pathname = '/TEST';
-      url.hash = encoded;
-      break;
-    case 'hash':
-      url.hash = encoded;
-      break;
-    case 'search': {
-      const {queryParam} = loc;
-      if (queryParam == null) {
-        url.search = encoded;
-      } else {
-        const searchParams = url.searchParams;
-        searchParams.set(queryParam, encoded);
-        url.search = searchParams.toString();
-      }
-      break;
-    }
-  }
-  return url.href;
-}
-
-function encodeURL(parts: Array<[LocationOption, {...}]>) {
-  let href = window.location.href;
-  for (const [loc, obj] of parts) {
-    href = encodeURLPart(href, loc, obj);
-  }
-  return href;
-}
-
-function expectURL(parts: Array<[LocationOption, {...}]>) {
-  expect(window.location.href).toBe(encodeURL(parts));
-}
-
-async function gotoURL(parts: Array<[LocationOption, {...}]>) {
-  history.pushState(null, '', encodeURL(parts));
-  history.pushState(null, '', '/POPSTATE');
-  history.back();
-  await flushPromisesAndTimers();
-}
-
-///////////////////////
-// Tests
-///////////////////////
 describe('Test URL Persistence', () => {
   beforeEach(() => {
     history.replaceState(null, '', '/path/page.html?foo=bar#anchor');
@@ -193,15 +85,20 @@ describe('Test URL Persistence', () => {
     remainder();
   }
 
-  // TODO Re-enable test when supporting multiple <RecoilRoot>'s
-  // test('Write to URL', () =>
-  //   testWriteToURL({part: 'href'}, () => {
-  //     expect(location.search).toBe('');
-  //     expect(location.pathname).toBe('/TEST');
-  //   }));
+  test('Write to URL', () =>
+    testWriteToURL({part: 'href'}, () => {
+      expect(location.search).toBe('');
+      expect(location.pathname).toBe('/TEST');
+    }));
   test('Write to URL - Anchor Hash', () =>
     testWriteToURL({part: 'hash'}, () => {
       expect(location.search).toBe('?foo=bar');
+    }));
+  test('Write to URL - Query Search', () =>
+    testWriteToURL({part: 'search'}, () => {
+      expect(location.hash).toBe('#anchor');
+      expect(new URL(location.href).searchParams.get('foo')).toBe(null);
+      expect(new URL(location.href).searchParams.get('bar')).toBe(null);
     }));
   test('Write to URL - Query Search Param', () =>
     testWriteToURL({part: 'search', queryParam: 'bar'}, () => {
@@ -289,9 +186,9 @@ describe('Test URL Persistence', () => {
     expect(container.textContent).toBe('"A""B""DEFAULT"');
   }
 
-  // TODO Re-enable test when supporting multiple <RecoilRoot>'s
-  // test('Read from URL', () => testReadFromURL({part: 'href'}));
+  test('Read from URL', () => testReadFromURL({part: 'href'}));
   test('Read from URL - Anchor Hash', () => testReadFromURL({part: 'hash'}));
+  test('Read from URL - Search Query', () => testReadFromURL({part: 'search'}));
   test('Read from URL - Search Query Param', () =>
     testReadFromURL({part: 'search', queryParam: 'param'}));
   test('Read from URL - Search Query Param with other param', () =>
@@ -306,7 +203,7 @@ describe('Test URL Persistence', () => {
       default: 'DEFAULT',
       effects_UNSTABLE: [
         // No matching sync effect
-        syncEffect({restore: validateString}),
+        syncEffect<string>({restore: validateString}),
       ],
     });
 
@@ -317,7 +214,9 @@ describe('Test URL Persistence', () => {
       effects_UNSTABLE: [
         // This sync effect is ignored
         syncEffect<string>({restore: upgrade(validateString, () => 'IGNORE')}),
-        syncEffect<string>({restore: upgrade(validateNumber, num => `${num}`)}),
+        syncEffect<string>({
+          restore: upgrade<number, string>(validateNumber, num => `${num}`),
+        }),
         // This sync effect is ignored
         syncEffect<string>({restore: upgrade(validateString, () => 'IGNORE')}),
       ],
@@ -373,8 +272,10 @@ describe('Test URL Persistence', () => {
       key: 'recoil-url-sync read/write upgrade type',
       default: 'DEFAULT',
       effects_UNSTABLE: [
-        syncEffect<string>({restore: upgrade(validateNumber, num => `${num}`)}),
-        syncEffect({restore: validateString}),
+        syncEffect<string>({
+          restore: upgrade<number, string>(validateNumber, num => `${num}`),
+        }),
+        syncEffect<string>({restore: validateString}),
       ],
     });
     const atomB = atom({
@@ -460,245 +361,6 @@ describe('Test URL Persistence', () => {
       [loc1, {}],
       [loc2, {}],
     ]);
-  });
-
-  test('Listen to URL changes', async () => {
-    const locFoo = {part: 'search', queryParam: 'foo'};
-    const locBar = {part: 'search', queryParam: 'bar'};
-
-    const atomA = atom({
-      key: 'recoil-url-sync listen',
-      default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({syncKey: 'foo', restore: validateAny})],
-    });
-    const atomB = atom({
-      key: 'recoil-url-sync listen to multiple keys',
-      default: 'DEFAULT',
-      effects_UNSTABLE: [
-        syncEffect({syncKey: 'foo', key: 'KEY A', restore: validateAny}),
-        syncEffect({syncKey: 'foo', key: 'KEY B', restore: validateAny}),
-      ],
-    });
-    const atomC = atom({
-      key: 'recoil-url-sync listen to multiple storage',
-      default: 'DEFAULT',
-      effects_UNSTABLE: [
-        syncEffect({syncKey: 'foo', restore: validateAny}),
-        syncEffect({syncKey: 'bar', restore: validateAny}),
-      ],
-    });
-
-    history.replaceState(
-      null,
-      '',
-      encodeURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'A',
-            'KEY A': 'B',
-            'recoil-url-sync listen to multiple storage': 'C',
-          },
-        ],
-      ]),
-    );
-
-    const container = renderElements(
-      <>
-        <TestURLSync syncKey="foo" location={locFoo} />
-        <TestURLSync syncKey="bar" location={locBar} />
-        <ReadsAtom atom={atomA} />
-        <ReadsAtom atom={atomB} />
-        <ReadsAtom atom={atomC} />
-      </>,
-    );
-
-    // Initial load will use the fallback storage for C
-    expect(container.textContent).toBe('"A""B""C"');
-    expectURL([
-      [
-        locFoo,
-        {
-          'recoil-url-sync listen': 'A',
-          'KEY A': 'B',
-          'recoil-url-sync listen to multiple storage': 'C',
-        },
-      ],
-    ]);
-
-    // Subscribe to new value
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'B',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""B""C1"');
-    // Changing value of C caused it to sync with locBar
-    expectURL([
-      [
-        locFoo,
-        {
-          'recoil-url-sync listen': 'AA',
-          'KEY A': 'B',
-          'recoil-url-sync listen to multiple storage': 'C1',
-        },
-      ],
-      [
-        locBar,
-        {
-          'recoil-url-sync listen to multiple storage': 'C1',
-        },
-      ],
-    ]);
-
-    // Subscribe to new value from different key
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'BB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expectURL([
-      [
-        locFoo,
-        {
-          'recoil-url-sync listen': 'AA',
-          'KEY A': 'BB',
-          'recoil-url-sync listen to multiple storage': 'C1',
-        },
-      ],
-      [
-        locBar,
-        {
-          'recoil-url-sync listen to multiple storage': 'C1',
-        },
-      ],
-    ]);
-    expect(container.textContent).toBe('"AA""BB""C1"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'BB',
-            'KEY B': 'BBB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""BBB""C1"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'IGNORE',
-            'KEY B': 'BBB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""BBB""C1"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'BBBB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""BBBB""C1"');
-
-    // Subscribe to reset
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""C1"');
-
-    // Subscribe to new value from different storage
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'B',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-        [locBar, {}],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""B""DEFAULT"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-        [
-          locBar,
-          {
-            'recoil-url-sync listen to multiple storage': 'CC2',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""CC2"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-        [locBar, {}],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'CC1',
-          },
-        ],
-        [locBar, {}],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
   });
 
   test('Persist default on read', async () => {

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+// TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
+// TODO PUBLIC LOADABLE INTERFACE
+
+// import type {Loadable} from '../../../adt/Recoil_Loadable';
+import type {LocationOption} from '../recoil-url-sync';
+
+const {act} = require('ReactTestUtils');
+
+const {loadableWithValue} = require('../../../adt/Recoil_Loadable');
+const atom = require('../../../recoil_values/Recoil_atom');
+const {
+  componentThatReadsAndWritesAtom,
+  renderElements,
+} = require('../../../testing/Recoil_TestingUtils');
+const {syncEffect} = require('../recoil-sync');
+const {urlSyncEffect, useRecoilURLSync} = require('../recoil-url-sync');
+const React = require('react');
+
+let atomIndex = 0;
+const nextKey = () => `recoil-url-sync/${atomIndex++}`;
+
+////////////////////////////
+// Mock validation library
+////////////////////////////
+const validateAny = loadableWithValue;
+// const validateString = x =>
+//   typeof x === 'string' ? loadableWithValue(x) : null;
+// const validateNumber = x =>
+//   typeof x === 'number' ? loadableWithValue(x) : null;
+// function upgrade<From, To>(
+//   validate: mixed => ?Loadable<From>,
+//   upgrade: From => To,
+// ): mixed => ?Loadable<To> {
+//   return x => validate(x)?.map(upgrade);
+// }
+
+// ////////////////////////////
+// // Mock Serialization
+// ////////////////////////////
+// Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
+const mapToObj = map => {
+  const obj = {};
+  for (const [key, value] of map.entries()) {
+    obj[key] = value;
+  }
+  return obj;
+};
+function TestURLSync({
+  syncKey,
+  location,
+}: {
+  syncKey?: string,
+  location: LocationOption,
+}) {
+  useRecoilURLSync({
+    syncKey,
+    location,
+    serialize: items =>
+      `${location.part === 'href' ? '/TEST#' : ''}${encodeURI(
+        JSON.stringify(mapToObj(items)),
+      )}`,
+  });
+  return null;
+}
+
+function encodeState(obj) {
+  return `${encodeURI(JSON.stringify(obj))}`;
+}
+
+function encodeURL(loc, obj) {
+  const encoded = encodeState(obj);
+  const url = new URL(window.location);
+  switch (loc.part) {
+    case 'href':
+      url.pathname = '/TEST';
+      url.hash = encoded;
+      break;
+    case 'hash':
+      url.hash = encoded;
+      break;
+    case 'search': {
+      const {queryParam} = loc;
+      if (queryParam == null) {
+        url.search = encoded;
+      } else {
+        // const searchParams = new URLSearchParams(location.search);
+        const searchParams = url.searchParams;
+        searchParams.set(queryParam, encoded);
+        url.search = searchParams.toString();
+      }
+      break;
+    }
+  }
+  return url.href;
+}
+
+function expectURL(loc, obj) {
+  expect(window.location.href).toBe(encodeURL(loc, obj));
+}
+
+///////////////////////
+// Tests
+///////////////////////
+describe('Test URL Persistence', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', '/path/page.html?foo=bar#anchor');
+  });
+
+  function testWriteToURL(loc, remainder) {
+    const atomA = atom({
+      key: nextKey(),
+      default: 'DEFAULT',
+      effects_UNSTABLE: [urlSyncEffect({key: 'a', restore: validateAny})],
+    });
+    const atomB = atom({
+      key: nextKey(),
+      default: 'DEFAULT',
+      effects_UNSTABLE: [urlSyncEffect({key: 'b', restore: validateAny})],
+    });
+    const ignoreAtom = atom({
+      key: nextKey(),
+      default: 'DEFAULT',
+    });
+
+    const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);
+    const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
+    const [IgnoreAtom, setIgnore] = componentThatReadsAndWritesAtom(ignoreAtom);
+    const container = renderElements(
+      <>
+        <TestURLSync location={loc} />
+        <AtomA />
+        <AtomB />
+        <IgnoreAtom />
+      </>,
+    );
+
+    expectURL(loc, {});
+    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+
+    act(() => setA('A'));
+    act(() => setB('B'));
+    act(() => setIgnore('IGNORE'));
+    expect(container.textContent).toBe('"A""B""IGNORE"');
+    expectURL(loc, {a: 'A', b: 'B'});
+
+    act(() => resetA());
+    act(() => setB('BB'));
+    expect(container.textContent).toBe('"DEFAULT""BB""IGNORE"');
+    expectURL(loc, {b: 'BB'});
+
+    remainder();
+  }
+
+  test('Write to URL', () =>
+    testWriteToURL({part: 'href'}, () => {
+      expect(location.search).toBe('');
+      expect(location.pathname).toBe('/TEST');
+    }));
+  test('Write to URL - Anchor Hash', () =>
+    testWriteToURL({part: 'hash'}, () => {
+      expect(location.search).toBe('?foo=bar');
+    }));
+  test('Write to URL - Query Search', () =>
+    testWriteToURL({part: 'search'}, () => {
+      expect(location.hash).toBe('#anchor');
+    }));
+  test('Write to URL - Query Search Param', () =>
+    testWriteToURL({part: 'search', queryParam: 'bar'}, () => {
+      expect(location.hash).toBe('#anchor');
+      expect(new URL(location.href).searchParams.get('foo')).toBe('bar');
+    }));
+
+  test('Write to multiple params', async () => {
+    const atomA = atom({
+      key: 'recoil-url-sync multiple param A',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        syncEffect({syncKey: 'A', key: 'x', restore: validateAny}),
+      ],
+    });
+    const atomB = atom({
+      key: 'recoil-url-sync multiple param B',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        syncEffect({syncKey: 'B', key: 'x', restore: validateAny}),
+      ],
+    });
+
+    const [AtomA, setA] = componentThatReadsAndWritesAtom(atomA);
+    const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
+    renderElements(
+      <>
+        <TestURLSync
+          syncKey="A"
+          location={{part: 'search', queryParam: 'foo'}}
+        />
+        <TestURLSync
+          syncKey="B"
+          location={{part: 'search', queryParam: 'bar'}}
+        />
+        <AtomA />
+        <AtomB />
+      </>,
+    );
+
+    act(() => setA('A'));
+    act(() => setB('B'));
+    const url = new URL(location.href);
+    url.searchParams.set('foo', encodeState({x: 'A'}));
+    url.searchParams.set('bar', encodeState({x: 'B'}));
+    expect(location.href).toBe(url.href);
+  });
+});

--- a/src/contrib/recoil-sync/recoil-sync.js
+++ b/src/contrib/recoil-sync/recoil-sync.js
@@ -199,12 +199,7 @@ function useRecoilSync({
 ///////////////////////
 // syncEffect()
 ///////////////////////
-function syncEffect<T>({
-  syncKey,
-  key,
-  restore,
-  syncDefault,
-}: {
+export type SyncEffectOptions<T> = {
   syncKey?: SyncKey,
   key?: ItemKey,
 
@@ -215,7 +210,14 @@ function syncEffect<T>({
 
   // Sync default value instead of empty when atom is indefault state
   syncDefault?: boolean,
-}): AtomEffect<T> {
+};
+
+function syncEffect<T>({
+  syncKey,
+  key,
+  restore,
+  syncDefault,
+}: SyncEffectOptions<T>): AtomEffect<T> {
   return ({node, setSelf, getLoadable, getInfo_UNSTABLE}) => {
     const itemKey = key ?? node.key;
 

--- a/src/contrib/recoil-sync/recoil-sync.js
+++ b/src/contrib/recoil-sync/recoil-sync.js
@@ -146,10 +146,12 @@ function useRecoilSync({
           delete registration.pendingUpdate;
         }
       }
-      write({
-        diff,
-        items: itemsFromSnapshot(syncKey, snapshot.getInfo_UNSTABLE),
-      });
+      if (diff.size) {
+        write({
+          diff,
+          items: itemsFromSnapshot(syncKey, snapshot.getInfo_UNSTABLE),
+        });
+      }
     }
   }, [snapshot, syncKey, write]);
 

--- a/src/contrib/recoil-sync/recoil-sync.js
+++ b/src/contrib/recoil-sync/recoil-sync.js
@@ -28,8 +28,8 @@ type NodeKey = string;
 export type ItemKey = string;
 export type SyncKey = string | void;
 
-export type ItemDiff = Map<ItemKey, ?Loadable<mixed>>;
-export type ItemSnapshot = Map<ItemKey, ?Loadable<mixed>>;
+export type ItemDiff = Map<ItemKey, ?Loadable<mixed>>; // null means reset
+export type ItemSnapshot = Map<ItemKey, ?Loadable<mixed>>; // null means default
 export type ReadItem = ItemKey => ?Loadable<mixed>;
 export type WriteItems = ({diff: ItemDiff, items: ItemSnapshot}) => void;
 export type UpdateItems = ItemDiff => void;

--- a/src/contrib/recoil-sync/recoil-url-sync.js
+++ b/src/contrib/recoil-sync/recoil-url-sync.js
@@ -86,10 +86,10 @@ function useRecoilURLSync({
   serialize,
   deserialize,
 }: RecoilURLSyncOptions): void {
-  function write({items}) {
+  function write({allItems}) {
     // Only serialize atoms in a non-default value state.
     const state = new Map(
-      Array.from(items.entries())
+      Array.from(allItems.entries())
         .filter(([, loadable]) => loadable?.state === 'hasValue')
         .map(([key, loadable]) => [key, loadable?.contents]),
     );
@@ -108,7 +108,7 @@ function useRecoilURLSync({
     }
   }
 
-  function listen({updateAllItems}) {
+  function listen({updateAllKnownItems}) {
     function handleUpdate() {
       const stateStr = parseURL(location);
       if (stateStr != null) {
@@ -119,7 +119,7 @@ function useRecoilURLSync({
             loadableWithValue(v),
           ]),
         );
-        updateAllItems(mappedState);
+        updateAllKnownItems(mappedState);
       }
     }
     window.addEventListener('popstate', handleUpdate);

--- a/src/contrib/recoil-sync/recoil-url-sync.js
+++ b/src/contrib/recoil-sync/recoil-url-sync.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {AtomEffect} from '../../recoil_values/Recoil_atom';
+import type {ItemKey, SyncEffectOptions, SyncKey} from './recoil-sync';
+
+const {syncEffect, useRecoilSync} = require('./recoil-sync');
+const React = require('react');
+
+type NodeKey = string;
+type AtomRegistration = {
+  history: HistoryOption,
+};
+
+const registries: Map<SyncKey, Map<NodeKey, AtomRegistration>> = new Map();
+
+function updateURL(loc: LocationOption, serialization): string {
+  switch (loc.part) {
+    case 'href':
+      return serialization;
+    case 'hash':
+      return `#${serialization}`;
+    case 'search': {
+      const {queryParam} = loc;
+      if (queryParam == null) {
+        return `?${serialization}${location.hash}`;
+      }
+      const searchParams = new URLSearchParams(location.search);
+      searchParams.set(queryParam, serialization);
+      return `?${searchParams.toString()}${location.hash}`;
+    }
+  }
+  throw new Error(`Unknown URL location part: "${loc.part}"`);
+}
+
+///////////////////////
+// useRecoilURLSync()
+///////////////////////
+export type LocationOption =
+  | {part: 'href'}
+  | {part: 'hash'}
+  | {part: 'search', queryParam?: string};
+export type ItemState = Map<ItemKey, mixed>;
+type RecoilURLSyncOptions = {
+  syncKey?: SyncKey,
+  location: LocationOption,
+  serialize: ItemState => string,
+};
+
+function useRecoilURLSync({
+  syncKey,
+  location,
+  serialize,
+}: RecoilURLSyncOptions): void {
+  function read() {}
+
+  function write({items}) {
+    // Only serialize atoms in a non-default value state.
+    const state = new Map(
+      Array.from(items.entries())
+        .filter(([, loadable]) => loadable?.state === 'hasValue')
+        .map(([key, loadable]) => [key, loadable?.contents]),
+    );
+
+    // TODO Support History Push vs Replace
+    const newURL = updateURL(location, serialize(state));
+    history.replaceState(null, '', newURL);
+  }
+
+  function listen() {}
+
+  useRecoilSync({syncKey, read, write, listen});
+}
+
+function RecoilURLSync(props: RecoilURLSyncOptions): React.Node {
+  useRecoilURLSync(props);
+  return null;
+}
+
+///////////////////////
+// urlSyncEffect()
+///////////////////////
+type HistoryOption = 'push' | 'replace';
+
+function urlSyncEffect<T>({
+  history = 'replace',
+  ...options
+}: {
+  ...SyncEffectOptions<T>,
+  history?: HistoryOption,
+}): AtomEffect<T> {
+  const atomEffect = syncEffect<T>(options);
+  return effectArgs => {
+    // Register URL sync options
+    if (!registries.has(options.syncKey)) {
+      registries.set(options.syncKey, new Map());
+    }
+    const atomRegistry = registries.get(options.syncKey);
+    if (atomRegistry == null) {
+      throw new Error('Error with atom registration');
+    }
+    atomRegistry.set(effectArgs.node.key, {history});
+
+    // Wrap syncEffect() atom effect
+    const cleanup = atomEffect(effectArgs);
+
+    // Cleanup atom option registration
+    return () => {
+      atomRegistry.delete(effectArgs.node.key);
+      cleanup?.();
+    };
+  };
+}
+
+module.exports = {
+  useRecoilURLSync,
+  RecoilURLSync,
+  urlSyncEffect,
+};


### PR DESCRIPTION
Summary:
Refactor tests so the tests which subscribe to listening to URL changes are pulled out in a separate module.  This allows us to have full coverage for testing using different parts of the URL (i.e. path, anchor hash, query search params) without causing the listening tests to trip up when other tests change the global URL in incompatible ways.

Also, normalize the validation and serialization mock-ups.

Reviewed By: davidmccabe

Differential Revision: D30947076

