### PR TITLE
Consolidate Loadable unit tests error object

### DIFF
--- a/src/adt/__tests__/Recoil_Loadable-test.js
+++ b/src/adt/__tests__/Recoil_Loadable-test.js
@@ -33,16 +33,15 @@ test('Value Loadable', async () => {
 });
 
 test('Error Loadable', async () => {
-  const error = new Error('ERROR');
-  const loadable = loadableWithError(error);
+  const loadable = loadableWithError(ERROR);
   expect(loadable.state).toBe('hasError');
-  expect(loadable.contents).toBe(error);
-  expect(() => loadable.getValue()).toThrow(error);
-  await expect(loadable.toPromise()).rejects.toBe(error);
+  expect(loadable.contents).toBe(ERROR);
+  expect(() => loadable.getValue()).toThrow(ERROR);
+  await expect(loadable.toPromise()).rejects.toBe(ERROR);
   expect(loadable.valueMaybe()).toBe(undefined);
   expect(() => loadable.valueOrThrow()).toThrow();
-  expect(loadable.errorMaybe()).toBe(error);
-  expect(loadable.errorOrThrow()).toBe(error);
+  expect(loadable.errorMaybe()).toBe(ERROR);
+  expect(loadable.errorOrThrow()).toBe(ERROR);
   expect(loadable.promiseMaybe()).toBe(undefined);
   expect(() => loadable.promiseOrThrow()).toThrow();
 });


### PR DESCRIPTION
Summary: Consolidate `Loadable` unit tests to use the same error object for consistency.

Differential Revision: D31089977

