### PR TITLE
Normalize err() Error factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^3.6.11",
     "eslint": "^7.2.0",
-    "eslint-plugin-fb-www": "^1.0.4",
+    "eslint-plugin-fb-www": "^1.0.6",
     "eslint-plugin-flowtype": "^5.1.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",

--- a/src/adt/Recoil_Loadable.js
+++ b/src/adt/Recoil_Loadable.js
@@ -17,6 +17,7 @@
 
 import type {NodeKey} from '../core/Recoil_Keys';
 
+const err = require('../util/Recoil_err');
 const isPromise = require('../util/Recoil_isPromise');
 const nullthrows = require('../util/Recoil_nullthrows');
 
@@ -98,13 +99,10 @@ const loadableAccessors = {
   },
 
   valueOrThrow() {
-    const error = new Error(
+    throw err(
       // $FlowFixMe[object-this-reference]
       `Loadable expected value, but in "${this.state}" state`,
     );
-    // V8 keeps closures alive until stack is accessed, this prevents a memory leak
-    error.stack;
-    throw error;
   },
 
   errorMaybe() {
@@ -112,13 +110,10 @@ const loadableAccessors = {
   },
 
   errorOrThrow() {
-    const error = new Error(
+    throw err(
       // $FlowFixMe[object-this-reference]
       `Loadable expected error, but in "${this.state}" state`,
     );
-    // V8 keeps closures alive until stack is accessed, this prevents a memory leak
-    error.stack;
-    throw error;
   },
 
   promiseMaybe() {
@@ -126,13 +121,10 @@ const loadableAccessors = {
   },
 
   promiseOrThrow() {
-    const error = new Error(
+    throw err(
       // $FlowFixMe[object-this-reference]
       `Loadable expected promise, but in "${this.state}" state`,
     );
-    // V8 keeps closures alive until stack is accessed, this prevents a memory leak
-    error.stack;
-    throw error;
   },
 
   is(other: Loadable<mixed>): boolean {
@@ -196,10 +188,7 @@ const loadableAccessors = {
           }),
       );
     }
-    const error = new Error('Invalid Loadable state');
-    // V8 keeps closures alive until stack is accessed, this prevents a memory leak
-    error.stack;
-    throw error;
+    throw err('Invalid Loadable state');
   },
 };
 

--- a/src/caches/Recoil_cacheFromPolicy.js
+++ b/src/caches/Recoil_cacheFromPolicy.js
@@ -17,6 +17,7 @@ import type {
   EvictionPolicy,
 } from './Recoil_CachePolicy';
 
+const err = require('../util/Recoil_err');
 const nullthrows = require('../util/Recoil_nullthrows');
 const stableStringify = require('../util/Recoil_stableStringify');
 const {LRUCache} = require('./Recoil_LRUCache');
@@ -47,7 +48,7 @@ function getValueMapper(equality: EqualityPolicy): mixed => mixed {
       return val => stableStringify(val);
   }
 
-  throw new Error(`Unrecognized equality policy ${equality}`);
+  throw err(`Unrecognized equality policy ${equality}`);
 }
 
 function getCache<K, V>(
@@ -67,7 +68,7 @@ function getCache<K, V>(
       return new LRUCache<K, V>({mapKey, maxSize: 1});
   }
 
-  throw new Error(`Unrecognized eviction policy ${eviction}`);
+  throw err(`Unrecognized eviction policy ${eviction}`);
 }
 
 module.exports = cacheFromPolicy;

--- a/src/caches/Recoil_treeCacheFromPolicy.js
+++ b/src/caches/Recoil_treeCacheFromPolicy.js
@@ -17,6 +17,7 @@ import type {
 } from './Recoil_CachePolicy';
 import type {TreeCacheImplementation} from './Recoil_TreeCacheImplementationType';
 
+const err = require('../util/Recoil_err');
 const nullthrows = require('../util/Recoil_nullthrows');
 const stableStringify = require('../util/Recoil_stableStringify');
 const {TreeCache} = require('./Recoil_TreeCache');
@@ -47,7 +48,7 @@ function getValueMapper(equality: EqualityPolicy): mixed => mixed {
       return val => stableStringify(val);
   }
 
