### PR TITLE
Handle canceled selector evaluations as rejections

### DIFF
--- a/src/adt/Recoil_Loadable.js
+++ b/src/adt/Recoil_Loadable.js
@@ -24,9 +24,6 @@ const TYPE_CHECK_COOKIE = 27495866187;
 // TODO Convert Loadable to a Class to allow for runtime type detection.
 // Containing static factories of withValue(), withError(), withPromise(), and all()
 
-class Canceled {}
-const CANCELED: Canceled = new Canceled();
-
 type Accessors<+T> = $ReadOnly<{
   // Attempt to get the value.
   // If there's an error, throw an error.  If it's still loading, throw a Promise
@@ -82,7 +79,7 @@ type ErrorLoadable<+T> = $ReadOnly<{
 type LoadingLoadable<+T> = $ReadOnly<{
   __loadable: number,
   state: 'loading',
-  contents: Promise<T | Canceled>,
+  contents: Promise<T>,
   ...LoadingAccessors<T>,
 }>;
 
@@ -233,33 +230,23 @@ function loadableWithError<T>(error: mixed): ErrorLoadable<T> {
   });
 }
 
-// TODO Probably need to clean-up this API to accept `Promise<T>`
-// with an alternative params or mechanism for internal key proxy.
-const throwCanceled = value => {
-  if (value instanceof Canceled) {
-    throw value;
-  }
-  return value;
-};
-function loadableWithPromise<T>(
-  promise: Promise<T | Canceled>,
-): LoadingLoadable<T> {
+function loadableWithPromise<T>(promise: Promise<T>): LoadingLoadable<T> {
   return Object.freeze({
     __loadable: TYPE_CHECK_COOKIE,
     state: 'loading',
     contents: promise,
     ...loadableAccessors,
     getValue() {
-      throw this.contents.then(throwCanceled);
+      throw this.contents;
     },
     toPromise() {
-      return this.contents.then(throwCanceled);
+      return this.contents;
     },
     promiseMaybe() {
-      return this.contents.then(throwCanceled);
+      return this.contents;
     },
     promiseOrThrow() {
-      return this.contents.then(throwCanceled);
+      return this.contents;
     },
   });
 }
@@ -335,7 +322,5 @@ module.exports = {
   loadableLoading,
   loadableAll,
   isLoadable,
-  Canceled,
-  CANCELED,
   RecoilLoadable: LoadableStaticInterface,
 };

--- a/src/core/Recoil_RecoilValueInterface.js
+++ b/src/core/Recoil_RecoilValueInterface.js
@@ -20,7 +20,6 @@ import type {
   TreeState,
 } from './Recoil_State';
 
-const {CANCELED} = require('../adt/Recoil_Loadable');
 const gkx = require('../util/Recoil_gkx');
 const nullthrows = require('../util/Recoil_nullthrows');
 const recoverableViolation = require('../util/Recoil_recoverableViolation');
@@ -64,7 +63,7 @@ function getRecoilValueAsLoadable<T>(
        * HACK: intercept thrown error here to prevent an uncaught promise exception. Ideally this would happen closer to selector
        * execution (perhaps introducing a new ERROR class to be resolved by async selectors that are in an error state)
        */
-      return CANCELED;
+      return;
     });
   }
 


### PR DESCRIPTION
Summary:
Simplify `Loadable`s and selector typing and logic by treating canceled `Promise`s as a rejected `Promise` instead of returning a placeholder `Canceled` object as the value.

This also fixes the current typing which it turns out is actually wrong and was revealed by the next diff which converts `Loadable`s to classes and has improved type checking.

Reviewed By: csantos42

Differential Revision: D31703653

