### PR TITLE
Split useRecoilRefresher() to a separate file.

### DIFF
--- a/packages/recoil/Recoil_index.js
+++ b/packages/recoil/Recoil_index.js
@@ -51,7 +51,6 @@ const {freshSnapshot} = require('./core/Recoil_Snapshot');
 const {
   useGotoRecoilSnapshot,
   useRecoilCallback,
-  useRecoilRefresher,
   useRecoilSnapshot,
   useRecoilState,
   useRecoilStateLoadable,
@@ -67,6 +66,7 @@ const {
 } = require('./hooks/Recoil_Hooks');
 const useGetRecoilValueInfo = require('./hooks/Recoil_useGetRecoilValueInfo');
 const useRecoilBridgeAcrossReactRoots = require('./hooks/Recoil_useRecoilBridgeAcrossReactRoots');
+const useRecoilRefresher = require('./hooks/Recoil_useRecoilRefresher');
 const atom = require('./recoil_values/Recoil_atom');
 const atomFamily = require('./recoil_values/Recoil_atomFamily');
 const constSelector = require('./recoil_values/Recoil_constSelector');

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -947,19 +947,8 @@ function useRecoilTransaction<Arguments: $ReadOnlyArray<mixed>>(
   );
 }
 
-function useRecoilRefresher<T>(recoilValue: RecoilValue<T>): () => void {
-  const storeRef = useStoreRef();
-  return useCallback(() => {
-    const store = storeRef.current;
-    const {currentTree} = store.getState();
-    const node = getNode(recoilValue.key);
-    node.clearCache?.(store, currentTree);
-  }, [recoilValue, storeRef]);
-}
-
 module.exports = {
   recoilComponentGetRecoilValueCount_FOR_TESTING,
-  useRecoilRefresher,
   useGotoRecoilSnapshot,
   useRecoilCallback,
   useRecoilInterface: useRecoilInterface_DEPRECATED,

--- a/packages/recoil/hooks/Recoil_useRecoilRefresher.js
+++ b/packages/recoil/hooks/Recoil_useRecoilRefresher.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {RecoilValue} from '../core/Recoil_RecoilValue';
+
+const {getNode} = require('../core/Recoil_Node');
+const {useStoreRef} = require('../core/Recoil_RecoilRoot.react');
+const {useCallback} = require('react');
+
+function useRecoilRefresher<T>(recoilValue: RecoilValue<T>): () => void {
+  const storeRef = useStoreRef();
+  return useCallback(() => {
+    const store = storeRef.current;
+    const {currentTree} = store.getState();
+    const node = getNode(recoilValue.key);
+    node.clearCache?.(store, currentTree);
+  }, [recoilValue, storeRef]);
+}
+
+module.exports = useRecoilRefresher;

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilRefresher-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilRefresher-test.js
@@ -25,11 +25,8 @@ const testRecoil = getRecoilTestFn(() => {
   atom = require('../../recoil_values/Recoil_atom');
   selector = require('../../recoil_values/Recoil_selector');
   ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
-  ({
-    useRecoilRefresher,
-    useRecoilValue,
-    useSetRecoilState,
-  } = require('../Recoil_Hooks'));
+  useRecoilRefresher = require('../Recoil_useRecoilRefresher');
+  ({useRecoilValue, useSetRecoilState} = require('../Recoil_Hooks'));
 });
 
 testRecoil('useRerunRecoilValue - no-op for atom', async () => {


### PR DESCRIPTION
Summary: Simplify `Recoil_Hooks.js` by splitting `useRecoilRefresher()` to a separate file.

Differential Revision: D31900359

