### PR TITLE
Update example to specify [] for the deps.

### DIFF
--- a/docs/docs/api-reference/core/useRecoilCallback.md
+++ b/docs/docs/api-reference/core/useRecoilCallback.md
@@ -55,7 +55,7 @@ function CartInfoDebug() {
   const logCartItems = useRecoilCallback(({snapshot}) => async () => {
     const numItemsInCart = await snapshot.getPromise(itemsInCart);
     console.log('Items in cart: ', numItemsInCart);
-  });
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
In practice, I expect that much of the motivation for using `useRecoilCallback()` is to avoid recreating a callback when a Recoil value changes, as the callback will always read the latest value via the `snapshot` when it is executed. As I understand it, like `useCallback()`, if `deps` is not specified, a new callback will get created on each render of the React component, which is not desirable. This is results in extra computation and can cause unnecessary re-renders of child components to which the callback is passed.