### PR TITLE
Mode for Recoil to sync with query parameters

### DIFF
--- a/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
@@ -93,15 +93,20 @@ describe('Test URL Persistence', () => {
       expect(new URL(location.href).searchParams.get('foo')).toBe(null);
       expect(new URL(location.href).searchParams.get('bar')).toBe(null);
     }));
-  test('Write to URL - Query Search Param', () =>
-    testWriteToURL({part: 'search', queryParam: 'bar'}, () => {
+  test('Write to URL - Query Params', () =>
+    testWriteToURL({part: 'queryParams'}, () => {
+      expect(location.hash).toBe('#anchor');
+      expect(new URL(location.href).searchParams.get('foo')).toBe('bar');
+    }));
+  test('Write to URL - Query Param', () =>
+    testWriteToURL({part: 'queryParams', param: 'bar'}, () => {
       expect(location.hash).toBe('#anchor');
       expect(new URL(location.href).searchParams.get('foo')).toBe('bar');
     }));
 
   test('Write to multiple params', async () => {
-    const locA = {part: 'search', queryParam: 'paramA'};
-    const locB = {part: 'search', queryParam: 'paramB'};
+    const locA = {part: 'queryParams', param: 'paramA'};
+    const locB = {part: 'queryParams', param: 'paramB'};
     const atomA = atom({
       key: 'recoil-url-sync multiple param A',
       default: 'DEFAULT',
@@ -182,10 +187,12 @@ describe('Test URL Persistence', () => {
   test('Read from URL', () => testReadFromURL({part: 'href'}));
   test('Read from URL - Anchor Hash', () => testReadFromURL({part: 'hash'}));
   test('Read from URL - Search Query', () => testReadFromURL({part: 'search'}));
-  test('Read from URL - Search Query Param', () =>
-    testReadFromURL({part: 'search', queryParam: 'param'}));
-  test('Read from URL - Search Query Param with other param', () =>
-    testReadFromURL({part: 'search', queryParam: 'other'}));
+  test('Read from URL - Query Params', () =>
+    testReadFromURL({part: 'queryParams'}));
+  test('Read from URL - Query Param', () =>
+    testReadFromURL({part: 'queryParams', param: 'param'}));
+  test('Read from URL - Query Param with other param', () =>
+    testReadFromURL({part: 'queryParams', param: 'other'}));
 
   test('Read from URL upgrade', async () => {
     const loc = {part: 'hash'};
@@ -258,8 +265,8 @@ describe('Test URL Persistence', () => {
   });
 
   test('Read/Write from URL with upgrade', async () => {
-    const loc1 = {part: 'search', queryParam: 'param1'};
-    const loc2 = {part: 'search', queryParam: 'param2'};
+    const loc1 = {part: 'queryParams', param: 'param1'};
+    const loc2 = {part: 'queryParams', param: 'param2'};
 
     const atomA = atom<string>({
       key: 'recoil-url-sync read/write upgrade type',

--- a/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
@@ -25,8 +25,8 @@ const React = require('react');
 const {string} = require('refine');
 
 test('Listen to URL changes', async () => {
-  const locFoo = {part: 'search', queryParam: 'foo'};
-  const locBar = {part: 'search', queryParam: 'bar'};
+  const locFoo = {part: 'queryParams', param: 'foo'};
+  const locBar = {part: 'queryParams', param: 'bar'};
 
   const atomA = atom({
     key: 'recoil-url-sync listen',

--- a/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
@@ -24,7 +24,7 @@ const React = require('react');
 const {string} = require('refine');
 
 test('Push URLs in browser history', async () => {
-  const loc = {part: 'search', queryParam: 'push'};
+  const loc = {part: 'queryParams'};
 
   const atomA = atom({
     key: 'recoil-url-sync replace',

--- a/packages/recoil-sync/util/RecoilSync_nullthrows.js
+++ b/packages/recoil-sync/util/RecoilSync_nullthrows.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @emails oncall+recoil
- * @flow strict
+ * @flow strict-local
  * @format
  */
 'use strict';
 
-const err = require('./Recoil_err');
+const err = require('./RecoilSync_err');
 
 function nullthrows<T>(x: ?T, message: ?string): T {
   if (x != null) {

--- a/packages/recoil-sync/util/RecoilSync_objectFromEntries.js
+++ b/packages/recoil-sync/util/RecoilSync_objectFromEntries.js
@@ -11,7 +11,7 @@
 'use strict';
 
 // Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
-function objectFromEntries<T>(entries: $ReadOnlyArray<[string, T]>): {
+function objectFromEntries<T>(entries: Iterable<[string, T]>): {
   [string]: T,
 } {
   const obj = {};


### PR DESCRIPTION
Summary:
We have a variety of modes for how Recoil Sync should serialize atoms to the URL.  For example:

* `href` - User has complete control over creating the URI
* `anchor` - User can serialize all atoms to an anchor string
* `search` - User can serialize all atoms to the query search string

This diff updates and clarifies the following two modes (which are probably the most useful):

* `queryParams` - User can serialize individual atoms to sync with individual query parameters
* `queryParams` with a `param` - User can serialize all atoms to a single query parameter string.

This flexibility is helpful because sometimes we want to use a mode like `{part: 'queryParams', param: 'state'}` to serialize with something like Google Transit to persist complex user objects in a single string with compression/de-duping while other times we may want a mode like `{part: 'queryParams'}` that for some trivial JSON serialization of atoms to their own query parameters.  That may not support complex objects or user classes, but is convenient for others to read the URL, such as for Relay pre-fetching.  the `{part: 'href'}` is a sort of fallback mechanism to allow user complete freedom.

Note that with this flexibility the `serialize()`/`deserialize()` callback signatures change to just be `mixed => string` and `string => mixed` and depending on the mode used with either pass individual atom values to serialize or an object containing all atom values.  We don't want to just always have the callback deal with individual atoms at a time because that would remove the opportunity for de-duping optimizations such as available with Google Transit.

Differential Revision: D31873185

