### PR TITLE
Suppress fb-www/no-unused-catch-bindings lint for err() polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^3.6.11",
     "eslint": "^7.2.0",
-    "eslint-plugin-fb-www": "^1.0.6",
+    "eslint-plugin-fb-www": "^1.0.7",
     "eslint-plugin-flowtype": "^5.1.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",

--- a/src/util/polyfill/err.js
+++ b/src/util/polyfill/err.js
@@ -19,8 +19,7 @@ function err(message: string): Error {
     // IE sets the stack only if error is thrown
     try {
       throw error;
-      // TODO, disable fb-www/no-unused-catch-bindings after bumping package.json to eslint-plugin-fb-www 1.0.7
-    } catch (_) {} // eslint-disable-line no-empty
+    } catch (_) {} // eslint-disable-line fb-www/no-unused-catch-bindings, no-empty
   }
 
   return error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,10 +1951,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-fb-www@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.6.tgz#8290293031adc07c5d9e3b38de6c405ad45e2320"
-  integrity sha512-K4wdAyM7Q7kPD/v4cisVLRUsZeKCqDIhpieblEldPj4Sdx0MkW7iFdcfX5C6U0ubIyPgiQc5zeRqm/Fc5JGU5w==
+eslint-plugin-fb-www@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.7.tgz#a78ad301a229107d1f194fbc71b3440168bdca52"
+  integrity sha512-BBQVht+TkWLGli59nn2CNRbJZ5+AnqG2B02VipgfzSeB68mqBNiEXbPZ5ZbuMMwSgDN+95WCsS6y1ZZntst3Qg==
 
 eslint-plugin-flowtype@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
Summary: Suppress `fb-www/no-unused-catch-bindings` lint for `err()` polyfill

Differential Revision: D31699203

