### PR TITLE
Typing nodeKey in cache as NodeKey rather than mixed

### DIFF
--- a/src/caches/Recoil_TreeCacheImplementationType.js
+++ b/src/caches/Recoil_TreeCacheImplementationType.js
@@ -10,7 +10,9 @@
  */
 'use strict';
 
-export type NodeCacheRoute = Array<[mixed, mixed]>;
+import type {NodeKey} from '../core/Recoil_Keys';
+
+export type NodeCacheRoute = Array<[NodeKey, mixed]>;
 
 export type TreeCacheNode<T> = TreeCacheLeaf<T> | TreeCacheBranch<T>;
 
@@ -23,13 +25,13 @@ export type TreeCacheLeaf<T> = {
 
 export type TreeCacheBranch<T> = {
   type: 'branch',
-  nodeKey: mixed,
+  nodeKey: NodeKey,
   branches: Map<mixed, TreeCacheNode<T>>,
   branchKey?: ?mixed,
   parent: ?TreeCacheBranch<T>,
 };
 
-export type NodeValueGet = (nodeKey: mixed) => mixed;
+export type NodeValueGet = (nodeKey: NodeKey) => mixed;
 
 type NodeVisitHandler<T> = (node: TreeCacheNode<T>) => void;
 

--- a/src/recoil_values/Recoil_selector.js
+++ b/src/recoil_values/Recoil_selector.js
@@ -1136,7 +1136,7 @@ function selector<T>(
   function clearSelectorCache(store: Store, treeState: TreeState) {
     invariant(recoilValue != null, 'Recoil Value can never be null');
     for (const nodeKey of discoveredDependencyNodeKeys) {
-      const node = getNode(String(nodeKey));
+      const node = getNode(nodeKey);
       node.clearCache?.(store, treeState);
     }
     invalidateSelector(treeState);


### PR DESCRIPTION
Summary: Typing nodeKey in cache as NodeKey rather than mixed

Differential Revision: D31741416