-  throw new Error(`Unrecognized equality policy ${equality}`);
+  throw err(`Unrecognized equality policy ${equality}`);
 }
 
 function getTreeCache<T>(
@@ -65,7 +66,7 @@ function getTreeCache<T>(
       return treeCacheLRU<T>(1, mapNodeValue);
   }
 
-  throw new Error(`Unrecognized eviction policy ${eviction}`);
+  throw err(`Unrecognized eviction policy ${eviction}`);
 }
 
 module.exports = treeCacheFromPolicy;

--- a/src/caches/__tests__/Recoil_LRUCache-test.js
+++ b/src/caches/__tests__/Recoil_LRUCache-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let LRUCache;
 

--- a/src/caches/__tests__/Recoil_MapCache-test.js
+++ b/src/caches/__tests__/Recoil_MapCache-test.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let MapCache;
 

--- a/src/caches/__tests__/Recoil_TreeCache-test.js
+++ b/src/caches/__tests__/Recoil_TreeCache-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let TreeCache, loadableWithValue, nullthrows;
 

--- a/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let cacheFromPolicy;
 

--- a/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let treeCacheFromPolicy;
 

--- a/src/caches/__tests__/Recoil_treeCacheLRU-test.js
+++ b/src/caches/__tests__/Recoil_treeCacheLRU-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let treeCacheLRU, loadableWithValue;
 

