### PR TITLE
Perform runtime check if user provided required options for atoms/selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Publish `RecoilLoadable` interface with factories and type checking for Loadables
   - Ability to map Loadables with other Loadables.
   - Re-implement Loadable as classes.
+- Perform runtime check in dev mode that required options are provided when creating atoms and selectors. (#1324)
 
 ### Pending
 - Memory management

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -153,8 +153,8 @@ type BaseAtomOptions<T> = $ReadOnly<{
 
 function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
   const {key, persistence_UNSTABLE: persistence} = options;
-  const retainedBy = retainedByOptionWithDefault(options.retainedBy_UNSTABLE);
 
+  const retainedBy = retainedByOptionWithDefault(options.retainedBy_UNSTABLE);
   let liveStoresCount = 0;
 
   let defaultLoadable: Loadable<T> = isPromise(options.default)
@@ -537,6 +537,17 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
 
 // prettier-ignore
 function atom<T>(options: AtomOptions<T>): RecoilState<T> {
+  if (__DEV__) {
+    if (typeof options.key !== 'string') {
+      throw err(
+        'A key option with a unique string value must be provided when creating an atom.',
+      );
+    }
+    if (!('default' in options)) {
+      throw err('A default value must be specified when creating an atom.');
+    }
+  }
+
   const {
     default: optionsDefault,
     // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS,

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -220,6 +220,18 @@ function selector<T>(
 
   const {key, get, cachePolicy_UNSTABLE: cachePolicy} = options;
   const set = options.set != null ? options.set : undefined; // flow
+  if (__DEV__) {
+    if (typeof key !== 'string') {
+      throw err(
+        'A key option with a unique string value must be provided when creating a selector.',
+      );
+    }
+    if (typeof get !== 'function') {
+      throw err(
+        'Selectors must specify a get callback option to get the selector value.',
+      );
+    }
+  }
 
   // This is every discovered dependency across executions
   const discoveredDependencyNodeKeys = new Set();
@@ -703,8 +715,8 @@ function selector<T>(
 
     setDepsInStore(store, state, deps, executionId);
 
-    function getRecoilValue<S>(recoilValue: RecoilValue<S>): S {
-      const {key: depKey} = recoilValue;
+    function getRecoilValue<S>(dep: RecoilValue<S>): S {
+      const {key: depKey} = dep;
 
       setNewDepInStore(store, state, deps, depKey, executionId);
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -1285,3 +1285,15 @@ testRecoil('object is frozen when stored in atom', async () => {
 
   window.__DEV__ = devStatus;
 });
+
+testRecoil('Required options are provided when creating atoms', () => {
+  const devStatus = window.__DEV__;
+  window.__DEV__ = true;
+
+  // $FlowExpectedError[prop-missing]
+  expect(() => atom({default: undefined})).toThrow();
+  // $FlowExpectedError[prop-missing]
+  expect(() => atom({key: 'MISSING DEFAULT'})).toThrow();
+
+  window.__DEV__ = devStatus;
+});

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -661,8 +661,10 @@ testRecoil('Selector getCallback', async () => {
     key: 'selector - getCallback',
     get: ({getCallback}) => {
       return {
-        onClick: getCallback(({snapshot}) => async () =>
-          await snapshot.getPromise(myAtom),
+        onClick: getCallback(
+          ({snapshot}) =>
+            async () =>
+              await snapshot.getPromise(myAtom),
         ),
       };
     },
@@ -1695,6 +1697,20 @@ testRecoil('Selector values are frozen', async () => {
   expect(Object.isFrozen(getValue(fwdMixedSelector))).toBe(true);
   expect(Object.isFrozen(getValue(upstreamMixedSelector))).toBe(false);
   expect(Object.isFrozen(getValue(upstreamMixedSelector).nested)).toBe(false);
+
+  window.__DEV__ = devStatus;
+});
+
+testRecoil('Required options are provided when creating selectors', () => {
+  const devStatus = window.__DEV__;
+  window.__DEV__ = true;
+
+  // $FlowExpectedError[incompatible-call]
+  expect(() => selector({get: () => {}})).toThrow();
+  // $FlowExpectedError[incompatible-call]
+  expect(() => selector({get: false})).toThrow();
+  // $FlowExpectedError[incompatible-call]
+  expect(() => selector({key: 'MISSING GET'})).toThrow();
 
   window.__DEV__ = devStatus;
 });


### PR DESCRIPTION
Summary: Perform runtime check if user provided required options for atoms/selectors.  Check that atoms provide a string `key` and a `default` value.  Check that selectors provide a string `key` and a `get` callback function.

Differential Revision: D31818325

