### PR TITLE
Mark useTransactionObservation_UNSTABLE() as deprecated

### DIFF
--- a/packages/recoil/Recoil_index.js
+++ b/packages/recoil/Recoil_index.js
@@ -128,7 +128,7 @@ module.exports = {
   useGotoRecoilSnapshot,
   useRecoilSnapshot,
   useRecoilTransactionObserver_UNSTABLE: useRecoilTransactionObserver,
-  useTransactionObservation_UNSTABLE: useTransactionObservation_DEPRECATED,
+  useTransactionObservation_DEPRECATED,
   useSetUnvalidatedAtomValues_UNSTABLE: useSetUnvalidatedAtomValues,
   snapshot_UNSTABLE: freshSnapshot,
 


### PR DESCRIPTION
Summary: Mark `useTransactionObservation_UNSTABLE()` as `useTransactionObservation_DEPRECATED()` now that the `recoil-sync` library is mostly available.

Differential Revision: D31949261

