### PR TITLE
Better error message for cache failures when setting selectors

### DIFF
--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -1046,7 +1046,13 @@ function selector<T>(
     loadable: Loadable<T>,
   ) {
     state.atomValues.set(key, loadable);
-    cache.set(cacheRoute, loadable);
+    try {
+      cache.set(cacheRoute, loadable);
+    } catch (err) {
+      throw new Error(
+        `Problem with setting cache for selector "${key}": ${err.message}`,
+      );
+    }
   }
 
   function detectCircularDependencies(fn) {


### PR DESCRIPTION
Summary: Better error message for cache failure when setting, not just getting selectors

Reviewed By: csantos42

Differential Revision: D31185423

