### PR TITLE
Expose factories for creating Loadables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `getLoadable()`, `getPromise()`, and `getInfo_UNSTABLE()` to Atom Effects interface for reading other atoms.
 - Atoms freeze default, initialized, and async values in dev mode.  Selectors should not freeze upstream dependencies. (#1261, #1259)
 - Added `useRecoilRefresher_UNSTABLE()` hook which forces a selector to re-run it's `get()`, and is a no-op for an atom. (#972)
+- Expose `RecoilLoadable` interface for creating `Loadable` objects.
 
 ### Pending
 - Memory management

--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -42,6 +42,7 @@ export type {
   SelectorFamilyOptions,
 } from './recoil_values/Recoil_selectorFamily';
 
+const {RecoilLoadable} = require('./adt/Recoil_Loadable');
 const {DefaultValue} = require('./core/Recoil_Node');
 const {RecoilRoot} = require('./core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
@@ -85,27 +86,31 @@ module.exports = {
   // Types
   DefaultValue,
   isRecoilValue,
+  RecoilLoadable,
 
-  // Components
+  // Recoil Root
   RecoilRoot,
   useRecoilBridgeAcrossReactRoots_UNSTABLE: useRecoilBridgeAcrossReactRoots,
 
-  // RecoilValues
+  // Atoms/Selectors
   atom,
   selector,
 
-  // Factories
-  retentionZone,
-  snapshot_UNSTABLE: freshSnapshot,
-
-  // Convenience RecoilValues
+  // Convenience Atoms/Selectors
   atomFamily,
   selectorFamily,
   constSelector,
   errorSelector,
   readOnlySelector,
 
-  // Hooks that accept RecoilValues
+  // Concurrency Helpers for Atoms/Selectors
+  noWait,
+  waitForNone,
+  waitForAny,
+  waitForAll,
+  waitForAllSettled,
+
+  // Hooks for Atoms/Selectors
   useRecoilValue,
   useRecoilValueLoadable,
   useRecoilState,
@@ -113,24 +118,21 @@ module.exports = {
   useSetRecoilState,
   useResetRecoilState,
   useGetRecoilValueInfo_UNSTABLE: useGetRecoilValueInfo,
-  useRetain,
   useRecoilRefresher_UNSTABLE: useRecoilRefresher,
 
-  // Hooks for complex operations with RecoilValues
+  // Hooks for complex operations
   useRecoilCallback,
   useRecoilTransaction_UNSTABLE: useRecoilTransaction,
 
-  // Hooks for Snapshots
+  // Snapshots
   useGotoRecoilSnapshot,
   useRecoilSnapshot,
   useRecoilTransactionObserver_UNSTABLE: useRecoilTransactionObserver,
   useTransactionObservation_UNSTABLE: useTransactionObservation_DEPRECATED,
   useSetUnvalidatedAtomValues_UNSTABLE: useSetUnvalidatedAtomValues,
+  snapshot_UNSTABLE: freshSnapshot,
 
-  // Concurrency Helpers
-  noWait,
-  waitForNone,
-  waitForAny,
-  waitForAll,
-  waitForAllSettled,
+  // Memory Management
+  useRetain,
+  retentionZone,
 };

--- a/src/adt/Recoil_Loadable.js
+++ b/src/adt/Recoil_Loadable.js
@@ -15,8 +15,6 @@
  */
 'use strict';
 
-import type {NodeKey} from '../core/Recoil_Keys';
-
 const err = require('../util/Recoil_err');
 const isPromise = require('../util/Recoil_isPromise');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -292,6 +290,12 @@ function isLoadable(x: mixed): boolean %checks {
   return (x: any).__loadable == TYPE_CHECK_COOKIE; // flowlint-line unclear-type:off
 }
 
+const LoadableFactories = {
+  of: <T>(value: T | Promise<T>): Loadable<T> =>
+    isPromise(value) ? loadableWithPromise(value) : loadableWithValue(value),
+  error: <T>(error: mixed): ErrorLoadable<T> => loadableWithError(error),
+};
+
 module.exports = {
   loadableWithValue,
   loadableWithError,
@@ -301,4 +305,5 @@ module.exports = {
   isLoadable,
   Canceled,
   CANCELED,
+  RecoilLoadable: LoadableFactories,
 };

--- a/src/adt/__tests__/Recoil_Loadable-test.js
+++ b/src/adt/__tests__/Recoil_Loadable-test.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const {
+  RecoilLoadable,
   loadableWithError,
   loadableWithPromise,
   loadableWithValue,
@@ -160,4 +161,18 @@ describe('Loadable mapping', () => {
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
   });
+});
+
+test('Loadable Factory Interface', async () => {
+  const valueLoadable = RecoilLoadable.of('VALUE');
+  expect(valueLoadable.state).toBe('hasValue');
+  expect(valueLoadable.contents).toBe('VALUE');
+
+  const promiseLoadable = RecoilLoadable.of(Promise.resolve('ASYNC'));
+  expect(promiseLoadable.state).toBe('loading');
+  await expect(promiseLoadable.contents).resolves.toBe('ASYNC');
+
+  const errorLoadable = RecoilLoadable.error('ERROR');
+  expect(errorLoadable.state).toBe('hasError');
+  expect(errorLoadable.contents).toBe('ERROR');
 });

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -13,9 +13,8 @@
  * This file is a manual translation of the flow types, which are the source of truth, so we should not introduce new terminology or behavior in this file.
  */
 
- export { };
+export { };
 
- import { voidTypeAnnotation } from '@babel/types';
 import * as React from 'react';
 
 // state.d.ts
@@ -431,6 +430,13 @@ export function waitForAllSettled<RecoilValues extends Array<RecoilValue<any>> |
 export function waitForAllSettled<RecoilValues extends { [key: string]: RecoilValue<any> }>(
  param: RecoilValues,
 ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+ export namespace RecoilLoadable {
+  function of<T>(x: T | Promise<T>): Loadable<T>;
+  function error(x: any): ErrorLoadable<any>;
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -26,7 +26,7 @@
   useRecoilValueLoadable,
   useResetRecoilState, useSetRecoilState,
   waitForAll, waitForAllSettled, waitForAny, waitForNone,
-  Loadable,
+  Loadable, RecoilLoadable,
   useRecoilTransaction_UNSTABLE,
   useRecoilRefresher_UNSTABLE,
 } from 'recoil';
@@ -688,3 +688,7 @@ isRecoilValue(mySelector1);
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+RecoilLoadable.of('x'); // $ExpectType Loadable<string>
+RecoilLoadable.of(Promise.resolve('x')); // $ExpectType Loadable<string>
+RecoilLoadable.error('x'); // $ExpectType ErrorLoadable<any>


### PR DESCRIPTION
Summary:
Expose factory interface for creating `Loadable` objects.  Note that `Loadable` is not a class due to limitations with Flow not supporting disjoint unions with class properties.  Therefore, I don't think we can export `Loadable` as a type as well as an object containing static factories.  So, use `Load` instead... :(

Proposed interface examples:

```
const valueLoadable = Load.of('VALUE');
```

```
const pendingLoadable = Load.of(Promise.resolve('ASYNC VALUE'));
```

```
const errorLoadable = Load.error(new Error('ERROR'));
```

D31040527 adds `Load.all()`

Differential Revision: D31038573

