### PR TITLE
Avoid double-encoding when using query params

### DIFF
--- a/packages/recoil-sync/RecoilSync_URL.js
+++ b/packages/recoil-sync/RecoilSync_URL.js
@@ -42,7 +42,7 @@ function parseURL(loc: LocationOption): ?string {
           : null;
       }
       const param = new URLSearchParams(location.search).get(queryParam);
-      return param != null ? decodeURIComponent(param) : null;
+      return param != null ? param : null;
     }
   }
   throw err(`Unknown URL location part: "${loc.part}"`);
@@ -60,7 +60,7 @@ function updateURL(loc: LocationOption, serialization): string {
         return `?${encodeURIComponent(serialization)}${location.hash}`;
       }
       const searchParams = new URLSearchParams(location.search);
-      searchParams.set(queryParam, encodeURIComponent(serialization));
+      searchParams.set(queryParam, serialization);
       return `?${searchParams.toString()}${location.hash}`;
     }
   }

--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -76,27 +76,26 @@ function TestURLSync({
 }
 
 function encodeState(obj) {
-  return `${encodeURIComponent(JSON.stringify(obj))}`;
+  return encodeURIComponent(JSON.stringify(obj));
 }
 
 function encodeURLPart(href: string, loc: LocationOption, obj): string {
-  const encoded = encodeState(obj);
   const url = new URL(href);
   switch (loc.part) {
     case 'href':
       url.pathname = '/TEST';
-      url.hash = encoded;
+      url.hash = encodeState(obj);
       break;
     case 'hash':
-      url.hash = encoded;
+      url.hash = encodeState(obj);
       break;
     case 'search': {
       const {queryParam} = loc;
       if (queryParam == null) {
-        url.search = encoded;
+        url.search = encodeState(obj);
       } else {
         const searchParams = url.searchParams;
-        searchParams.set(queryParam, encoded);
+        searchParams.set(queryParam, JSON.stringify(obj));
         url.search = searchParams.toString();
       }
       break;


### PR DESCRIPTION
Summary: Avoid double-encoding when using query params

Reviewed By: geekster777

Differential Revision: D31866909

