### PR TITLE
Update package.json for eslint-plugin-fb-www 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^3.6.11",
     "eslint": "^7.2.0",
-    "eslint-plugin-fb-www": "^1.0.4",
+    "eslint-plugin-fb-www": "^1.0.6",
     "eslint-plugin-flowtype": "^5.1.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",

--- a/src/caches/__tests__/Recoil_LRUCache-test.js
+++ b/src/caches/__tests__/Recoil_LRUCache-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let LRUCache;
 

--- a/src/caches/__tests__/Recoil_MapCache-test.js
+++ b/src/caches/__tests__/Recoil_MapCache-test.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let MapCache;
 

--- a/src/caches/__tests__/Recoil_TreeCache-test.js
+++ b/src/caches/__tests__/Recoil_TreeCache-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let TreeCache, loadableWithValue, nullthrows;
 

--- a/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_cacheFromPolicy-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let cacheFromPolicy;
 

--- a/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
+++ b/src/caches/__tests__/Recoil_treeCacheFromPolicy-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let treeCacheFromPolicy;
 

--- a/src/caches/__tests__/Recoil_treeCacheLRU-test.js
+++ b/src/caches/__tests__/Recoil_treeCacheLRU-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let treeCacheLRU, loadableWithValue;
 

--- a/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
+++ b/src/contrib/recoil-sync/__test_utils__/recoil-url-sync_mockSerialization.js
@@ -13,7 +13,7 @@ import type {LocationOption} from '../recoil-url-sync';
 
 const {
   flushPromisesAndTimers,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
 const {useRecoilURLSync} = require('../recoil-url-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-sync-test.js
@@ -22,6 +22,12 @@ const {
   validateString,
 } = require('../__test_utils__/recoil-sync_mockValidation');
 const {
+  ReadsAtom,
+  componentThatReadsAndWritesAtom,
+  flushPromisesAndTimers,
+  renderElements,
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const {
   loadableWithError,
   loadableWithPromise,
   loadableWithValue,
@@ -30,12 +36,6 @@ const {useRecoilValue} = require('../../../hooks/Recoil_Hooks');
 const atom = require('../../../recoil_values/Recoil_atom');
 const atomFamily = require('../../../recoil_values/Recoil_atomFamily');
 const selectorFamily = require('../../../recoil_values/Recoil_selectorFamily');
-const {
-  ReadsAtom,
-  componentThatReadsAndWritesAtom,
-  flushPromisesAndTimers,
-  renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
 const {syncEffect, useRecoilSync} = require('../recoil-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-listen-test.js
@@ -18,11 +18,11 @@ const {
   expectURL,
   gotoURL,
 } = require('../__test_utils__/recoil-url-sync_mockSerialization');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   ReadsAtom,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {syncEffect} = require('../recoil-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-push-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-push-test.js
@@ -17,11 +17,11 @@ const {
   expectURL,
   goBack,
 } = require('../__test_utils__/recoil-url-sync_mockSerialization');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   componentThatReadsAndWritesAtom,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {urlSyncEffect} = require('../recoil-url-sync');
 const React = require('react');
 

--- a/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
+++ b/src/contrib/recoil-sync/__tests__/recoil-url-sync-test.js
@@ -22,13 +22,13 @@ const {
   encodeURL,
   expectURL,
 } = require('../__test_utils__/recoil-url-sync_mockSerialization');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   ReadsAtom,
   componentThatReadsAndWritesAtom,
   flushPromisesAndTimers,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {syncEffect} = require('../recoil-sync');
 const {urlSyncEffect} = require('../recoil-url-sync');
 const React = require('react');

--- a/src/contrib/uri_persistence/__tests__/Recoil_Link-test.js
+++ b/src/contrib/uri_persistence/__tests__/Recoil_Link-test.js
@@ -12,13 +12,13 @@
 
 const {Simulate, act} = require('ReactTestUtils');
 
-const {freshSnapshot} = require('../../../core/Recoil_Snapshot');
-const atom = require('../../../recoil_values/Recoil_atom');
 const {
   componentThatReadsAndWritesAtom,
   flushPromisesAndTimers,
   renderElements,
-} = require('../../../testing/Recoil_TestingUtils');
+} = require('../../../__test_utils__/Recoil_TestingUtils');
+const {freshSnapshot} = require('../../../core/Recoil_Snapshot');
+const atom = require('../../../recoil_values/Recoil_atom');
 const {
   LinkToRecoilSnapshot,
   LinkToRecoilStateChange,

--- a/src/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/src/core/__tests__/Recoil_RecoilRoot-test.js
@@ -9,7 +9,7 @@
 
 import type {Store} from '../Recoil_State';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -39,7 +39,7 @@ const testRecoil = getRecoilTestFn(() => {
     ReadsAtom,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({RecoilRoot} = require('../Recoil_RecoilRoot.react'));
   ({useStoreRef} = require('../Recoil_RecoilRoot.react'));
 });

--- a/src/core/__tests__/Recoil_RecoilValueInterface-test.js
+++ b/src/core/__tests__/Recoil_RecoilValueInterface-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let act,
   atom,
@@ -27,7 +27,7 @@ let act,
   store;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   ({act} = require('ReactTestUtils'));
   atom = require('../../recoil_values/Recoil_atom');

--- a/src/core/__tests__/Recoil_Retention-test.js
+++ b/src/core/__tests__/Recoil_Retention-test.js
@@ -13,7 +13,7 @@
 
 import type {RecoilState} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -46,7 +46,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   gkx = require('../../util/Recoil_gkx');
 
   const initialGKValue = gkx('recoil_memory_managament_2020');

--- a/src/core/__tests__/Recoil_Snapshot-test.js
+++ b/src/core/__tests__/Recoil_Snapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -42,7 +42,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({Snapshot, freshSnapshot} = require('../Recoil_Snapshot'));
 });
 

--- a/src/core/__tests__/Recoil_batcher-test.js
+++ b/src/core/__tests__/Recoil_batcher-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let unstable_batchedUpdates, batchUpdates, getBatcher, setBatcher;
 

--- a/src/core/__tests__/Recoil_core-test.js
+++ b/src/core/__tests__/Recoil_core-test.js
@@ -10,12 +10,12 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let a, atom, store, nullthrows, getNodeLoadable, setNodeValue;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   atom = require('../../recoil_values/Recoil_atom');
   nullthrows = require('../../util/Recoil_nullthrows');

--- a/src/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/src/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -18,7 +18,7 @@ import type {
 } from '../../core/Recoil_RecoilValue';
 import type {PersistenceSettings} from '../../recoil_values/Recoil_atom';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 let {mutableSourceExists} = require('../../util/Recoil_mutableSource');
 
 let React,
@@ -64,7 +64,7 @@ const testRecoil = getRecoilTestFn(() => {
     flushPromisesAndTimers,
     renderElements,
     renderElementsWithSuspenseCount,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({mutableSourceExists} = require('../../util/Recoil_mutableSource'));
   ({
     recoilComponentGetRecoilValueCount_FOR_TESTING,

--- a/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/src/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -31,7 +31,7 @@ const testRecoil = getRecoilTestFn(() => {
     ReadsAtom,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   useGetRecoilValueInfo = require('../Recoil_useGetRecoilValueInfo');
 });
 

--- a/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -48,7 +48,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
 });
 
 testRecoil('Goto mapped snapshot', async () => {

--- a/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useEffect,
@@ -32,7 +32,7 @@ const testRecoil = getRecoilTestFn(() => {
   atom = require('../../recoil_values/Recoil_atom');
   ({
     componentThatReadsAndWritesAtom,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   useRecoilBridgeAcrossReactRoots = require('../Recoil_useRecoilBridgeAcrossReactRoots');
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useRef,
@@ -46,7 +46,7 @@ const testRecoil = getRecoilTestFn(() => {
     ReadsAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   invariant = require('../../util/Recoil_invariant');
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilInterface-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilInterface-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useRef,
@@ -27,7 +27,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({act} = require('ReactTestUtils'));
 
   atom = require('../../recoil_values/Recoil_atom');
-  ({renderElements} = require('../../testing/Recoil_TestingUtils'));
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useRecoilInterface} = require('../Recoil_Hooks'));
 
   counterAtom = atom({

--- a/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useEffect,
@@ -42,7 +42,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useGotoRecoilSnapshot, useRecoilSnapshot} = require('../Recoil_Hooks'));
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilStateReset-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilStateReset-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -34,7 +34,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
 });
 
 testRecoil('useRecoilValueReset - value default', () => {

--- a/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilTransactionObserver-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -37,7 +37,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useRecoilTransactionObserver} = require('../Recoil_Hooks'));
 });
 

--- a/src/hooks/__tests__/Recoil_useRecoilValueLoadable-test.js
+++ b/src/hooks/__tests__/Recoil_useRecoilValueLoadable-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -32,7 +32,7 @@ const testRecoil = getRecoilTestFn(() => {
     asyncSelector,
     renderElements,
     flushPromisesAndTimers,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({useRecoilValueLoadable} = require('../Recoil_Hooks'));
 });
 

--- a/src/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/src/hooks/__tests__/Recoil_useTransaction-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React, atom, useRecoilValue, useRecoilTransaction, renderElements;
 
@@ -21,7 +21,7 @@ const testRecoil = getRecoilTestFn(() => {
     useRecoilTransaction_UNSTABLE: useRecoilTransaction,
     useRecoilValue,
   } = require('../../Recoil_index'));
-  ({renderElements} = require('../../testing/Recoil_TestingUtils'));
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
 });
 
 testRecoil(

--- a/src/hooks/__tests__/Recoil_useTransition-test.js
+++ b/src/hooks/__tests__/Recoil_useTransition-test.js
@@ -14,7 +14,7 @@
 const {
   IS_INTERNAL,
   getRecoilTestFn,
-} = require('../../testing/Recoil_TestingUtils');
+} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   act,
@@ -34,7 +34,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     renderElementsInConcurrentRoot,
     flushPromisesAndTimers,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
 
   const initialGKValue = gkx('recoil_early_rendering_2021');
   gkx.setPass('recoil_early_rendering_2021');

--- a/src/recoil_values/__tests__/Recoil_WaitFor-test.js
+++ b/src/recoil_values/__tests__/Recoil_WaitFor-test.js
@@ -16,7 +16,7 @@ import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 const {
   flushPromisesAndTimers,
   getRecoilTestFn,
-} = require('../../testing/Recoil_TestingUtils');
+} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let getRecoilValueAsLoadable,
   noWait,
@@ -29,7 +29,7 @@ let getRecoilValueAsLoadable,
   invariant;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   invariant = require('../../util/Recoil_invariant');
   ({

--- a/src/recoil_values/__tests__/Recoil_atom-test.js
+++ b/src/recoil_values/__tests__/Recoil_atom-test.js
@@ -9,7 +9,7 @@
 
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -36,7 +36,7 @@ let React,
   store;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({useState, Profiler} = require('react'));
@@ -61,7 +61,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   atom = require('../Recoil_atom');
   selector = require('../Recoil_selector');
   immutable = require('immutable');

--- a/src/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -12,7 +12,7 @@
 
 import type {Store} from '../../core/Recoil_State';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let store: Store,
   React,
@@ -39,7 +39,7 @@ let store: Store,
   pAtom;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({Profiler, useState} = require('react'));
@@ -62,7 +62,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     flushPromisesAndTimers,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({mutableSourceExists} = require('../../util/Recoil_mutableSource'));
   stableStringify = require('../../util/Recoil_stableStringify');
   atom = require('../Recoil_atom');

--- a/src/recoil_values/__tests__/Recoil_atomWithFallback-test.js
+++ b/src/recoil_values/__tests__/Recoil_atomWithFallback-test.js
@@ -10,10 +10,10 @@
  */
 'use strict';
 
-import type {RecoilValue} from 'Recoil_RecoilValue';
-import type {Store} from 'Recoil_State';
+import type {RecoilValue} from '../../core/Recoil_RecoilValue';
+import type {Store} from '../../core/Recoil_State';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   useState,
@@ -29,12 +29,12 @@ let React,
   constSelector,
   store: Store;
 
-let fallback: RecoilValue<number>, hasFallback: RecoilValue<number>;
+let fallbackAtom: RecoilValue<number>, hasFallbackAtom: RecoilValue<number>;
 
 let id = 0;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({useState} = require('react'));
@@ -52,17 +52,17 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     componentThatReadsAndWritesAtom,
     renderElements,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   atom = require('../Recoil_atom');
   constSelector = require('../Recoil_constSelector');
 
   store = makeStore();
-  fallback = atom<number>({key: `fallback${id}`, default: 1});
-  hasFallback = atom<number>({
+  fallbackAtom = atom<number>({key: `fallback${id}`, default: 1});
+  hasFallbackAtom = atom<number>({
     key: `hasFallback${id++}`,
-    default: fallback,
+    default: fallbackAtom,
   });
-  subscribeToRecoilValue(store, hasFallback, () => undefined);
+  subscribeToRecoilValue(store, hasFallbackAtom, () => undefined);
 });
 
 function get(recoilValue) {
@@ -74,11 +74,11 @@ function set(recoilValue, value) {
 }
 
 testRecoil('atomWithFallback', () => {
-  expect(get(hasFallback)).toBe(1);
-  set(fallback, 2);
-  expect(get(hasFallback)).toBe(2);
-  set(hasFallback, 3);
-  expect(get(hasFallback)).toBe(3);
+  expect(get(hasFallbackAtom)).toBe(1);
+  set(fallbackAtom, 2);
+  expect(get(hasFallbackAtom)).toBe(2);
+  set(hasFallbackAtom, 3);
+  expect(get(hasFallbackAtom)).toBe(3);
 });
 
 describe('ReturnDefaultOrFallback', () => {
@@ -178,13 +178,13 @@ describe('ReturnDefaultOrFallback', () => {
 });
 
 testRecoil('Atom with atom fallback can store null and undefined', () => {
-  const fallbackAtom = atom<?string>({
+  const myFallbackAtom = atom<?string>({
     key: 'fallback for null undefined',
     default: 'FALLBACK',
   });
   const myAtom = atom<?string>({
     key: 'fallback atom with undefined',
-    default: fallbackAtom,
+    default: myFallbackAtom,
   });
   expect(get(myAtom)).toBe('FALLBACK');
   act(() => set(myAtom, 'VALUE'));
@@ -216,13 +216,13 @@ testRecoil('Atom with selector fallback can store null and undefined', () => {
 
 testRecoil('Effects', () => {
   let inited = false;
-  const fallbackAtom = atom({
+  const myFallbackAtom = atom({
     key: 'atom with fallback effects init fallback',
     default: 'FALLBACK',
   });
   const myAtom = atom<string>({
     key: 'atom with fallback effects init',
-    default: fallbackAtom,
+    default: myFallbackAtom,
     effects_UNSTABLE: [
       ({setSelf}) => {
         inited = true;

--- a/src/recoil_values/__tests__/Recoil_constSelector-test.js
+++ b/src/recoil_values/__tests__/Recoil_constSelector-test.js
@@ -12,12 +12,12 @@
 
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let getRecoilValueAsLoadable, store, constSelector;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   ({
     getRecoilValueAsLoadable,

--- a/src/recoil_values/__tests__/Recoil_errorSelector-test.js
+++ b/src/recoil_values/__tests__/Recoil_errorSelector-test.js
@@ -10,12 +10,12 @@
  */
 'use strict';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let store, getRecoilValueAsLoadable, errorSelector;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   ({
     getRecoilValueAsLoadable,

--- a/src/recoil_values/__tests__/Recoil_selector-test.js
+++ b/src/recoil_values/__tests__/Recoil_selector-test.js
@@ -13,7 +13,7 @@
 import type {Loadable} from '../../adt/Recoil_Loadable';
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let React,
   store,
@@ -46,7 +46,7 @@ let React,
   freshSnapshot;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   React = require('react');
   ({useEffect, useState, Profiler} = require('react'));
@@ -76,7 +76,7 @@ const testRecoil = getRecoilTestFn(() => {
     resolvingAsyncSelector,
     loadingAsyncSelector,
     flushPromisesAndTimers,
-  } = require('../../testing/Recoil_TestingUtils'));
+  } = require('../../__test_utils__/Recoil_TestingUtils'));
   ({noWait} = require('../Recoil_WaitFor'));
   ({DefaultValue} = require('../../core/Recoil_Node'));
   ({mutableSourceExists} = require('../../util/Recoil_mutableSource'));

--- a/src/recoil_values/__tests__/Recoil_selectorFamily-test.js
+++ b/src/recoil_values/__tests__/Recoil_selectorFamily-test.js
@@ -12,7 +12,7 @@
 
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 
-const {getRecoilTestFn} = require('../../testing/Recoil_TestingUtils');
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
 
 let atom,
   DefaultValue,
@@ -23,7 +23,7 @@ let atom,
   myAtom;
 
 const testRecoil = getRecoilTestFn(() => {
-  const {makeStore} = require('../../testing/Recoil_TestingUtils');
+  const {makeStore} = require('../../__test_utils__/Recoil_TestingUtils');
 
   atom = require('../Recoil_atom');
   ({DefaultValue} = require('../../core/Recoil_Node'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,10 +1951,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-fb-www@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.4.tgz#8fb4beb4105e4e355582363bd4a199230eed26a4"
-  integrity sha512-m/XABkdtBcml2cTwDysQx/laAU1sAhwjaELP8X/RYY0CoKAQelYZvBHOF2Puc8sZlGNJy3cNnjZ48qYzgTIRqQ==
+eslint-plugin-fb-www@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.6.tgz#8290293031adc07c5d9e3b38de6c405ad45e2320"
+  integrity sha512-K4wdAyM7Q7kPD/v4cisVLRUsZeKCqDIhpieblEldPj4Sdx0MkW7iFdcfX5C6U0ubIyPgiQc5zeRqm/Fc5JGU5w==
 
 eslint-plugin-flowtype@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
Summary:
Update `package.json` for `eslint-plugin-fb-www` 1.0.6 for `fb-www/no-null-fallback-for-error-boundary` lint rule oss mock.

Will need a follow-up diff to bump to 1.0.7 when available.

Differential Revision: D31667597

