### PR TITLE
remove batcher from internal interface

### DIFF
--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -42,7 +42,6 @@ export type {
   SelectorFamilyOptions,
 } from './recoil_values/Recoil_selectorFamily';
 
-const {batchUpdates, setBatcher} = require('./core/Recoil_Batching');
 const {DefaultValue} = require('./core/Recoil_Node');
 const {RecoilRoot} = require('./core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
@@ -133,10 +132,6 @@ module.exports = {
 
   // Other functions
   isRecoilValue,
-
-  // Batching
-  batchUpdates,
-  setBatcher,
 
   // Snapshot Utils
   snapshot_UNSTABLE: freshSnapshot,


### PR DESCRIPTION
Summary: Remove `batchUpdates()` and `setBatcher()` from the internal Recoil interface.  It isn't used and wasn't intended to be part of the public API.

Differential Revision: D31459050

