### PR TITLE
Implement useRecoilRefresher_UNSTABLE hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Allow class instances in family parameters for Flow
 - Add `getLoadable()`, `getPromise()`, and `getInfo_UNSTABLE()` to Atom Effects interface for reading other atoms.
 - Atoms freeze default, initialized, and async values in dev mode.  Selectors should not freeze upstream dependencies. (#1261, #1259)
+- Added `useRecoilRefresher_UNSTABLE()` hook which forces a selector to re-run it's `get()`, and is a no-op for an atom. (#972)
 
 ### Pending
 - Memory management

--- a/src/Recoil_index.js
+++ b/src/Recoil_index.js
@@ -50,6 +50,7 @@ const {freshSnapshot} = require('./core/Recoil_Snapshot');
 const {
   useGotoRecoilSnapshot,
   useRecoilCallback,
+  useRecoilRefresher,
   useRecoilSnapshot,
   useRecoilState,
   useRecoilStateLoadable,
@@ -113,6 +114,7 @@ module.exports = {
   useResetRecoilState,
   useGetRecoilValueInfo_UNSTABLE: useGetRecoilValueInfo,
   useRetain,
+  useRecoilRefresher_UNSTABLE: useRecoilRefresher,
 
   // Hooks for complex operations with RecoilValues
   useRecoilCallback,

--- a/src/core/Recoil_Node.js
+++ b/src/core/Recoil_Node.js
@@ -58,9 +58,14 @@ export type ReadOnlyNodeOptions<T> = $ReadOnly<{
   // the node is released again.
   init: (Store, TreeState, Trigger) => () => void,
 
-  // Informs the node to invalidate any caches as needed in case either it is
-  // set or it has an upstream dependency that was set. (Called at batch end.)
-  invalidate?: TreeState => void,
+  // Invalidate the cached value stored in the TreeState.
+  // It is used at the end of each batch for mutated state.
+  // This does not affect any other caches such as the selector cache.
+  invalidate: TreeState => void,
+
+  // Clear all internal caches for this node.  Unlike "invalidate()" this clears
+  // the selector cache and clears for all possible dependency values.
+  clearCache?: (Store, RecoilValue<T>) => void,
 
   shouldRestoreFromSnapshots: boolean,
 

--- a/src/hooks/__tests__/Recoil_useRecoilRefresher-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilRefresher-test.js
@@ -1,0 +1,106 @@
+/**
+ * (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
+
+let React,
+  act,
+  atom,
+  selector,
+  renderElements,
+  useRecoilValue,
+  useSetRecoilState,
+  useRecoilRefresher;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({act} = require('ReactTestUtils'));
+  atom = require('../../recoil_values/Recoil_atom');
+  selector = require('../../recoil_values/Recoil_selector');
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
+  ({
+    useRecoilRefresher,
+    useRecoilValue,
+    useSetRecoilState,
+  } = require('../Recoil_Hooks'));
+});
+
+testRecoil('useRerunRecoilValue - no-op for atom', async () => {
+  const myAtom = atom({
+    key: 'useRerunRecoilValue/atom',
+    default: 'default',
+  });
+
+  let refresh;
+  function Component() {
+    const value = useRecoilValue(myAtom);
+    refresh = useRecoilRefresher(myAtom);
+    return value;
+  }
+
+  const container = renderElements(<Component />);
+  expect(container.textContent).toBe('default');
+  act(() => refresh());
+  expect(container.textContent).toBe('default');
+});
+
+testRecoil('useRerunRecoilValue - re-executes selector', async () => {
+  let i = 0;
+  const myselector = selector({
+    key: 'useRerunRecoilValue/selector',
+    get: () => i++,
+  });
+
+  let refresh;
+  function Component() {
+    const value = useRecoilValue(myselector);
+    refresh = useRecoilRefresher(myselector);
+    return value;
+  }
+
+  const container = renderElements(<Component />);
+  expect(container.textContent).toBe('0');
+  act(() => refresh());
+  expect(container.textContent).toBe('1');
+});
+
+testRecoil('useRerunRecoilValue - clears entire cache', async () => {
+  const myatom = atom({
+    key: 'useRerunRecoilValue/myatom',
+    default: 'a',
+  });
+
+  let i = 0;
+  const myselector = selector({
+    key: 'useRerunRecoilValue/selector',
+    get: ({get}) => [get(myatom), i++],
+  });
+
+  let setMyAtom;
+  let refresh;
+  function Component() {
+    const [atomValue, iValue] = useRecoilValue(myselector);
+    refresh = useRecoilRefresher(myselector);
+    setMyAtom = useSetRecoilState(myatom);
+    return `${atomValue}-${iValue}`;
+  }
+
+  const container = renderElements(<Component />);
+  expect(container.textContent).toBe('a-0');
+
+  act(() => setMyAtom('b'));
+  expect(container.textContent).toBe('b-1');
+
+  act(() => refresh());
+  expect(container.textContent).toBe('b-2');
+
+  act(() => setMyAtom('a'));
+  expect(container.textContent).toBe('a-3');
+});

--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -96,7 +96,10 @@ const {
 } = require('../core/Recoil_Node');
 const {isRecoilValue} = require('../core/Recoil_RecoilValue');
 const {AbstractRecoilValue} = require('../core/Recoil_RecoilValue');
-const {setRecoilValueLoadable} = require('../core/Recoil_RecoilValueInterface');
+const {
+  markRecoilValueModified,
+  setRecoilValueLoadable,
+} = require('../core/Recoil_RecoilValueInterface');
 const {retainedByOptionWithDefault} = require('../core/Recoil_Retention');
 const {cloneSnapshot} = require('../core/Recoil_Snapshot');
 const deepFreezeValue = require('../util/Recoil_deepFreezeValue');
@@ -1123,6 +1126,11 @@ function selector<T>(
     state.atomValues.delete(key);
   }
 
+  function clearSelectorCache(store: Store, recoilValue: RecoilValue<T>) {
+    cache.clear();
+    markRecoilValueModified(store, recoilValue);
+  }
+
   if (set != null) {
     /**
      * ES5 strict mode prohibits defining non-top-level function declarations,
@@ -1208,6 +1216,7 @@ function selector<T>(
       set: selectorSet,
       init: selectorInit,
       invalidate: invalidateSelector,
+      clearCache: clearSelectorCache,
       shouldDeleteConfigOnRelease: selectorShouldDeleteConfigOnRelease,
       dangerouslyAllowMutability: options.dangerouslyAllowMutability,
       shouldRestoreFromSnapshots: false,
@@ -1221,6 +1230,7 @@ function selector<T>(
       get: selectorGet,
       init: selectorInit,
       invalidate: invalidateSelector,
+      clearCache: clearSelectorCache,
       shouldDeleteConfigOnRelease: selectorShouldDeleteConfigOnRelease,
       dangerouslyAllowMutability: options.dangerouslyAllowMutability,
       shouldRestoreFromSnapshots: false,


### PR DESCRIPTION
Summary:
It is often desirable to be able to re-run a selector in a Recoil application. There is currently no first class way of doing this. The suggested approach is to define an upstream atom (such as a number), which your selector depends on. You can then bump this atom when you need the selector to re-run.

This new approach adds a first class hook which can be used to force a selector to re-run.

Internally it simply clears the cache, and marks the value as updated.

Differential Revision: D31579872

