### PR TITLE
useRecoilRefresher should clear cache transitively

### DIFF
--- a/src/core/Recoil_Node.js
+++ b/src/core/Recoil_Node.js
@@ -65,7 +65,7 @@ export type ReadOnlyNodeOptions<T> = $ReadOnly<{
 
   // Clear all internal caches for this node.  Unlike "invalidate()" this clears
   // the selector cache and clears for all possible dependency values.
-  clearCache?: (Store, RecoilValue<T>) => void,
+  clearCache?: (Store, TreeState) => void,
 
   shouldRestoreFromSnapshots: boolean,
 

--- a/src/hooks/Recoil_Hooks.js
+++ b/src/hooks/Recoil_Hooks.js
@@ -953,8 +953,7 @@ function useRecoilRefresher<T>(recoilValue: RecoilValue<T>): () => void {
     const store = storeRef.current;
     const {currentTree} = store.getState();
     const node = getNode(recoilValue.key);
-    node.invalidate(currentTree);
-    node.clearCache?.(store, recoilValue);
+    node.clearCache?.(store, currentTree);
   }, [recoilValue, storeRef]);
 }
 


### PR DESCRIPTION
Summary:
After using this in practice, it wasn't good enough to simply refresh the selector which gets the ultimate result, because it itself can have dependencies which cache.

This new version keeps track of all deps for a selector, and clears them recursively.

Reviewed By: drarmstr

Differential Revision: D31692885

