### PR TITLE
optional object properties

### DIFF
--- a/packages/refine/Refine_index.js
+++ b/packages/refine/Refine_index.js
@@ -20,6 +20,7 @@ export type {
   Get,
   Path,
 } from './Refine_Checkers';
+export type {OptionalPropertyChecker} from './Refine_ContainerCheckers';
 
 const {assertion, coercion} = require('./Refine_API');
 const {
@@ -27,6 +28,7 @@ const {
   dict,
   map,
   object,
+  optional,
   set,
   tuple,
   writableArray,
@@ -89,6 +91,7 @@ module.exports = {
   tuple,
   dict,
   object,
+  optional,
   set,
   map,
   writableArray,

--- a/packages/refine/__tests__/Refine_Containers-test.js
+++ b/packages/refine/__tests__/Refine_Containers-test.js
@@ -9,7 +9,6 @@
  * @format
  */
 'use strict';
-
 const invariant = require('../__test_utils__/Refine_invariant');
 const {coercion} = require('../Refine_API');
 const {
@@ -17,6 +16,7 @@ const {
   dict,
   map,
   object,
+  optional,
   set,
   tuple,
   writableArray,
@@ -171,6 +171,32 @@ describe('object', () => {
     const b: string = result.value.b;
     expect(a).toEqual(1);
     expect(b).toEqual('test');
+  });
+
+  it('should allow optional props', () => {
+    const coerce = object({
+      a: number(),
+      b: string(),
+      c: optional(number()),
+    });
+
+    const result = coerce({a: 1, b: 'test'});
+    invariant(result.type === 'success', 'should succeed');
+
+    // eslint-disable-next-line no-unused-vars
+    const n: ?number = result.value.c;
+
+    // typecheck assertion
+    const a: number = result.value.a;
+    const b: string = result.value.b;
+    expect(a).toEqual(1);
+    expect(b).toEqual('test');
+
+    const result2 = coerce({a: 1, b: 'test', c: 2});
+    invariant(result2.type === 'success', 'should succeed');
+
+    const result3 = coerce({a: 1, b: 'test', c: undefined});
+    invariant(result3.type === 'failure', 'should fail');
   });
 
   it('should succeed in parsing nested objects', () => {


### PR DESCRIPTION
Summary:
- heavily requested feature
- adds support for declaring optional properties as an additional argument to `object`/`writableObject`
- checker passes if key is not present, or checker function passes.

NOTE: I'm not totally sure on the flow declarations -- I think we are reaching the limit of what flow can actually check here

Reviewed By: drarmstr

Differential Revision: D31833012

