### PR TITLE
Selectors should not freeze upstream dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Ability to map Loadables with other Loadables
 - Allow class instances in family parameters for Flow
 - Add `getLoadable()`, `getPromise()`, and `getInfo_UNSTABLE()` to Atom Effects interface for reading other atoms.
+- Atoms freeze default, initialized, and async values in dev mode.  Selectors should not freeze upstream dependencies. (#1261, #1259)
 
 ### Pending
 - Memory management

--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -555,8 +555,6 @@ function selector<T>(
           updateExecutionInfoDepValues(depValues, store, executionId);
         }
 
-        maybeFreezeLoadableContents(loadable);
-
         if (loadable.state !== 'loading') {
           setCache(state, depValuesToDepRoute(depValues), loadable);
           setDepsInStore(store, state, new Set(depValues.keys()), executionId);
@@ -677,8 +675,6 @@ function selector<T>(
 
       const depLoadable = getCachedNodeLoadable(store, state, depKey);
 
-      maybeFreezeLoadableContents(depLoadable);
-
       depValues.set(depKey, depLoadable);
 
       if (depLoadable.state === 'hasValue') {
@@ -750,7 +746,9 @@ function selector<T>(
       loadable = loadableWithValue<T>(result);
     }
 
-    maybeFreezeLoadableContents(loadable);
+    if (loadable.state !== 'loading') {
+      maybeFreezeValue(loadable.contents);
+    }
 
     return [loadable, depValues];
   }
@@ -1034,12 +1032,6 @@ function selector<T>(
     return executionId === executionInfo.latestExecutionId;
   }
 
-  function maybeFreezeLoadableContents(loadable: Loadable<T>) {
-    if (loadable.state !== 'loading') {
-      maybeFreezeValue(loadable.contents);
-    }
-  }
-
   function maybeFreezeValue(val) {
     if (__DEV__) {
       if (Boolean(options.dangerouslyAllowMutability) === false) {
@@ -1111,8 +1103,6 @@ function selector<T>(
         }
 
         const loadable = getCachedNodeLoadable(store, state, depKey);
-
-        maybeFreezeLoadableContents(loadable);
 
         if (loadable.state === 'hasValue') {
           return loadable.contents;


### PR DESCRIPTION
Summary: Selectors freeze their values to help catch potential user errors where they may mutate state directly and miss notifying Recoil and React for proper re-rendering.  However, selectors should only freeze their own values, not those of upstream dependencies.

Differential Revision: D31122898

