### PR TITLE
Rename storeKey and itemKey

### DIFF
--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -23,14 +23,14 @@ const React = require('react');
 // ////////////////////////////
 
 function TestURLSync({
-  syncKey,
+  storeKey,
   location,
 }: {
-  syncKey?: string,
+  storeKey?: string,
   location: LocationOption,
 }): React.Node {
   useRecoilURLSync({
-    syncKey,
+    storeKey,
     location,
     serialize: items => {
       const str = nullthrows(JSON.stringify(items));

--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -41,27 +41,13 @@ function TestURLSync({
     deserialize: str => {
       const stateStr =
         location.part === 'href' ? decodeURIComponent(str.split('#')[1]) : str;
-      // Skip the default URL parts which don't conform to the serialized standard
-      if (
-        stateStr == null ||
-        stateStr === 'anchor' ||
-        stateStr === 'foo=bar' ||
-        stateStr === 'bar'
-      ) {
+      // Skip the default URL parts which don't conform to the serialized standard.
+      // 'bar' also doesn't conform, but we want to test coexistence of foreign
+      // query parameters.
+      if (stateStr == null || stateStr === 'anchor' || stateStr === 'foo=bar') {
         return {};
       }
-      try {
-        return JSON.parse(stateStr);
-      } catch (e) {
-        // eslint-disable-next-line fb-www/no-console
-        console.error(
-          'Error parsing: ',
-          location,
-          stateStr,
-          decodeURI(stateStr),
-        );
-        throw e;
-      }
+      return JSON.parse(stateStr);
     },
   });
   return null;

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -33,16 +33,16 @@ const {asType, match, number, string} = require('refine');
 // Mock Storage
 ////////////////////////////
 function TestRecoilSync({
-  syncKey,
+  storeKey,
   storage,
   regListen,
 }: {
-  syncKey?: string,
+  storeKey?: string,
   storage: Map<string, Loadable<mixed>>,
   regListen?: ListenInterface => void,
 }) {
   useRecoilSync({
-    syncKey,
+    storeKey,
     read: itemKey => {
       if (itemKey === 'error') {
         throw new Error('READ ERROR');
@@ -120,12 +120,12 @@ test('Write to multiple storages', async () => {
   const atomA = atom({
     key: 'recoil-sync multiple storage A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({syncKey: 'A', refine: string()})],
+    effects_UNSTABLE: [syncEffect({storeKey: 'A', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync multiple storage B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({syncKey: 'B', refine: string()})],
+    effects_UNSTABLE: [syncEffect({storeKey: 'B', refine: string()})],
   });
 
   const storageA = new Map();
@@ -135,8 +135,8 @@ test('Write to multiple storages', async () => {
   const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
   renderElements(
     <>
-      <TestRecoilSync syncKey="A" storage={storageA} />
-      <TestRecoilSync syncKey="B" storage={storageB} />
+      <TestRecoilSync storeKey="A" storage={storageA} />
+      <TestRecoilSync storeKey="B" storage={storageB} />
       <AtomA />
       <AtomB />
     </>,
@@ -227,7 +227,7 @@ test('Read from storage error', async () => {
     key: 'recoil-sync read error C',
     default: 'DEFAULT',
     // <TestRecoilSync> will throw error if the key is "error"
-    effects_UNSTABLE: [syncEffect({key: 'error', refine: string()})],
+    effects_UNSTABLE: [syncEffect({itemKey: 'error', refine: string()})],
   });
   const atomD = atom({
     key: 'recoil-sync read error D',
@@ -235,7 +235,7 @@ test('Read from storage error', async () => {
     // <TestRecoilSync> will throw error if the key is "error"
     effects_UNSTABLE: [
       syncEffect({
-        key: 'error',
+        itemKey: 'error',
         refine: string(),
         actionOnFailure: 'defaultValue',
       }),
@@ -484,8 +484,8 @@ test('Read/Write from storage upgrade', async () => {
     key: 'recoil-sync read/write upgrade key',
     default: 'DEFAULT',
     effects_UNSTABLE: [
-      syncEffect({key: 'OLD KEY', refine: string()}),
-      syncEffect({key: 'NEW KEY', refine: string()}),
+      syncEffect({itemKey: 'OLD KEY', refine: string()}),
+      syncEffect({itemKey: 'NEW KEY', refine: string()}),
     ],
   });
   const atomC = atom({
@@ -493,7 +493,7 @@ test('Read/Write from storage upgrade', async () => {
     default: 'DEFAULT',
     effects_UNSTABLE: [
       syncEffect({refine: string()}),
-      syncEffect({syncKey: 'OTHER_SYNC', refine: string()}),
+      syncEffect({storeKey: 'OTHER_SYNC', refine: string()}),
     ],
   });
 
@@ -512,7 +512,7 @@ test('Read/Write from storage upgrade', async () => {
   const container = renderElements(
     <>
       <TestRecoilSync storage={storage1} />
-      <TestRecoilSync storage={storage2} syncKey="OTHER_SYNC" />
+      <TestRecoilSync storage={storage2} storeKey="OTHER_SYNC" />
       <AtomA />
       <AtomB />
       <AtomC />
@@ -552,22 +552,22 @@ test('Listen to storage', async () => {
   const atomA = atom({
     key: 'recoil-sync listen',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({syncKey: 'SYNC_1', refine: string()})],
+    effects_UNSTABLE: [syncEffect({storeKey: 'SYNC_1', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync listen to multiple keys',
     default: 'DEFAULT',
     effects_UNSTABLE: [
-      syncEffect({syncKey: 'SYNC_1', key: 'KEY A', refine: string()}),
-      syncEffect({syncKey: 'SYNC_1', key: 'KEY B', refine: string()}),
+      syncEffect({storeKey: 'SYNC_1', itemKey: 'KEY A', refine: string()}),
+      syncEffect({storeKey: 'SYNC_1', itemKey: 'KEY B', refine: string()}),
     ],
   });
   const atomC = atom({
     key: 'recoil-sync listen to multiple storage',
     default: 'DEFAULT',
     effects_UNSTABLE: [
-      syncEffect({syncKey: 'SYNC_1', refine: string()}),
-      syncEffect({syncKey: 'SYNC_2', refine: string()}),
+      syncEffect({storeKey: 'SYNC_1', refine: string()}),
+      syncEffect({storeKey: 'SYNC_2', refine: string()}),
     ],
   });
 
@@ -592,7 +592,7 @@ test('Listen to storage', async () => {
   const container = renderElements(
     <>
       <TestRecoilSync
-        syncKey="SYNC_1"
+        storeKey="SYNC_1"
         storage={storage1}
         regListen={listenInterface => {
           updateItem1 = listenInterface.updateItem;
@@ -600,7 +600,7 @@ test('Listen to storage', async () => {
         }}
       />
       <TestRecoilSync
-        syncKey="SYNC_2"
+        storeKey="SYNC_2"
         storage={storage2}
         regListen={listenInterface => {
           updateItem2 = listenInterface.updateItem;
@@ -872,17 +872,17 @@ test('Sync based on component props', async () => {
   const atomA = atom({
     key: 'recoil-sync from props spam',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({key: 'spam', refine: string()})],
+    effects_UNSTABLE: [syncEffect({itemKey: 'spam', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync from props eggs',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({key: 'eggs', refine: string()})],
+    effects_UNSTABLE: [syncEffect({itemKey: 'eggs', refine: string()})],
   });
   const atomC = atom({
     key: 'recoil-sync from props default',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({key: 'default', refine: string()})],
+    effects_UNSTABLE: [syncEffect({itemKey: 'default', refine: string()})],
   });
 
   const container = renderElements(
@@ -901,7 +901,7 @@ test('Sync Atom Family', async () => {
   const atoms = atomFamily({
     key: 'recoil-sync atom family',
     default: 'DEFAULT',
-    effects_UNSTABLE: param => [syncEffect({key: param, refine: string()})],
+    effects_UNSTABLE: param => [syncEffect({itemKey: param, refine: string()})],
   });
 
   const storage = new Map([
@@ -926,7 +926,7 @@ test('Reading before sync hook', async () => {
   const atoms = atomFamily({
     key: 'recoil-sync order',
     default: 'DEFAULT',
-    effects_UNSTABLE: param => [syncEffect({key: param, refine: string()})],
+    effects_UNSTABLE: param => [syncEffect({itemKey: param, refine: string()})],
   });
 
   function SyncOrder() {

--- a/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
@@ -38,12 +38,12 @@ describe('Test URL Persistence', () => {
     const atomA = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [urlSyncEffect({key: 'a', refine: string()})],
+      effects_UNSTABLE: [urlSyncEffect({itemKey: 'a', refine: string()})],
     });
     const atomB = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [urlSyncEffect({key: 'b', refine: string()})],
+      effects_UNSTABLE: [urlSyncEffect({itemKey: 'b', refine: string()})],
     });
     const ignoreAtom = atom({
       key: nextKey(),
@@ -111,14 +111,14 @@ describe('Test URL Persistence', () => {
       key: 'recoil-url-sync multiple param A',
       default: 'DEFAULT',
       effects_UNSTABLE: [
-        syncEffect({syncKey: 'A', key: 'x', refine: string()}),
+        syncEffect({storeKey: 'A', itemKey: 'x', refine: string()}),
       ],
     });
     const atomB = atom({
       key: 'recoil-url-sync multiple param B',
       default: 'DEFAULT',
       effects_UNSTABLE: [
-        syncEffect({syncKey: 'B', key: 'x', refine: string()}),
+        syncEffect({storeKey: 'B', itemKey: 'x', refine: string()}),
       ],
     });
 
@@ -126,8 +126,8 @@ describe('Test URL Persistence', () => {
     const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
     renderElements(
       <>
-        <TestURLSync syncKey="A" location={locA} />
-        <TestURLSync syncKey="B" location={locB} />
+        <TestURLSync storeKey="A" location={locA} />
+        <TestURLSync storeKey="B" location={locB} />
         <AtomA />
         <AtomB />
       </>,
@@ -145,17 +145,17 @@ describe('Test URL Persistence', () => {
     const atomA = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({key: 'a', refine: string()})],
+      effects_UNSTABLE: [syncEffect({itemKey: 'a', refine: string()})],
     });
     const atomB = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({key: 'b', refine: string()})],
+      effects_UNSTABLE: [syncEffect({itemKey: 'b', refine: string()})],
     });
     const atomC = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({key: 'c', refine: string()})],
+      effects_UNSTABLE: [syncEffect({itemKey: 'c', refine: string()})],
     });
 
     history.replaceState(
@@ -284,8 +284,8 @@ describe('Test URL Persistence', () => {
       key: 'recoil-url-sync read/write upgrade key',
       default: 'DEFAULT',
       effects_UNSTABLE: [
-        syncEffect({key: 'OLD KEY', refine: string()}),
-        syncEffect({key: 'NEW KEY', refine: string()}),
+        syncEffect({itemKey: 'OLD KEY', refine: string()}),
+        syncEffect({itemKey: 'NEW KEY', refine: string()}),
       ],
     });
     const atomC = atom({
@@ -293,7 +293,7 @@ describe('Test URL Persistence', () => {
       default: 'DEFAULT',
       effects_UNSTABLE: [
         syncEffect({refine: string()}),
-        syncEffect({syncKey: 'SYNC_2', refine: string()}),
+        syncEffect({storeKey: 'SYNC_2', refine: string()}),
       ],
     });
 
@@ -324,7 +324,7 @@ describe('Test URL Persistence', () => {
     const container = renderElements(
       <>
         <TestURLSync location={loc1} />
-        <TestURLSync location={loc2} syncKey="SYNC_2" />
+        <TestURLSync location={loc2} storeKey="SYNC_2" />
         <AtomA />
         <AtomB />
         <AtomC />

--- a/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
@@ -93,15 +93,20 @@ describe('Test URL Persistence', () => {
       expect(new URL(location.href).searchParams.get('foo')).toBe(null);
       expect(new URL(location.href).searchParams.get('bar')).toBe(null);
     }));
-  test('Write to URL - Query Search Param', () =>
-    testWriteToURL({part: 'search', queryParam: 'bar'}, () => {
+  test('Write to URL - Query Params', () =>
+    testWriteToURL({part: 'queryParams'}, () => {
+      expect(location.hash).toBe('#anchor');
+      expect(new URL(location.href).searchParams.get('foo')).toBe('bar');
+    }));
+  test('Write to URL - Query Param', () =>
+    testWriteToURL({part: 'queryParams', param: 'bar'}, () => {
       expect(location.hash).toBe('#anchor');
       expect(new URL(location.href).searchParams.get('foo')).toBe('bar');
     }));
 
   test('Write to multiple params', async () => {
-    const locA = {part: 'search', queryParam: 'paramA'};
-    const locB = {part: 'search', queryParam: 'paramB'};
+    const locA = {part: 'queryParams', param: 'paramA'};
+    const locB = {part: 'queryParams', param: 'paramB'};
     const atomA = atom({
       key: 'recoil-url-sync multiple param A',
       default: 'DEFAULT',
@@ -182,10 +187,12 @@ describe('Test URL Persistence', () => {
   test('Read from URL', () => testReadFromURL({part: 'href'}));
   test('Read from URL - Anchor Hash', () => testReadFromURL({part: 'hash'}));
   test('Read from URL - Search Query', () => testReadFromURL({part: 'search'}));
-  test('Read from URL - Search Query Param', () =>
-    testReadFromURL({part: 'search', queryParam: 'param'}));
-  test('Read from URL - Search Query Param with other param', () =>
-    testReadFromURL({part: 'search', queryParam: 'other'}));
+  test('Read from URL - Query Params', () =>
+    testReadFromURL({part: 'queryParams'}));
+  test('Read from URL - Query Param', () =>
+    testReadFromURL({part: 'queryParams', param: 'param'}));
+  test('Read from URL - Query Param with other param', () =>
+    testReadFromURL({part: 'queryParams', param: 'other'}));
 
   test('Read from URL upgrade', async () => {
     const loc = {part: 'hash'};
@@ -258,8 +265,8 @@ describe('Test URL Persistence', () => {
   });
 
   test('Read/Write from URL with upgrade', async () => {
-    const loc1 = {part: 'search', queryParam: 'param1'};
-    const loc2 = {part: 'search', queryParam: 'param2'};
+    const loc1 = {part: 'queryParams', param: 'param1'};
+    const loc2 = {part: 'queryParams', param: 'param2'};
 
     const atomA = atom<string>({
       key: 'recoil-url-sync read/write upgrade type',

--- a/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
@@ -25,8 +25,8 @@ const React = require('react');
 const {string} = require('refine');
 
 test('Listen to URL changes', async () => {
-  const locFoo = {part: 'search', queryParam: 'foo'};
-  const locBar = {part: 'search', queryParam: 'bar'};
+  const locFoo = {part: 'queryParams', param: 'foo'};
+  const locBar = {part: 'queryParams', param: 'bar'};
 
   const atomA = atom({
     key: 'recoil-url-sync listen',

--- a/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
@@ -31,22 +31,22 @@ test('Listen to URL changes', async () => {
   const atomA = atom({
     key: 'recoil-url-sync listen',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({syncKey: 'foo', refine: string()})],
+    effects_UNSTABLE: [syncEffect({storeKey: 'foo', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-url-sync listen to multiple keys',
     default: 'DEFAULT',
     effects_UNSTABLE: [
-      syncEffect({syncKey: 'foo', key: 'KEY A', refine: string()}),
-      syncEffect({syncKey: 'foo', key: 'KEY B', refine: string()}),
+      syncEffect({storeKey: 'foo', itemKey: 'KEY A', refine: string()}),
+      syncEffect({storeKey: 'foo', itemKey: 'KEY B', refine: string()}),
     ],
   });
   const atomC = atom({
     key: 'recoil-url-sync listen to multiple storage',
     default: 'DEFAULT',
     effects_UNSTABLE: [
-      syncEffect({syncKey: 'foo', refine: string()}),
-      syncEffect({syncKey: 'bar', refine: string()}),
+      syncEffect({storeKey: 'foo', refine: string()}),
+      syncEffect({storeKey: 'bar', refine: string()}),
     ],
   });
 
@@ -67,8 +67,8 @@ test('Listen to URL changes', async () => {
 
   const container = renderElements(
     <>
-      <TestURLSync syncKey="foo" location={locFoo} />
-      <TestURLSync syncKey="bar" location={locBar} />
+      <TestURLSync storeKey="foo" location={locFoo} />
+      <TestURLSync storeKey="bar" location={locBar} />
       <ReadsAtom atom={atomA} />
       <ReadsAtom atom={atomB} />
       <ReadsAtom atom={atomC} />

--- a/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
@@ -24,7 +24,7 @@ const React = require('react');
 const {string} = require('refine');
 
 test('Push URLs in browser history', async () => {
-  const loc = {part: 'search', queryParam: 'push'};
+  const loc = {part: 'queryParams'};
 
   const atomA = atom({
     key: 'recoil-url-sync replace',

--- a/packages/recoil-sync/util/RecoilSync_nullthrows.js
+++ b/packages/recoil-sync/util/RecoilSync_nullthrows.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @emails oncall+recoil
- * @flow strict
+ * @flow strict-local
  * @format
  */
 'use strict';
 
-const err = require('./Recoil_err');
+const err = require('./RecoilSync_err');
 
 function nullthrows<T>(x: ?T, message: ?string): T {
   if (x != null) {

--- a/packages/recoil-sync/util/RecoilSync_objectFromEntries.js
+++ b/packages/recoil-sync/util/RecoilSync_objectFromEntries.js
@@ -11,7 +11,7 @@
 'use strict';
 
 // Object.fromEntries() is not available in GitHub's version of Node.js (9/21/2021)
-function objectFromEntries<T>(entries: $ReadOnlyArray<[string, T]>): {
+function objectFromEntries<T>(entries: Iterable<[string, T]>): {
   [string]: T,
 } {
   const obj = {};


### PR DESCRIPTION
Summary:
Rename option properties `key` -> `itemKey` and `syncKey` -> `storeKey`.

Based on initial user confusion/feedback, do this rename to help better clarify what the two types of keys are:

* *`storeKey`* - Key per external storage system.  There is a single `storeKey` per `useRecoilSync()` hook usage when establishing each of the possible storages to sync with.  This key may be undefined as a value.
* *`itemKey`* - Key per individual atom.  Each atom may specify an `itemKey` to uniquely identify it within a store.  If not specified it defaults to the atom's key.  Note that advanced use cases do allow atoms to have multiple keys or read/write from multiple items in the external store.

Reviewed By: geekster777

Differential Revision: D31878058

