### PR TITLE
Add isReset parameter to onSet() atom effect callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,18 @@
 
 ***Add new changes here as they land***
 
-- Allow class instances in family parameters for Flow
-- Add `getLoadable()`, `getPromise()`, and `getInfo_UNSTABLE()` to Atom Effects interface for reading other atoms.
-- Atoms freeze default, initialized, and async values in dev mode.  Selectors should not freeze upstream dependencies. (#1261, #1259)
 - Added `useRecoilRefresher_UNSTABLE()` hook which forces a selector to re-run it's `get()`, and is a no-op for an atom. (#972)
+- Atom effect improvements:
+  - Add `getLoadable()`, `getPromise()`, and `getInfo_UNSTABLE()` to Atom Effects interface for reading other atoms.
+  - Add `isReset` parameter to `onSet()` callback to know if the atom is being reset or not. (#1345)
 - `Loadable` improvements:
-  - Publish `RecoilLoadable` interface with factories and type checking for Loadables
+  - Publish `RecoilLoadable` interface with factories and type checking for Loadables.
   - Ability to map Loadables with other Loadables.
   - Re-implement Loadable as classes.
-- Perform runtime check in dev mode that required options are provided when creating atoms and selectors. (#1324)
+- Improved dev-mode checks:
+  - Atoms freeze default, initialized, and async values.  Selectors should not freeze upstream dependencies. (#1261, #1259)
+  - Perform runtime check that required options are provided when creating atoms and selectors. (#1324)
+- Allow class instances in family parameters for Flow
 
 ### Pending
 - Memory management

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -89,7 +89,7 @@ export type AtomEffect<T> = (param: {
  // Subscribe callbacks to events.
  // Atom effect observers are called before global transaction observers
  onSet: (
-   param: (newValue: T, oldValue: T | DefaultValue) => void,
+   param: (newValue: T, oldValue: T | DefaultValue, isReset: boolean) => void,
  ) => void,
 }) => void | (() => void);
 

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -563,8 +563,10 @@ isRecoilValue(mySelector1);
         setSelf(1);
         setSelf('a'); // $ExpectError
 
-        onSet(val => {
+        onSet((val, oldVal, isReset) => {
           val; // $ExpectType number
+          oldVal; // $ExpectType number | DefaultValue
+          isReset; // $ExpectType boolean
         });
         onSet('a'); // $ExpectError
 


### PR DESCRIPTION
Summary:
Add `isReset` parameter to an atom effect's `onSet()` callback to know if an atom is being reset or not.

I'm not super happy using positional parameters for this, as it means having to ignore the middle one in some cases, but seems the most straightforward..

Example usage:
```
const localStorageEffect = key => ({setSelf, onSet}) => {
  const savedValue = localStorage.getItem(key)
  if (savedValue != null) {
    setSelf(JSON.parse(savedValue));
  }
  onSet((newValue, _oldValue, isReset) => {
    if (isReset) {
      localStorage.removeItem(key);
    } else {
      localStorage.setItem(key, JSON.stringify(newValue));
    }
  });
};
```

Differential Revision: D31971419

