### PR TITLE
Add test initializing atoms based on props

### DIFF
--- a/src/adt/__tests__/Recoil_Loadable-test.js
+++ b/src/adt/__tests__/Recoil_Loadable-test.js
@@ -47,8 +47,7 @@ test('Error Loadable', async () => {
 });
 
 test('Pending Value Loadable', async () => {
-  // TODO update API to avoid wrapping
-  const promise = Promise.resolve({__value: 'VALUE'});
+  const promise = Promise.resolve('VALUE');
   const loadable = loadableWithPromise(promise);
   expect(loadable.state).toBe('loading');
   expect(loadable.contents).toBe(promise);
@@ -100,27 +99,22 @@ describe('Loadable mapping', () => {
   });
 
   test('Loadable mapping promise value', async () => {
-    // TODO update API to avoid wrapping
-    const loadable = loadableWithPromise(
-      Promise.resolve({__value: 'VALUE'}),
-    ).map(x => 'MAPPED ' + x);
+    const loadable = loadableWithPromise(Promise.resolve('VALUE')).map(
+      x => 'MAPPED ' + x,
+    );
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
   });
 
   test('Loadable mapping promise value to reject', async () => {
-    // TODO update API to avoid wrapping
-    const loadable = loadableWithPromise(
-      Promise.resolve({__value: 'VALUE'}),
-    ).map(() => Promise.reject(ERROR));
+    const loadable = loadableWithPromise(Promise.resolve('VALUE')).map(() =>
+      Promise.reject(ERROR),
+    );
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).rejects.toBe(ERROR);
   });
   test('Loadable mapping promise value to error', async () => {
-    // TODO update API to avoid wrapping
-    const loadable = loadableWithPromise(
-      Promise.resolve({__value: 'VALUE'}),
-    ).map(() => {
+    const loadable = loadableWithPromise(Promise.resolve('VALUE')).map(() => {
       throw ERROR;
     });
     expect(loadable.state).toBe('loading');
@@ -144,30 +138,24 @@ describe('Loadable mapping', () => {
   });
 
   test('Loadable mapping promise to loadable value', async () => {
-    // TODO update API to avoid wrapping
-    const loadable = loadableWithPromise(
-      Promise.resolve({__value: 'VALUE'}),
-    ).map(value => loadableWithValue('MAPPED ' + value));
+    const loadable = loadableWithPromise(Promise.resolve('VALUE')).map(value =>
+      loadableWithValue('MAPPED ' + value),
+    );
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
   });
 
   test('Loadable mapping promise to loadable error', async () => {
-    // TODO update API to avoid wrapping
-    const loadable = loadableWithPromise(
-      Promise.resolve({__value: 'VALUE'}),
-    ).map(() => loadableWithError(ERROR));
+    const loadable = loadableWithPromise(Promise.resolve('VALUE')).map(() =>
+      loadableWithError(ERROR),
+    );
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).rejects.toBe(ERROR);
   });
 
   test('Loadable mapping promise to loadable promise', async () => {
-    // TODO update API to avoid wrapping
-    const loadable = loadableWithPromise(
-      Promise.resolve({__value: 'VALUE'}),
-    ).map(value =>
-      // TODO update API to avoid wrapping
-      loadableWithPromise(Promise.resolve({__value: 'MAPPED ' + value})),
+    const loadable = loadableWithPromise(Promise.resolve('VALUE')).map(value =>
+      loadableWithPromise(Promise.resolve('MAPPED ' + value)),
     );
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');

--- a/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
+++ b/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
@@ -118,8 +118,13 @@ function expectURL(parts: Array<[LocationOption, {...}]>) {
 }
 
 async function gotoURL(parts: Array<[LocationOption, {...}]>) {
-  history.pushState(null, '', encodeURL(parts));
+  history.replaceState(null, '', encodeURL(parts));
   history.pushState(null, '', '/POPSTATE');
+  history.back();
+  await flushPromisesAndTimers();
+}
+
+async function goBack() {
   history.back();
   await flushPromisesAndTimers();
 }
@@ -129,4 +134,5 @@ module.exports = {
   encodeURL,
   expectURL,
   gotoURL,
+  goBack,
 };

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -203,10 +203,7 @@ test('Read from storage async', async () => {
   });
 
   const storage = new Map([
-    [
-      'recoil-sync read async',
-      loadableWithPromise(Promise.resolve({__value: 'A'})),
-    ],
+    ['recoil-sync read async', loadableWithPromise(Promise.resolve('A'))],
   ]);
 
   const container = renderElements(
@@ -296,7 +293,7 @@ test('Read from storage upgrade', async () => {
           // Test async validation
           x =>
             typeof x === 'string'
-              ? loadableWithPromise(Promise.resolve({__value: x}))
+              ? loadableWithPromise(Promise.resolve(x))
               : null,
           str => Number(str),
         ),
@@ -321,10 +318,7 @@ test('Read from storage upgrade', async () => {
     ['recoil-sync fail validation', loadableWithValue(123)],
     ['recoil-sync upgrade number', loadableWithValue(123)],
     ['recoil-sync upgrade string', loadableWithValue('123')],
-    [
-      'recoil-sync upgrade async',
-      loadableWithPromise(Promise.resolve({__value: 123})),
-    ],
+    ['recoil-sync upgrade async', loadableWithPromise(Promise.resolve(123))],
   ]);
 
   const container = renderElements(
@@ -608,7 +602,7 @@ test('Listen to storage', async () => {
   // act(() =>
   //   updateItem1(
   //     'recoil-sync listen',
-  //     loadableWithPromise(Promise.resolve({__value: 'ASYNC'})),
+  //     loadableWithPromise(Promise.resolve( 'ASYNC')),
   //   ),
   // );
   // await flushPromisesAndTimers();

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -662,7 +662,6 @@ test('Persist on read - async', async () => {
 
   const atomA = atom({
     key: 'recoil-sync persist on read default async',
-    // default: Promise.resolve('ASYNC_DEFAULT'),
     default: new Promise(resolve => {
       resolveA = resolve;
     }),
@@ -726,4 +725,41 @@ test('Persist on read - async', async () => {
   expect(
     storage.get('recoil-sync persist on read init async')?.getValue(),
   ).toBe('ASYNC_INIT_AFTER');
+});
+
+test('Sync based on component props', async () => {
+  function SyncWithProps(props) {
+    useRecoilSync({
+      read: itemKey =>
+        itemKey in props ? loadableWithValue(props[itemKey]) : null,
+    });
+    return null;
+  }
+
+  const atomA = atom({
+    key: 'recoil-sync from props spam',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [syncEffect({key: 'spam', restore: validateAny})],
+  });
+  const atomB = atom({
+    key: 'recoil-sync from props eggs',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [syncEffect({key: 'eggs', restore: validateAny})],
+  });
+  const atomC = atom({
+    key: 'recoil-sync from props default',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [syncEffect({key: 'default', restore: validateAny})],
+  });
+
+  const container = renderElements(
+    <>
+      <SyncWithProps spam="SPAM" eggs="EGGS" />
+      <ReadsAtom atom={atomA} />
+      <ReadsAtom atom={atomB} />
+      <ReadsAtom atom={atomC} />
+    </>,
+  );
+
+  expect(container.textContent).toBe('"SPAM""EGGS""DEFAULT"');
 });

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
@@ -26,65 +26,36 @@ const {
 const {syncEffect} = require('../recoil-sync');
 const React = require('react');
 
-describe('Test URL Persistence', () => {
-  beforeEach(() => {
-    history.replaceState(null, '', '/path/page.html?foo=bar#anchor');
+test('Listen to URL changes', async () => {
+  const locFoo = {part: 'search', queryParam: 'foo'};
+  const locBar = {part: 'search', queryParam: 'bar'};
+
+  const atomA = atom({
+    key: 'recoil-url-sync listen',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [syncEffect({syncKey: 'foo', restore: validateAny})],
+  });
+  const atomB = atom({
+    key: 'recoil-url-sync listen to multiple keys',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [
+      syncEffect({syncKey: 'foo', key: 'KEY A', restore: validateAny}),
+      syncEffect({syncKey: 'foo', key: 'KEY B', restore: validateAny}),
+    ],
+  });
+  const atomC = atom({
+    key: 'recoil-url-sync listen to multiple storage',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [
+      syncEffect({syncKey: 'foo', restore: validateAny}),
+      syncEffect({syncKey: 'bar', restore: validateAny}),
+    ],
   });
 
-  test('Listen to URL changes', async () => {
-    const locFoo = {part: 'search', queryParam: 'foo'};
-    const locBar = {part: 'search', queryParam: 'bar'};
-
-    const atomA = atom({
-      key: 'recoil-url-sync listen',
-      default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({syncKey: 'foo', restore: validateAny})],
-    });
-    const atomB = atom({
-      key: 'recoil-url-sync listen to multiple keys',
-      default: 'DEFAULT',
-      effects_UNSTABLE: [
-        syncEffect({syncKey: 'foo', key: 'KEY A', restore: validateAny}),
-        syncEffect({syncKey: 'foo', key: 'KEY B', restore: validateAny}),
-      ],
-    });
-    const atomC = atom({
-      key: 'recoil-url-sync listen to multiple storage',
-      default: 'DEFAULT',
-      effects_UNSTABLE: [
-        syncEffect({syncKey: 'foo', restore: validateAny}),
-        syncEffect({syncKey: 'bar', restore: validateAny}),
-      ],
-    });
-
-    history.replaceState(
-      null,
-      '',
-      encodeURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'A',
-            'KEY A': 'B',
-            'recoil-url-sync listen to multiple storage': 'C',
-          },
-        ],
-      ]),
-    );
-
-    const container = renderElements(
-      <>
-        <TestURLSync syncKey="foo" location={locFoo} />
-        <TestURLSync syncKey="bar" location={locBar} />
-        <ReadsAtom atom={atomA} />
-        <ReadsAtom atom={atomB} />
-        <ReadsAtom atom={atomC} />
-      </>,
-    );
-
-    // Initial load will use the fallback storage for C
-    expect(container.textContent).toBe('"A""B""C"');
-    expectURL([
+  history.replaceState(
+    null,
+    '',
+    encodeURL([
       [
         locFoo,
         {
@@ -93,24 +64,35 @@ describe('Test URL Persistence', () => {
           'recoil-url-sync listen to multiple storage': 'C',
         },
       ],
-    ]);
+    ]),
+  );
 
-    // Subscribe to new value
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'B',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""B""C1"');
-    // Changing value of C caused it to sync with locBar
-    expectURL([
+  const container = renderElements(
+    <>
+      <TestURLSync syncKey="foo" location={locFoo} />
+      <TestURLSync syncKey="bar" location={locBar} />
+      <ReadsAtom atom={atomA} />
+      <ReadsAtom atom={atomB} />
+      <ReadsAtom atom={atomC} />
+    </>,
+  );
+
+  // Initial load will use the fallback storage for C
+  expect(container.textContent).toBe('"A""B""C"');
+  expectURL([
+    [
+      locFoo,
+      {
+        'recoil-url-sync listen': 'A',
+        'KEY A': 'B',
+        'recoil-url-sync listen to multiple storage': 'C',
+      },
+    ],
+  ]);
+
+  // Subscribe to new value
+  await act(() =>
+    gotoURL([
       [
         locFoo,
         {
@@ -119,28 +101,30 @@ describe('Test URL Persistence', () => {
           'recoil-url-sync listen to multiple storage': 'C1',
         },
       ],
-      [
-        locBar,
-        {
-          'recoil-url-sync listen to multiple storage': 'C1',
-        },
-      ],
-    ]);
+    ]),
+  );
+  expect(container.textContent).toBe('"AA""B""C1"');
+  // Changing value of C caused it to sync with locBar
+  expectURL([
+    [
+      locFoo,
+      {
+        'recoil-url-sync listen': 'AA',
+        'KEY A': 'B',
+        'recoil-url-sync listen to multiple storage': 'C1',
+      },
+    ],
+    [
+      locBar,
+      {
+        'recoil-url-sync listen to multiple storage': 'C1',
+      },
+    ],
+  ]);
 
-    // Subscribe to new value from different key
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'BB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expectURL([
+  // Subscribe to new value from different key
+  await act(() =>
+    gotoURL([
       [
         locFoo,
         {
@@ -149,124 +133,134 @@ describe('Test URL Persistence', () => {
           'recoil-url-sync listen to multiple storage': 'C1',
         },
       ],
+    ]),
+  );
+  expectURL([
+    [
+      locFoo,
+      {
+        'recoil-url-sync listen': 'AA',
+        'KEY A': 'BB',
+        'recoil-url-sync listen to multiple storage': 'C1',
+      },
+    ],
+    [
+      locBar,
+      {
+        'recoil-url-sync listen to multiple storage': 'C1',
+      },
+    ],
+  ]);
+  expect(container.textContent).toBe('"AA""BB""C1"');
+  await act(() =>
+    gotoURL([
       [
-        locBar,
+        locFoo,
+        {
+          'recoil-url-sync listen': 'AA',
+          'KEY A': 'BB',
+          'KEY B': 'BBB',
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+    ]),
+  );
+  expect(container.textContent).toBe('"AA""BBB""C1"');
+  await act(() =>
+    gotoURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen': 'AA',
+          'KEY A': 'IGNORE',
+          'KEY B': 'BBB',
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+    ]),
+  );
+  expect(container.textContent).toBe('"AA""BBB""C1"');
+  await act(() =>
+    gotoURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen': 'AA',
+          'KEY A': 'BBBB',
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+    ]),
+  );
+  expect(container.textContent).toBe('"AA""BBBB""C1"');
+
+  // Subscribe to reset
+  await act(() =>
+    gotoURL([
+      [
+        locFoo,
         {
           'recoil-url-sync listen to multiple storage': 'C1',
         },
       ],
-    ]);
-    expect(container.textContent).toBe('"AA""BB""C1"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'BB',
-            'KEY B': 'BBB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""BBB""C1"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'IGNORE',
-            'KEY B': 'BBB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""BBB""C1"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'BBBB',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""BBBB""C1"');
+    ]),
+  );
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""C1"');
 
-    // Subscribe to reset
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""C1"');
-
-    // Subscribe to new value from different storage
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen': 'AA',
-            'KEY A': 'B',
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-        [locBar, {}],
-      ]),
-    );
-    expect(container.textContent).toBe('"AA""B""DEFAULT"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-        [
-          locBar,
-          {
-            'recoil-url-sync listen to multiple storage': 'CC2',
-          },
-        ],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""CC2"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'C1',
-          },
-        ],
-        [locBar, {}],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
-    act(() =>
-      gotoURL([
-        [
-          locFoo,
-          {
-            'recoil-url-sync listen to multiple storage': 'CC1',
-          },
-        ],
-        [locBar, {}],
-      ]),
-    );
-    expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
-  });
+  // Subscribe to new value from different storage
+  await act(() =>
+    gotoURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen': 'AA',
+          'KEY A': 'B',
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+      [locBar, {}],
+    ]),
+  );
+  expect(container.textContent).toBe('"AA""B""DEFAULT"');
+  await act(() =>
+    gotoURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+      [
+        locBar,
+        {
+          'recoil-url-sync listen to multiple storage': 'CC2',
+        },
+      ],
+    ]),
+  );
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""CC2"');
+  await act(() =>
+    gotoURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen to multiple storage': 'C1',
+        },
+      ],
+      [locBar, {}],
+    ]),
+  );
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  await act(() =>
+    gotoURL([
+      [
+        locFoo,
+        {
+          'recoil-url-sync listen to multiple storage': 'CC1',
+        },
+      ],
+      [locBar, {}],
+    ]),
+  );
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
 });

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-push-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-push-test.js
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+// TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
+
+const {act} = require('ReactTestUtils');
+
+const {validateAny} = require('../__test_utils__/recoil-sync_mockValidation');
+const {
+  TestURLSync,
+  expectURL,
+  goBack,
+} = require('../__test_utils__/recoil-url-sync_mockSerialization');
+const atom = require('../../../recoil_values/Recoil_atom');
+const {
+  componentThatReadsAndWritesAtom,
+  renderElements,
+} = require('../../../testing/Recoil_TestingUtils');
+const {urlSyncEffect} = require('../recoil-url-sync');
+const React = require('react');
+
+test('Push URLs in browser history', async () => {
+  const loc = {part: 'search', queryParam: 'push'};
+
+  const atomA = atom({
+    key: 'recoil-url-sync replace',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [
+      urlSyncEffect({restore: validateAny, history: 'replace'}),
+    ],
+  });
+  const atomB = atom({
+    key: 'recoil-url-sync push',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [urlSyncEffect({restore: validateAny, history: 'push'})],
+  });
+  const atomC = atom({
+    key: 'recoil-url-sync push 2',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [urlSyncEffect({restore: validateAny, history: 'push'})],
+  });
+
+  const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);
+  const [AtomB, setB, resetB] = componentThatReadsAndWritesAtom(atomB);
+  const [AtomC, setC] = componentThatReadsAndWritesAtom(atomC);
+  const container = renderElements(
+    <>
+      <TestURLSync location={loc} />
+      <AtomA />
+      <AtomB />
+      <AtomC />
+    </>,
+  );
+
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  const baseHistory = history.length;
+
+  // Replace A
+  // 1: A__
+  act(() => setA('A'));
+  expect(container.textContent).toBe('"A""DEFAULT""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+      },
+    ],
+  ]);
+  expect(history.length).toBe(baseHistory);
+
+  // Push B
+  // 1: A__
+  // 2: AB_
+  act(() => setB('B'));
+  expect(container.textContent).toBe('"A""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Push C
+  // 1: A__
+  // 2: AB_
+  // 3: ABC
+  act(() => setC('C'));
+  expect(container.textContent).toBe('"A""B""C"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+        'recoil-url-sync push': 'B',
+        'recoil-url-sync push 2': 'C',
+      },
+    ],
+  ]);
+
+  // Pop and confirm C is reset
+  // 1: A__
+  // 2: AB_
+  await act(goBack);
+  expect(container.textContent).toBe('"A""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Replace Reset A
+  // 1: A__
+  // 2: _B_
+  act(resetA);
+  expect(container.textContent).toBe('"DEFAULT""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Push a Reset
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  act(resetB);
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  expectURL([[loc, {}]]);
+
+  // Push BB
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  // 4: _BB_
+  act(() => setB('BB'));
+  expect(container.textContent).toBe('"DEFAULT""BB""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync push': 'BB',
+      },
+    ],
+  ]);
+
+  // Replace AA
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  // 4: AABB_
+  act(() => setA('AA'));
+  expect(container.textContent).toBe('"AA""BB""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'AA',
+        'recoil-url-sync push': 'BB',
+      },
+    ],
+  ]);
+
+  // Replace AAA
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  // 4: AAABB_
+  act(() => setA('AAA'));
+  expect(container.textContent).toBe('"AAA""BB""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'AAA',
+        'recoil-url-sync push': 'BB',
+      },
+    ],
+  ]);
+
+  // Pop
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  await act(goBack);
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  expectURL([[loc, {}]]);
+
+  // Pop
+  // 1: A__
+  // 2: _B_
+  await act(goBack);
+  expect(container.textContent).toBe('"DEFAULT""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Pop
+  // 1: A__
+  await act(goBack);
+  expect(container.textContent).toBe('"A""DEFAULT""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+      },
+    ],
+  ]);
+});

