### PR TITLE
Fix components in useRecoilCallback() unit tests to return value

### DIFF
--- a/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -67,7 +67,7 @@ testRecoil(
     }
 
     const container = document.createElement('div');
-    await act(() => {
+    act(() => {
       ReactDOM.render(
         <RecoilRoot initializeState={initializeState}>
           <ReadWriteAtom />

--- a/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -314,11 +314,13 @@ describe('useRecoilCallback', () => {
           set(family(i), 1);
         }
       });
+      return null;
     }
 
     let store: any; // flowlint-line unclear-type:off
     function GetStore() {
       store = useStoreRef().current;
+      return null;
     }
 
     renderElements(
@@ -393,6 +395,8 @@ testRecoil(
       useRecoilValue(atomWithEffect); // second initialization
 
       expect(numTimesEffectInit).toBe(2);
+
+      return null;
     };
 
     renderElements(<Component />);
@@ -432,6 +436,8 @@ testRecoil(
       readAtomFromSnapshot();
 
       expect(numTimesEffectInit).toBe(1);
+
+      return null;
     };
 
     renderElements(<Component />);

--- a/src/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/src/hooks/__tests__/Recoil_useTransaction-test.js
@@ -55,6 +55,8 @@ testRecoil(
       useRecoilValue(atomWithEffect);
 
       expect(numTimesEffectInit).toBe(1);
+
+      return null;
     };
 
     renderElements(<Component />);
@@ -94,6 +96,8 @@ testRecoil(
       readAtomFromSnapshot();
 
       expect(numTimesEffectInit).toBe(1);
+
+      return null;
     };
 
     renderElements(<Component />);


### PR DESCRIPTION
Summary: Fix components in unit tests for `useRecoilCallback()` to always return a value such as `null` instead of `undefined`.

Differential Revision: D31089558

