### PR TITLE
Use objects instead of maps for useRecoilURLSync() hook

### DIFF
--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -21,15 +21,6 @@ const React = require('react');
 // // Mock Serialization
 // ////////////////////////////
 
-// Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
-const mapToObj = map => {
-  const obj = {};
-  for (const [key, value] of map.entries()) {
-    obj[key] = value;
-  }
-  return obj;
-};
-
 function TestURLSync({
   syncKey,
   location,
@@ -41,7 +32,7 @@ function TestURLSync({
     syncKey,
     location,
     serialize: items => {
-      const str = JSON.stringify(mapToObj(items));
+      const str = JSON.stringify(items);
       return location.part === 'href'
         ? `/TEST#${encodeURIComponent(str)}`
         : str;
@@ -56,10 +47,10 @@ function TestURLSync({
         stateStr === 'foo=bar' ||
         stateStr === 'bar'
       ) {
-        return new Map();
+        return {};
       }
       try {
-        return new Map(Object.entries(JSON.parse(stateStr)));
+        return JSON.parse(stateStr);
       } catch (e) {
         // eslint-disable-next-line fb-www/no-console
         console.error(

--- a/packages/recoil-sync/util/RecoilSync_objectFromEntries.js
+++ b/packages/recoil-sync/util/RecoilSync_objectFromEntries.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+// Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
+function objectFromEntries<T>(entries: $ReadOnlyArray<[string, T]>): {
+  [string]: T,
+} {
+  const obj = {};
+  for (const [key, value] of entries) {
+    obj[key] = value;
+  }
+  return obj;
+}
+
+module.exports = objectFromEntries;


### PR DESCRIPTION
Summary: Use JS objects instead of JS Maps for serialization/deserialization API in `useRecoilURLSync()` hook.  This makes it a bit easier for trivial JSON encoding.  Keys are always only strings, so this should be fine.

Reviewed By: geekster777

Differential Revision: D31868788