--- a/src/core/Recoil_Node.js
+++ b/src/core/Recoil_Node.js
@@ -26,7 +26,7 @@ class DefaultValue {}
 const DEFAULT_VALUE: DefaultValue = new DefaultValue();
 
 class RecoilValueNotReady extends Error {
-  constructor(key: string) {
+  constructor(key: NodeKey) {
     super(
       `Tried to set the value of Recoil selector ${key} using an updater function, but it is an async selector in a pending or error state; this is not supported.`,
     );

--- a/src/recoil_values/Recoil_WaitFor.js
+++ b/src/recoil_values/Recoil_WaitFor.js
@@ -66,18 +66,6 @@ function unwrapDependencies(
     : Object.getOwnPropertyNames(dependencies).map(key => dependencies[key]);
 }
 
-function getValueFromLoadablePromiseResult(result) {
-  if (
-    result != null &&
-    typeof result === 'object' &&
-    result.hasOwnProperty('__value')
-  ) {
-    return result.__value;
-  }
-
-  return result;
-}
-
 function wrapResults(
   dependencies:
     | $ReadOnlyArray<RecoilValueReadOnly<mixed>>
@@ -191,7 +179,7 @@ const waitForAny: <
         if (isPromise(exp)) {
           exp
             .then(result => {
-              results[i] = getValueFromLoadablePromiseResult(result);
+              results[i] = result;
               exceptions[i] = undefined;
               resolve(wrapLoadables(dependencies, results, exceptions));
             })
@@ -244,9 +232,7 @@ const waitForAll: <
     return Promise.all(exceptions).then(exceptionResults =>
       wrapResults(
         dependencies,
-        combineAsyncResultsWithSyncResults(results, exceptionResults).map(
-          getValueFromLoadablePromiseResult,
-        ),
+        combineAsyncResultsWithSyncResults(results, exceptionResults),
       ),
     );
   },
@@ -286,7 +272,7 @@ const waitForAllSettled: <
           isPromise(exp)
             ? exp
                 .then(result => {
-                  results[i] = getValueFromLoadablePromiseResult(result);
+                  results[i] = result;
                   exceptions[i] = undefined;
                 })
                 .catch(error => {

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -490,12 +490,10 @@ testRecoil('useRecoilState - selector catching promise 2', async () => {
       } catch (promise) {
         expect(promise instanceof Promise).toBe(true);
         // eslint-disable-next-line jest/valid-expect
-        dependencyPromiseTest = expect(promise).resolves.toHaveProperty(
-          '__value',
-          'READY',
-        );
+        dependencyPromiseTest = expect(promise).resolves.toBe('READY');
 
-        return promise.then(result => {
+        return promise.then(pending => {
+          const result = pending.value;
           expect(result).toBe('READY');
           return result.value + ' NOW';
         });


### PR DESCRIPTION
Summary: Add test demonstrating the use-case of initializing atoms based on prop values.  This is normally difficult because atoms are not created in the scope of React render functions and can't set their default based on React props or hooks.  This is because there would be race conditions for atom initialization based on what component happened to render using it first.  However, using atom effects we can initialize the atoms based on the `useRecoilSync()` hook using values from a React render function including props and other hooks.  The race condition is solved because there is a single hook setting up the synchronization per `<RecoilRoot>`.

Differential Revision: D31036191

