### PR TITLE
Partially convert Loadables to classes

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/__tests__.*
 .*/node_modules.*
+<PROJECT_ROOT>/packages-ext/.*
 
 [include]
 
@@ -8,10 +9,6 @@
 
 [options]
 module.system=node
-
-esproposal.class_static_fields=enable
-esproposal.optional_chaining=enable
-esproposal.nullish_coalescing=enable
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
@@ -52,4 +49,4 @@ unsafe-getters-setters
 all=warn
 
 [version]
-^0.129.0
+^0.162.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ***Add new changes here as they land***
 
-- Ability to map Loadables with other Loadables
 - Allow class instances in family parameters for Flow
 - Add `getLoadable()`, `getPromise()`, and `getInfo_UNSTABLE()` to Atom Effects interface for reading other atoms.
 - Atoms freeze default, initialized, and async values in dev mode.  Selectors should not freeze upstream dependencies. (#1261, #1259)
 - Added `useRecoilRefresher_UNSTABLE()` hook which forces a selector to re-run it's `get()`, and is a no-op for an atom. (#972)
-- Expose `RecoilLoadable` interface for creating `Loadable` objects.
+- `Loadable` improvements:
+  - Publish `RecoilLoadable` interface with factories and type checking for Loadables
+  - Ability to map Loadables with other Loadables.
+  - Re-implement Loadable as classes.
 
 ### Pending
 - Memory management

--- a/__mocks__/gkx.js
+++ b/__mocks__/gkx.js
@@ -9,6 +9,6 @@
  * @format
  */
 
-module.exports = function gkx(_gk: string) {
+module.exports = function gkx(_gk: string): boolean {
   return false;
 };

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-rulesdir": "^0.1.0",
-    "flow-bin": "^0.129.0",
+    "flow-bin": "^0.162.1",
     "gen-flow-files": "^0.4.11",
     "husky": ">=4",
     "immutable": "^4.0.0-rc.12",

--- a/packages/recoil/adt/Recoil_PersistentMap.js
+++ b/packages/recoil/adt/Recoil_PersistentMap.js
@@ -74,7 +74,7 @@ class BuiltInMap<K: string, V> implements PersistentMap<K, V> {
 class HashArrayMappedTrieMap<K: string, V> implements PersistentMap<K, V> {
   // Because hamt.empty is not a function there is no way to introduce type
   // parameters on it, so empty is typed as HAMTPlusMap<string, mixed>.
-  // flowlint-next-line unclear-type:off
+  // $FlowIssue
   _hamt: HAMTPlusMap<K, V> = ((hamt.empty: any).beginMutation(): HAMTPlusMap<
     K,
     V,

--- a/packages/recoil/core/Recoil_RecoilRoot.react.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.react.js
@@ -326,7 +326,7 @@ function RecoilRoot_INTERNAL({
   initializeState,
   store_INTERNAL: storeProp, // For use with React "context bridging"
   children,
-}: InternalProps): ReactElement {
+}: InternalProps): React.Node {
   // prettier-ignore
   // @fb-only: useEffect(() => {
     // @fb-only: if (gkx('recoil_usage_logging')) {

--- a/packages/recoil/core/Recoil_RecoilValueInterface.js
+++ b/packages/recoil/core/Recoil_RecoilValueInterface.js
@@ -267,7 +267,7 @@ function setRecoilValueLoadable<T>(
   queueOrPerformStateUpdate(store, {
     type: 'setLoadable',
     recoilValue,
-    loadable,
+    loadable: (loadable: Loadable<T>),
   });
 }
 

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -55,16 +55,17 @@ export type AtomFamilyOptions<T, P: Parameter> = $ReadOnly<{
 }>;
 
 // Process scopeRules to handle any entries which are functions taking parameters
-function mapScopeRules<P>(
-  scopeRules?: ParameterizedScopeRules<P>,
-  param: P,
-): ScopeRules | void {
-  return scopeRules?.map(rule =>
-    Array.isArray(rule)
-      ? rule.map(entry => (typeof entry === 'function' ? entry(param) : entry))
-      : rule,
-  );
-}
+// prettier-ignore
+// @fb-only: function mapScopeRules<P>(
+  // @fb-only: scopeRules?: ParameterizedScopeRules<P>,
+  // @fb-only: param: P,
+// @fb-only: ): ScopeRules | void {
+  // @fb-only: return scopeRules?.map(rule =>
+    // @fb-only: Array.isArray(rule)
+      // @fb-only: ? rule.map(entry => (typeof entry === 'function' ? entry(param) : entry))
+      // @fb-only: : rule,
+  // @fb-only: );
+// @fb-only: }
 
 /*
 A function which returns an atom based on the input parameter.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,10 +2297,10 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
 
-flow-bin@^0.129.0:
-  version "0.129.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.129.0.tgz#50294d6e335dd97d095c27b096ea0b94c2415d55"
-  integrity sha512-WLXOj09oCK6nODVKM5uxvAzBpxXeI304E60tELMeQd/TJsyfbykNCZ+e4xml9eUOyoac9nDL3YrJpPZMzq0tMA==
+flow-bin@^0.162.1:
+  version "0.162.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.162.1.tgz#5aaac790dab8664ce363fd0f09764fb9f0daed20"
+  integrity sha512-gFNWkEzBuQ9YzQcPKcVL16V5MZixbiQ+Kn867iwaCfs1TAFuhQQcng4vX3Rtyd7JI3O+g8jToEX7pEDhdzG80Q==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Summary:
Convert each of the three `Loadable` types to classes for improved type checking and actual type refinement with `isLoadable()`.  Note the `Loadable<T>` type is still a union type of all three classes and not a class itself, so we still cannot have static factory methods.

Thanks Flow Master csantos42!

Reviewed By: csantos42

Differential Revision: D31671931