--- a/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
+++ b/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
@@ -13,7 +13,7 @@ import type {LocationOption} from '../recoil-url-sync';
 
 const {
   flushPromisesAndTimers,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
 const {useRecoilURLSync} = require('../recoil-url-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -22,6 +22,12 @@ const {
   validateString,
 } = require('../__test_utils__/recoil-sync_mockValidation');
 const {
+  ReadsAtom,
+  componentThatReadsAndWritesAtom,
+  flushPromisesAndTimers,
+  renderElements,
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const {
   loadableWithError,
   loadableWithPromise,
   loadableWithValue,
@@ -30,12 +36,6 @@ const {useRecoilValue} = require('../../../hooks/Recoil_Hooks');
 const atom = require('../../../recoil_values/Recoil_atom');
 const atomFamily = require('../../../recoil_values/Recoil_atomFamily');
 const selectorFamily = require('../../../recoil_values/Recoil_selectorFamily');
-const {
-  ReadsAtom,
-  componentThatReadsAndWritesAtom,
-  flushPromisesAndTimers,
-  renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
 const {syncEffect, useRecoilSync} = require('../recoil-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
@@ -18,11 +18,11 @@ const {
   expectURL,
   gotoURL,
 } = require('../__test_utils__/recoil-url-sync_mockSerialization');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   ReadsAtom,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {syncEffect} = require('../recoil-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-push-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-push-test.js
@@ -17,11 +17,11 @@ const {
   expectURL,
   goBack,
 } = require('../__test_utils__/recoil-url-sync_mockSerialization');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   componentThatReadsAndWritesAtom,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {urlSyncEffect} = require('../recoil-url-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
@@ -22,13 +22,13 @@ const {
   encodeURL,
   expectURL,
 } = require('../__test_utils__/recoil-url-sync_mockSerialization');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   ReadsAtom,
   componentThatReadsAndWritesAtom,
   flushPromisesAndTimers,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {syncEffect} = require('../recoil-sync');
 const {urlSyncEffect} = require('../recoil-url-sync');
 const React = require('react');

--- a/src/contrib/recoil-sync/recoil-sync.js
+++ b/src/contrib/recoil-sync/recoil-sync.js
@@ -22,6 +22,7 @@ const {
   useRecoilSnapshot,
   useRecoilTransaction,
 } = require('../../hooks/Recoil_Hooks');
+const err = require('../../util/Recoil_err');
 const {useCallback, useEffect} = require('react');
 
 type NodeKey = string;
@@ -204,7 +205,7 @@ function useRecoilSync({
                 break;
               case 'loading':
                 // TODO Async atom support
-                throw new Error(
+                throw err(
                   'Recoil does not yet support setting atoms to an asynchronous state',
                 );
             }
@@ -295,7 +296,10 @@ function syncEffect<T>({
         const loadable = readFromStorage(itemKey);
         if (loadable != null) {
           if (!isLoadable(loadable)) {
-            throw new Error('Sync read must provide a Loadable');
+            throw err('Sync read must provide a Loadable');
+          }
+          if (loadable.state === 'hasError') {
+            throw loadable.contents;
           }
 
           const validated = validateLoadable<T>(loadable, {restore});

--- a/src/contrib/recoil-sync/recoil-url-sync.js
+++ b/src/contrib/recoil-sync/recoil-url-sync.js
@@ -18,6 +18,7 @@ import type {AtomEffect} from '../../recoil_values/Recoil_atom';
 import type {ItemKey, SyncEffectOptions, SyncKey} from './recoil-sync';
 
 const {loadableWithValue} = require('../../adt/Recoil_Loadable');
+const err = require('../../util/Recoil_err');
 const {syncEffect, useRecoilSync} = require('./recoil-sync');
 const React = require('react');
 const {useCallback, useEffect, useRef} = require('react');
@@ -47,7 +48,7 @@ function parseURL(loc: LocationOption): ?string {
       return param != null ? decodeURIComponent(param) : null;
     }
   }
-  throw new Error(`Unknown URL location part: "${loc.part}"`);
+  throw err(`Unknown URL location part: "${loc.part}"`);
 }
 
 function updateURL(loc: LocationOption, serialization): string {
@@ -66,7 +67,7 @@ function updateURL(loc: LocationOption, serialization): string {
       return `?${searchParams.toString()}${location.hash}`;
     }
   }
-  throw new Error(`Unknown URL location part: "${loc.part}"`);
+  throw err(`Unknown URL location part: "${loc.part}"`);
 }
 
 ///////////////////////
@@ -223,7 +224,7 @@ function urlSyncEffect<T>({
     }
     const atomRegistry = registries.get(options.syncKey);
     if (atomRegistry == null) {
-      throw new Error('Error with atom registration');
+      throw err('Error with atom registration');
     }
     atomRegistry.set(effectArgs.node.key, {
       history,

--- a/src/contrib/uri_persistence/__tests__/Recoil_Link-test.js
+++ b/src/contrib/uri_persistence/__tests__/Recoil_Link-test.js
@@ -12,13 +12,13 @@
 
 const {Simulate, act} = require('ReactTestUtils');
 
-const {freshSnapshot} = require('../../../core/Recoil_Snapshot');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   componentThatReadsAndWritesAtom,
   flushPromisesAndTimers,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const {freshSnapshot} = require('../../../core/Recoil_Snapshot');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {
   LinkToRecoilSnapshot,
   LinkToRecoilStateChange,

--- a/src/core/Recoil_AtomicUpdates.js
+++ b/src/core/Recoil_AtomicUpdates.js
@@ -22,6 +22,7 @@ const {
   invalidateDownstreams,
   writeLoadableToTreeState,
 } = require('../core/Recoil_RecoilValueInterface');
+const err = require('../util/Recoil_err');
 
 export interface TransactionInterface {
   get: <T>(RecoilValue<T>) => T;
@@ -52,7 +53,7 @@ class TransactionInterfaceImpl {
       return this._changes.get(recoilValue.key);
     }
     if (!isAtom(recoilValue)) {
-      throw new Error('Reading selectors within atomicUpdate is not supported');
+      throw err('Reading selectors within atomicUpdate is not supported');
     }
     const loadable = getRecoilValueAsLoadable(
       this._store,
@@ -64,7 +65,7 @@ class TransactionInterfaceImpl {
     } else if (loadable.state === 'hasError') {
       throw loadable.contents;
     } else {
-      throw new Error(
+      throw err(
         `Expected Recoil atom ${recoilValue.key} to have a value, but it is in a loading state.`,
       );
     }
@@ -77,7 +78,7 @@ class TransactionInterfaceImpl {
     valueOrUpdater: ValueOrUpdater<T>,
   ): void => {
     if (!isAtom(recoilState)) {
-      throw new Error('Setting selectors within atomicUpdate is not supported');
+      throw err('Setting selectors within atomicUpdate is not supported');
     }
     if (typeof valueOrUpdater === 'function') {
       const current = this.get(recoilState);

--- a/src/core/Recoil_RecoilRoot.react.js
+++ b/src/core/Recoil_RecoilRoot.react.js
@@ -23,6 +23,7 @@ const {
   getNextTreeStateVersion,
   makeEmptyStoreState,
 } = require('../core/Recoil_State');
+const err = require('../util/Recoil_err');
 const expectationViolation = require('../util/Recoil_expectationViolation');
 const gkx = require('../util/Recoil_gkx');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -60,9 +61,7 @@ type InternalProps = {
 };
 
 function notInAContext() {
-  throw new Error(
-    'This component must be used inside a <RecoilRoot> component.',
-  );
+  throw err('This component must be used inside a <RecoilRoot> component.');
 }
 
 const defaultStore: Store = Object.freeze({
@@ -77,7 +76,7 @@ let stateReplacerIsBeingExecuted: boolean = false;
 
 function startNextTreeIfNeeded(store: Store): void {
   if (stateReplacerIsBeingExecuted) {
-    throw new Error(
+    throw err(
       'An atom update was triggered within the execution of a state updater function. State updater functions provided to Recoil must be pure functions.',
     );
   }

--- a/src/core/Recoil_Snapshot.js
+++ b/src/core/Recoil_Snapshot.js
@@ -23,6 +23,7 @@ import type {StateID, Store, StoreState, TreeState} from './Recoil_State';
 
 const concatIterables = require('../util/Recoil_concatIterables');
 const {isSSR} = require('../util/Recoil_Environment');
+const err = require('../util/Recoil_err');
 const filterIterable = require('../util/Recoil_filterIterable');
 const gkx = require('../util/Recoil_gkx');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -90,7 +91,7 @@ class Snapshot {
       },
       subscribeToTransactions: () => ({release: () => {}}),
       addTransactionMetadata: () => {
-        throw new Error('Cannot subscribe to Snapshots');
+        throw err('Cannot subscribe to Snapshots');
       },
     };
     // Initialize any nodes that are live in the parent store (primarily so that this
@@ -151,7 +152,7 @@ class Snapshot {
         recoverableViolation(retainWarning, 'recoil');
       }
       // What we will ship later:
-      // throw new Error(retainWarning);
+      // throw err(retainWarning);
     }
   }
 

--- a/src/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/src/core/__tests__/Recoil_RecoilRoot-test.js
@@ -9,7 +9,7 @@
 
 import type {Store} from '../Recoil_State';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -39,7 +39,7 @@ const testRecoil = getRecoilTestFn(() => {
     ReadsAtom,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({RecoilRoot} = require('../Recoil_RecoilRoot.react'));
   ({useStoreRef} = require('../Recoil_RecoilRoot.react'));
 });

--- a/src/core/__tests__/Recoil_RecoilValueInterface-test.js
+++ b/src/core/__tests__/Recoil_RecoilValueInterface-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let act,
   atom,
@@ -27,7 +27,7 @@ let act,
   store;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   ({act} = require('ReactTestUtils'));
   atom = require('../../recoil_values/Recoil_atom');

--- a/src/core/__tests__/Recoil_Retention-test.js
+++ b/src/core/__tests__/Recoil_Retention-test.js
@@ -13,7 +13,7 @@
 
 import type {RecoilState} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -46,7 +46,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   gkx = require('../../util/Recoil_gkx');
 
   const initialGKValue = gkx('recoil_memory_managament_2020');

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -42,7 +42,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({Snapshot, freshSnapshot} = require('../Recoil_Snapshot'));
 });
 

--- a/src/core/__tests__/Recoil_batcher-test.js
+++ b/src/core/__tests__/Recoil_batcher-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let unstable_batchedUpdates, batchUpdates, getBatcher, setBatcher;
 

--- a/src/core/__tests__/Recoil_core-test.js
+++ b/src/core/__tests__/Recoil_core-test.js
@@ -10,12 +10,12 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let a, atom, store, nullthrows, getNodeLoadable, setNodeValue;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   atom = require('../../recoil_values/Recoil_atom');
   nullthrows = require('../../util/Recoil_nullthrows');

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -39,6 +39,7 @@ const {Snapshot, cloneSnapshot} = require('../core/Recoil_Snapshot');
 const {setByAddingToSet} = require('../util/Recoil_CopyOnWrite');
 const differenceSets = require('../util/Recoil_differenceSets');
 const {isSSR} = require('../util/Recoil_Environment');
+const err = require('../util/Recoil_err');
 const expectationViolation = require('../util/Recoil_expectationViolation');
 const filterMap = require('../util/Recoil_filterMap');
 const filterSet = require('../util/Recoil_filterSet');
@@ -82,19 +83,13 @@ function handleLoadable<T>(
   } else if (loadable.state === 'hasError') {
     throw loadable.contents;
   } else {
-    const err = new Error(
-      `Invalid value of loadable atom "${recoilValue.key}"`,
-    );
-
-    err.stack; // In V8, Error objects keep closures alive until the error.stack property is accessed
-
-    throw err;
+    throw err(`Invalid value of loadable atom "${recoilValue.key}"`);
   }
 }
 
 function validateRecoilValue(recoilValue, hookName) {
   if (!isRecoilValue(recoilValue)) {
-    throw new Error(
+    throw err(
       `Invalid argument to ${hookName}: expected an atom or selector but got ${String(
         recoilValue,
       )}`,
@@ -836,7 +831,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
           'types of the callback you want to create.  Please see the docs ' +
           'at recoiljs.org for details.';
         if (typeof fn !== 'function') {
-          throw new Error(errMsg);
+          throw err(errMsg);
         }
         // flowlint-next-line unclear-type:off
         const cb = (fn: any)({
@@ -847,7 +842,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
           transact_UNSTABLE: atomicUpdate,
         });
         if (typeof cb !== 'function') {
-          throw new Error(errMsg);
+          throw err(errMsg);
         }
         ret = cb(...args);
       });

--- a/src/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/src/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -18,7 +18,7 @@ import type {
 } from '../../core/Recoil_RecoilValue';
 import type {PersistenceSettings} from '../../recoil_values/Recoil_atom';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 let {mutableSourceExists} = require('../../util/Recoil_mutableSource');
 
 let React,
@@ -64,7 +64,7 @@ const testRecoil = getRecoilTestFn(() => {
     flushPromisesAndTimers,
     renderElements,
     renderElementsWithSuspenseCount,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({mutableSourceExists} = require('../../util/Recoil_mutableSource'));
   ({
     recoilComponentGetRecoilValueCount_FOR_TESTING,

--- a/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -31,7 +31,7 @@ const testRecoil = getRecoilTestFn(() => {
     ReadsAtom,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   useGetRecoilValueInfo = require('../Recoil_useGetRecoilValueInfo');
 });
 

--- a/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -48,7 +48,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
 });
 
 testRecoil('Goto mapped snapshot', async () => {

--- a/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useEffect,
@@ -32,7 +32,7 @@ const testRecoil = getRecoilTestFn(() => {
   atom = require('../../recoil_values/Recoil_atom');
   ({
     componentThatReadsAndWritesAtom,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   useRecoilBridgeAcrossReactRoots = require('../Recoil_useRecoilBridgeAcrossReactRoots');
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useRef,
@@ -46,7 +46,7 @@ const testRecoil = getRecoilTestFn(() => {
     ReadsAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   invariant = require('../../util/Recoil_invariant');
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilInterface-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilInterface-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useRef,
@@ -27,7 +27,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({act} = require('ReactTestUtils'));
 
   atom = require('../../recoil_values/Recoil_atom');
-  ({renderElements} = require('../../testing/Recoil_TestingUtils'));
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useRecoilInterface} = require('../Recoil_Hooks'));
 
   counterAtom = atom({

--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useEffect,
@@ -42,7 +42,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useGotoRecoilSnapshot, useRecoilSnapshot} = require('../Recoil_Hooks'));
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilStateReset-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilStateReset-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -34,7 +34,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
 });
 
 testRecoil('useRecoilValueReset - value default', () => {

--- a/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -37,7 +37,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useRecoilTransactionObserver} = require('../Recoil_Hooks'));
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilValueLoadable-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilValueLoadable-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -32,7 +32,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     renderElements,
     flushPromisesAndTimers,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useRecoilValueLoadable} = require('../Recoil_Hooks'));
 });
 

--- a/src/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/src/hooks/__tests__/Recoil_useTransaction-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React, atom, useRecoilValue, useRecoilTransaction, renderElements;
 
@@ -21,7 +21,7 @@ const testRecoil = getRecoilTestFn(() => {
     useRecoilTransaction_UNSTABLE: useRecoilTransaction,
     useRecoilValue,
   } = require('../../Recoil_index'));
-  ({renderElements} = require('../../testing/Recoil_TestingUtils'));
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
 });
 
 testRecoil(

--- a/src/hooks/__tests__/Recoil_useTransition-test.js
+++ b/src/hooks/__tests__/Recoil_useTransition-test.js
@@ -14,7 +14,7 @@
 const {
   IS_INTERNAL,
   getRecoilTestFn,
-} = require('../../testing/Recoil_TestingUtils');
+} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -34,7 +34,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     renderElementsInConcurrentRoot,
     flushPromisesAndTimers,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
 
   const initialGKValue = gkx('recoil_early_rendering_2021');
   gkx.setPass('recoil_early_rendering_2021');

--- a/src/recoil_values/Recoil_atom.js
+++ b/src/recoil_values/Recoil_atom.js
@@ -93,6 +93,7 @@ const {
 } = require('../core/Recoil_RecoilValueInterface');
 const {retainedByOptionWithDefault} = require('../core/Recoil_Retention');
 const deepFreezeValue = require('../util/Recoil_deepFreezeValue');
+const err = require('../util/Recoil_err');
 const expectationViolation = require('../util/Recoil_expectationViolation');
 const isPromise = require('../util/Recoil_isPromise');
 const nullthrows = require('../util/Recoil_nullthrows');
@@ -323,9 +324,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
           }
         } else {
           if (isPromise(valueOrUpdater)) {
-            throw new Error(
-              'Setting atoms to async values is not implemented.',
-            );
+            throw err('Setting atoms to async values is not implemented.');
           }
 
           if (typeof valueOrUpdater !== 'function') {

--- a/src/recoil_values/Recoil_errorSelector.js
+++ b/src/recoil_values/Recoil_errorSelector.js
@@ -12,14 +12,16 @@
 
 import type {RecoilValueReadOnly} from '../core/Recoil_RecoilValue';
 
+const err = require('../util/Recoil_err');
 const selectorFamily = require('./Recoil_selectorFamily');
 
 // flowlint-next-line unclear-type:off
 const throwingSelector = selectorFamily<any, any>({
   key: '__error',
   get: message => () => {
-    throw new Error(message);
+    throw err(message);
   },
+  // TODO Why?
   cachePolicyForParams_UNSTABLE: {
     equality: 'reference',
   },

--- a/src/recoil_values/__tests__/Recoil_WaitFor-test.js
+++ b/src/recoil_values/__tests__/Recoil_WaitFor-test.js
@@ -16,7 +16,7 @@ import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 const {
   flushPromisesAndTimers,
   getRecoilTestFn,
-} = require('../../testing/Recoil_TestingUtils');
+} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let getRecoilValueAsLoadable,
   noWait,
@@ -29,7 +29,7 @@ let getRecoilValueAsLoadable,
   invariant;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   invariant = require('../../util/Recoil_invariant');
   ({

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -9,7 +9,7 @@
 
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -36,7 +36,7 @@ let React,
   store;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({useState, Profiler} = require('react'));
@@ -61,7 +61,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   atom = require('../Recoil_atom');
   selector = require('../Recoil_selector');
   immutable = require('immutable');

--- a/src/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -12,7 +12,7 @@
 
 import type {Store} from '../../core/Recoil_State';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let store: Store,
   React,
@@ -39,7 +39,7 @@ let store: Store,
   pAtom;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({Profiler, useState} = require('react'));
@@ -62,7 +62,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({mutableSourceExists} = require('../../util/Recoil_mutableSource'));
   stableStringify = require('../../util/Recoil_stableStringify');
   atom = require('../Recoil_atom');

--- a/src/recoil_values/__tests__/Recoil_atomWithFallback-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomWithFallback-test.js
@@ -10,10 +10,10 @@
  */
 'use strict';
 
-import type {RecoilValue} from 'Recoil_RecoilValue';
-import type {Store} from 'Recoil_State';
+import type {RecoilValue} from '../../core/Recoil_RecoilValue';
+import type {Store} from '../../core/Recoil_State';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -29,12 +29,12 @@ let React,
   constSelector,
   store: Store;
 
-let fallback: RecoilValue<number>, hasFallback: RecoilValue<number>;
+let fallbackAtom: RecoilValue<number>, hasFallbackAtom: RecoilValue<number>;
 
 let id = 0;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({useState} = require('react'));
@@ -52,17 +52,17 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   atom = require('../Recoil_atom');
   constSelector = require('../Recoil_constSelector');
 
   store = makeStore();
-  fallback = atom<number>({key: `fallback${id}`, default: 1});
-  hasFallback = atom<number>({
+  fallbackAtom = atom<number>({key: `fallback${id}`, default: 1});
+  hasFallbackAtom = atom<number>({
     key: `hasFallback${id++}`,
-    default: fallback,
+    default: fallbackAtom,
   });
-  subscribeToRecoilValue(store, hasFallback, () => undefined);
+  subscribeToRecoilValue(store, hasFallbackAtom, () => undefined);
 });
 
 function get(recoilValue) {
@@ -74,11 +74,11 @@ function set(recoilValue, value) {
 }
 
 testRecoil('atomWithFallback', () => {
-  expect(get(hasFallback)).toBe(1);
-  set(fallback, 2);
-  expect(get(hasFallback)).toBe(2);
-  set(hasFallback, 3);
-  expect(get(hasFallback)).toBe(3);
+  expect(get(hasFallbackAtom)).toBe(1);
+  set(fallbackAtom, 2);
+  expect(get(hasFallbackAtom)).toBe(2);
+  set(hasFallbackAtom, 3);
+  expect(get(hasFallbackAtom)).toBe(3);
 });
 
 describe('ReturnDefaultOrFallback', () => {
@@ -178,13 +178,13 @@ describe('ReturnDefaultOrFallback', () => {
 });
 
 testRecoil('Atom with atom fallback can store null and undefined', () => {
-  const fallbackAtom = atom<?string>({
+  const myFallbackAtom = atom<?string>({
     key: 'fallback for null undefined',
     default: 'FALLBACK',
   });
   const myAtom = atom<?string>({
     key: 'fallback atom with undefined',
-    default: fallbackAtom,
+    default: myFallbackAtom,
   });
   expect(get(myAtom)).toBe('FALLBACK');
   act(() => set(myAtom, 'VALUE'));
@@ -216,13 +216,13 @@ testRecoil('Atom with selector fallback can store null and undefined', () => {
 
 testRecoil('Effects', () => {
   let inited = false;
-  const fallbackAtom = atom({
+  const myFallbackAtom = atom({
     key: 'atom with fallback effects init fallback',
     default: 'FALLBACK',
   });
   const myAtom = atom<string>({
     key: 'atom with fallback effects init',
-    default: fallbackAtom,
+    default: myFallbackAtom,
     effects_UNSTABLE: [
       ({setSelf}) => {
         inited = true;

--- a/src/recoil_values/__tests__/Recoil_constSelector-test.js
+++ b/src/recoil_values/__tests__/Recoil_constSelector-test.js
@@ -12,12 +12,12 @@
 
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let getRecoilValueAsLoadable, store, constSelector;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   ({
     getRecoilValueAsLoadable,

--- a/src/recoil_values/__tests__/Recoil_errorSelector-test.js
+++ b/src/recoil_values/__tests__/Recoil_errorSelector-test.js
@@ -10,12 +10,12 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let store, getRecoilValueAsLoadable, errorSelector;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   ({
     getRecoilValueAsLoadable,

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -13,7 +13,7 @@
 import type {Loadable} from '../../adt/Recoil_Loadable';
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   store,
@@ -46,7 +46,7 @@ let React,
   freshSnapshot;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({useEffect, useState, Profiler} = require('react'));
@@ -76,7 +76,7 @@ const testRecoil = getRecoilTestFn(() => {
     resolvingAsyncSelector,
     loadingAsyncSelector,
     flushPromisesAndTimers,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({noWait} = require('../Recoil_WaitFor'));
   ({DefaultValue} = require('../../core/Recoil_Node'));
   ({mutableSourceExists} = require('../../util/Recoil_mutableSource'));

--- a/src/recoil_values/__tests__/Recoil_selectorFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_selectorFamily-test.js
@@ -12,7 +12,7 @@
 
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let atom,
   DefaultValue,
@@ -23,7 +23,7 @@ let atom,
   myAtom;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   atom = require('../Recoil_atom');
   ({DefaultValue} = require('../../core/Recoil_Node'));

--- a/src/util/Recoil_err.js
+++ b/src/util/Recoil_err.js
@@ -10,13 +10,8 @@
  */
 'use strict';
 
-const err = require('../util/Recoil_err');
+// @fb-only: const {err} = require('fb-error');
 
-function nullthrows<T>(x: ?T, message: ?string): T {
-  if (x != null) {
-    return x;
-  }
-  throw err(message ?? 'Got unexpected null or undefined');
-}
+const err = require('./polyfill/err.js'); // @oss-only
 
-module.exports = nullthrows;
+module.exports = err;

--- a/src/util/Recoil_stableStringify.js
+++ b/src/util/Recoil_stableStringify.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+const err = require('./Recoil_err');
 const isPromise = require('./Recoil_isPromise');
 
 const TIME_WARNING_THRESHOLD_MS = 15;
@@ -38,7 +39,7 @@ function stringify(x: mixed, opt: Options, key?: string): string {
       return JSON.stringify(x);
     case 'function':
       if (opt?.allowFunctions !== true) {
-        throw new Error('Attempt to serialize function in a Recoil cache key');
+        throw err('Attempt to serialize function in a Recoil cache key');
       }
       return `__FUNCTION(${x.name})__`;
   }
@@ -105,10 +106,10 @@ function stringify(x: mixed, opt: Options, key?: string): string {
 
   // For all other Objects, sort the keys in a stable order.
   return `{${Object.keys(x)
-    .filter(key => x[key] !== undefined)
+    .filter(k => x[k] !== undefined)
     .sort()
     // stringify the key to add quotes and escape any nested slashes or quotes.
-    .map(key => `${stringify(key, opt)}:${stringify(x[key], opt, key)}`)
+    .map(k => `${stringify(k, opt)}:${stringify(x[k], opt, k)}`)
     .join(',')}}`;
 }
 

--- a/src/util/Recoil_useComponentName.js
+++ b/src/util/Recoil_useComponentName.js
@@ -27,6 +27,7 @@ function useComponentName(): string {
         // with 'use'. We are only enabling this in dev for now, since once the
         // codebase is minified, the naming assumptions no longer hold true.
 
+        // eslint-disable-next-line fb-www/no-new-error
         const frames = stackTraceParser(new Error().stack);
         for (const {methodName} of frames) {
           // I observed cases where the frame was of the form 'Object.useXXX'

--- a/src/util/polyfill/err.js
+++ b/src/util/polyfill/err.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict
+ * @format
+ */
+'use strict';
+
+function err(message: string): Error {
+  const error = new Error(message);
+
+  // In V8, Error objects keep the closure scope chain alive until the
+  // err.stack property is accessed.
+  if (error.stack === undefined) {
+    // IE sets the stack only if error is thrown
+    try {
+      throw error;
+      // TODO, disable fb-www/no-unused-catch-bindings after bumping package.json to eslint-plugin-fb-www 1.0.7
+    } catch (_) {} // eslint-disable-line no-empty
+  }
+
+  return error;
+}
+
+module.exports = err;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,10 +1951,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-fb-www@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.4.tgz#8fb4beb4105e4e355582363bd4a199230eed26a4"
-  integrity sha512-m/XABkdtBcml2cTwDysQx/laAU1sAhwjaELP8X/RYY0CoKAQelYZvBHOF2Puc8sZlGNJy3cNnjZ48qYzgTIRqQ==
+eslint-plugin-fb-www@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.6.tgz#8290293031adc07c5d9e3b38de6c405ad45e2320"
+  integrity sha512-K4wdAyM7Q7kPD/v4cisVLRUsZeKCqDIhpieblEldPj4Sdx0MkW7iFdcfX5C6U0ubIyPgiQc5zeRqm/Fc5JGU5w==
 
 eslint-plugin-flowtype@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
Summary:
Normalize the `err()` factory for `Error` objects.  Internally use the `fb-error` module and create a polyfill for OSS.

Create separate polyfill for Refine.

Reviewed By: davidmccabe

Differential Revision: D31465013

