### PR TITLE
Load.all()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `getLoadable()`, `getPromise()`, and `getInfo_UNSTABLE()` to Atom Effects interface for reading other atoms.
 - Atoms freeze default, initialized, and async values in dev mode.  Selectors should not freeze upstream dependencies. (#1261, #1259)
 - Added `useRecoilRefresher_UNSTABLE()` hook which forces a selector to re-run it's `get()`, and is a no-op for an atom. (#972)
+- Expose `RecoilLoadable` interface for creating `Loadable` objects.
 
 ### Pending
 - Memory management

--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -42,6 +42,7 @@ export type {
   SelectorFamilyOptions,
 } from './recoil_values/Recoil_selectorFamily';
 
+const {RecoilLoadable} = require('./adt/Recoil_Loadable');
 const {DefaultValue} = require('./core/Recoil_Node');
 const {RecoilRoot} = require('./core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
@@ -85,27 +86,31 @@ module.exports = {
   // Types
   DefaultValue,
   isRecoilValue,
+  RecoilLoadable,
 
-  // Components
+  // Recoil Root
   RecoilRoot,
   useRecoilBridgeAcrossReactRoots_UNSTABLE: useRecoilBridgeAcrossReactRoots,
 
-  // RecoilValues
+  // Atoms/Selectors
   atom,
   selector,
 
-  // Factories
-  retentionZone,
-  snapshot_UNSTABLE: freshSnapshot,
-
-  // Convenience RecoilValues
+  // Convenience Atoms/Selectors
   atomFamily,
   selectorFamily,
   constSelector,
   errorSelector,
   readOnlySelector,
 
-  // Hooks that accept RecoilValues
+  // Concurrency Helpers for Atoms/Selectors
+  noWait,
+  waitForNone,
+  waitForAny,
+  waitForAll,
+  waitForAllSettled,
+
+  // Hooks for Atoms/Selectors
   useRecoilValue,
   useRecoilValueLoadable,
   useRecoilState,
@@ -113,24 +118,21 @@ module.exports = {
   useSetRecoilState,
   useResetRecoilState,
   useGetRecoilValueInfo_UNSTABLE: useGetRecoilValueInfo,
-  useRetain,
   useRecoilRefresher_UNSTABLE: useRecoilRefresher,
 
-  // Hooks for complex operations with RecoilValues
+  // Hooks for complex operations
   useRecoilCallback,
   useRecoilTransaction_UNSTABLE: useRecoilTransaction,
 
-  // Hooks for Snapshots
+  // Snapshots
   useGotoRecoilSnapshot,
   useRecoilSnapshot,
   useRecoilTransactionObserver_UNSTABLE: useRecoilTransactionObserver,
   useTransactionObservation_UNSTABLE: useTransactionObservation_DEPRECATED,
   useSetUnvalidatedAtomValues_UNSTABLE: useSetUnvalidatedAtomValues,
+  snapshot_UNSTABLE: freshSnapshot,
 
-  // Concurrency Helpers
-  noWait,
-  waitForNone,
-  waitForAny,
-  waitForAll,
-  waitForAllSettled,
+  // Memory Management
+  useRetain,
+  retentionZone,
 };

--- a/src/adt/Recoil_Loadable.js
+++ b/src/adt/Recoil_Loadable.js
@@ -15,8 +15,6 @@
  */
 'use strict';
 
-import type {NodeKey} from '../core/Recoil_Keys';
-
 const err = require('../util/Recoil_err');
 const isPromise = require('../util/Recoil_isPromise');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -292,6 +290,12 @@ function isLoadable(x: mixed): boolean %checks {
   return (x: any).__loadable == TYPE_CHECK_COOKIE; // flowlint-line unclear-type:off
 }
 
+const LoadableFactories = {
+  of: <T>(value: T | Promise<T>): Loadable<T> =>
+    isPromise(value) ? loadableWithPromise(value) : loadableWithValue(value),
+  error: <T>(error: mixed): ErrorLoadable<T> => loadableWithError(error),
+};
+
 module.exports = {
   loadableWithValue,
   loadableWithError,
@@ -301,4 +305,5 @@ module.exports = {
   isLoadable,
   Canceled,
   CANCELED,
+  RecoilLoadable: LoadableFactories,
 };

--- a/src/adt/__tests__/Recoil_Loadable-test.js
+++ b/src/adt/__tests__/Recoil_Loadable-test.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const {
+  RecoilLoadable,
   loadableWithError,
   loadableWithPromise,
   loadableWithValue,
@@ -160,4 +161,18 @@ describe('Loadable mapping', () => {
     expect(loadable.state).toBe('loading');
     await expect(loadable.toPromise()).resolves.toBe('MAPPED VALUE');
   });
+});
+
+test('Loadable Factory Interface', async () => {
+  const valueLoadable = RecoilLoadable.of('VALUE');
+  expect(valueLoadable.state).toBe('hasValue');
+  expect(valueLoadable.contents).toBe('VALUE');
+
+  const promiseLoadable = RecoilLoadable.of(Promise.resolve('ASYNC'));
+  expect(promiseLoadable.state).toBe('loading');
+  await expect(promiseLoadable.contents).resolves.toBe('ASYNC');
+
+  const errorLoadable = RecoilLoadable.error('ERROR');
+  expect(errorLoadable.state).toBe('hasError');
+  expect(errorLoadable.contents).toBe('ERROR');
 });

--- a/src/adt/__tests__/Recoil_Loadable-test.js
+++ b/src/adt/__tests__/Recoil_Loadable-test.js
@@ -176,3 +176,58 @@ test('Loadable Factory Interface', async () => {
   expect(errorLoadable.state).toBe('hasError');
   expect(errorLoadable.contents).toBe('ERROR');
 });
+
+test('Load All Array', async () => {
+  expect(
+    RecoilLoadable.all([RecoilLoadable.of('x'), RecoilLoadable.of(123)])
+      .contents,
+  ).toEqual(['x', 123]);
+  await expect(
+    RecoilLoadable.all([
+      RecoilLoadable.of(Promise.resolve('x')),
+      RecoilLoadable.of(123),
+    ]).contents,
+  ).resolves.toEqual(['x', 123]);
+  expect(
+    RecoilLoadable.all([
+      RecoilLoadable.of('x'),
+      RecoilLoadable.of(123),
+      RecoilLoadable.error('ERROR'),
+    ]).contents,
+  ).toEqual('ERROR');
+
+  expect(
+    RecoilLoadable.all([
+      RecoilLoadable.of('x'),
+      RecoilLoadable.all([RecoilLoadable.of(1), RecoilLoadable.of(2)]),
+    ]).contents,
+  ).toEqual(['x', [1, 2]]);
+});
+
+test('Load All Object', async () => {
+  expect(
+    RecoilLoadable.all({
+      str: RecoilLoadable.of('x'),
+      num: RecoilLoadable.of(123),
+    }).contents,
+  ).toEqual({
+    str: 'x',
+    num: 123,
+  });
+  await expect(
+    RecoilLoadable.all({
+      str: RecoilLoadable.of(Promise.resolve('x')),
+      num: RecoilLoadable.of(123),
+    }).contents,
+  ).resolves.toEqual({
+    str: 'x',
+    num: 123,
+  });
+  expect(
+    RecoilLoadable.all({
+      str: RecoilLoadable.of('x'),
+      num: RecoilLoadable.of(123),
+      err: RecoilLoadable.error('ERROR'),
+    }).contents,
+  ).toEqual('ERROR');
+});

--- a/src/contrib/recoil-sync/__test_utils__/recoil-sync_mockValidation.js
+++ b/src/contrib/recoil-sync/__test_utils__/recoil-sync_mockValidation.js
@@ -8,20 +8,19 @@
 'use strict';
 
 // TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
-// TODO PUBLIC LOADABLE INTERFACE
 
 import type {Loadable} from '../../../adt/Recoil_Loadable';
 
-const {loadableWithValue} = require('../../../adt/Recoil_Loadable');
+const {RecoilLoadable} = require('../../../adt/Recoil_Loadable');
 
 ////////////////////////////
 // Mock validation library
 ////////////////////////////
-const validateAny = loadableWithValue;
+const validateAny = RecoilLoadable.of;
 const validateString = (x: mixed): ?Loadable<string> =>
-  typeof x === 'string' ? loadableWithValue<string>(x) : null;
+  typeof x === 'string' ? RecoilLoadable.of(x) : null;
 const validateNumber = (x: mixed): ?Loadable<number> =>
-  typeof x === 'number' ? loadableWithValue<number>(x) : null;
+  typeof x === 'number' ? RecoilLoadable.of(x) : null;
 function upgrade<From, To>(
   validate: mixed => ?Loadable<From>,
   upgrader: From => To,

--- a/src/contrib/recoil-sync/recoil-url-sync.js
+++ b/src/contrib/recoil-sync/recoil-url-sync.js
@@ -11,13 +11,12 @@
 'use strict';
 
 // TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
-// TODO PUBLIC LOADABLE INTERFACE
 
 import type {Loadable} from '../../adt/Recoil_Loadable';
 import type {AtomEffect} from '../../recoil_values/Recoil_atom';
 import type {ItemKey, SyncEffectOptions, SyncKey} from './recoil-sync';
 
-const {loadableWithValue} = require('../../adt/Recoil_Loadable');
+const {RecoilLoadable} = require('../../adt/Recoil_Loadable');
 const err = require('../../util/Recoil_err');
 const {syncEffect, useRecoilSync} = require('./recoil-sync');
 const React = require('react');
@@ -113,12 +112,15 @@ function useRecoilURLSync({
   // Update cached URL parsing if properties of location prop change, but not
   // based on just the object reference itself.
   // eslint-disable-next-line fb-www/react-hooks-deps
-  useEffect(() => updateCachedState(location), [
-    location.part,
-    // $FlowFixMe[prop-missing] Complications with disjoint unions...
-    location.queryParam,
-    updateCachedState,
-  ]);
+  useEffect(
+    () => updateCachedState(location),
+    [
+      location.part,
+      // $FlowFixMe[prop-missing] Complications with disjoint unions...
+      location.queryParam,
+      updateCachedState,
+    ],
+  );
 
   function write({diff, allItems}) {
     // Only serialize atoms in a non-default value state.
@@ -175,7 +177,7 @@ function useRecoilURLSync({
 
   function read(itemKey): ?Loadable<mixed> {
     return cachedState.current?.has(itemKey)
-      ? loadableWithValue(cachedState.current?.get(itemKey))
+      ? RecoilLoadable.of(cachedState.current?.get(itemKey))
       : null;
   }
 
@@ -186,7 +188,7 @@ function useRecoilURLSync({
         const mappedState = new Map(
           Array.from(cachedState.current.entries()).map(([k, v]) => [
             k,
-            loadableWithValue(v),
+            RecoilLoadable.of(v),
           ]),
         );
         updateAllKnownItems(mappedState);

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -431,12 +431,19 @@ export function waitForAllSettled<RecoilValues extends { [key: string]: RecoilVa
  param: RecoilValues,
 ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+ export type UnwrapLoadable<T> = T extends Loadable<infer R> ? R : never;
+ export type UnwrapLoadables<T extends Array<Loadable<any>> | { [key: string]: Loadable<any> }> = {
+   [P in keyof T]: UnwrapLoadable<T[P]>;
+ };
+
+ /* eslint-disable @typescript-eslint/no-unused-vars */
  export namespace RecoilLoadable {
-  function of<T>(x: T | Promise<T>): Loadable<T>;
-  function error(x: any): ErrorLoadable<any>;
-}
-/* eslint-enable @typescript-eslint/no-unused-vars */
+   function of<T>(x: T | Promise<T>): Loadable<T>;
+   function error(x: any): ErrorLoadable<any>;
+   function all<Inputs extends Array<Loadable<any>> | [Loadable<any>]>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
+   function all<Inputs extends {[key: string]: Loadable<any>}>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
+ }
+ /* eslint-enable @typescript-eslint/no-unused-vars */
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -13,9 +13,8 @@
  * This file is a manual translation of the flow types, which are the source of truth, so we should not introduce new terminology or behavior in this file.
  */
 
- export { };
+export { };
 
- import { voidTypeAnnotation } from '@babel/types';
 import * as React from 'react';
 
 // state.d.ts
@@ -431,6 +430,13 @@ export function waitForAllSettled<RecoilValues extends Array<RecoilValue<any>> |
 export function waitForAllSettled<RecoilValues extends { [key: string]: RecoilValue<any> }>(
  param: RecoilValues,
 ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+ export namespace RecoilLoadable {
+  function of<T>(x: T | Promise<T>): Loadable<T>;
+  function error(x: any): ErrorLoadable<any>;
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -26,7 +26,7 @@
   useRecoilValueLoadable,
   useResetRecoilState, useSetRecoilState,
   waitForAll, waitForAllSettled, waitForAny, waitForNone,
-  Loadable,
+  Loadable, RecoilLoadable,
   useRecoilTransaction_UNSTABLE,
   useRecoilRefresher_UNSTABLE,
 } from 'recoil';
@@ -688,3 +688,7 @@ isRecoilValue(mySelector1);
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+RecoilLoadable.of('x'); // $ExpectType Loadable<string>
+RecoilLoadable.of(Promise.resolve('x')); // $ExpectType Loadable<string>
+RecoilLoadable.error('x'); // $ExpectType ErrorLoadable<any>

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -689,6 +689,31 @@ isRecoilValue(mySelector1);
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-RecoilLoadable.of('x'); // $ExpectType Loadable<string>
-RecoilLoadable.of(Promise.resolve('x')); // $ExpectType Loadable<string>
-RecoilLoadable.error('x'); // $ExpectType ErrorLoadable<any>
+/**
+ * Loadable Factory Tests
+ */
+ {
+  RecoilLoadable.of('x'); // $ExpectType Loadable<string>
+  RecoilLoadable.of(Promise.resolve('x')); // $ExpectType Loadable<string>
+  RecoilLoadable.error('x'); // $ExpectType ErrorLoadable<any>
+
+  const allLoadableArray = RecoilLoadable.all([
+    RecoilLoadable.of('str'),
+    RecoilLoadable.of(123),
+  ]);
+  allLoadableArray.map(x => {
+    x[0]; // $ExpectType string
+    x[1]; // $ExpectType number
+    x[2]; // $ExpectError
+  });
+
+  const allLoadableObj = RecoilLoadable.all({
+    str: RecoilLoadable.of('str'),
+    num: RecoilLoadable.of(123),
+  });
+  allLoadableObj.map(x => {
+    x.str; // $ExpectType string
+    x.num; // $ExpectType number
+    x.void; // $ExpectError
+  });
+}


### PR DESCRIPTION
Summary:
Add a `Load.all()` factory for Loadables analogous to `Promise.all()`:

```
Load.all([ Load.of('abc'), Load.of(123) ]).contents
['abc', 123]
```

Also provide an object version in addition to an array version:

```
Load.all({ str: Load.of('abc'), num: Load.of(123) }).contents
{str: abc, num: 123}
```

This also works nested:

```
Load.all([
  Load.all([Load.of('a'), Load.of('b')]),
  Load.all([Load.of(1), Load.of(2)]),
]).contents

[ ['a','b'], [1,2] ]
```

And it support async inputs:
```
Load.all([ Load.of(Promise.resolve('async')), Load.of('sync') ]).map(values => {
  values is ['async', 'sync']
});
```

Note TypeScript should have the proper tuple and object mapping, but not sure how to enable that for Flow since the factory is nested in `Load` object...

Differential Revision: D31040527

