### PR TITLE
upgrade prettier to match internal version & format codebase

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "overrides": [
     {
       "files": ["*.js"],

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "install-peers-cli": "^2.2.0",
     "jest-cli": "^26.0.1",
     "lint-staged": ">=10",
-    "prettier": "^2.0.5",
+    "prettier": "^2.1.4",
     "promise-polyfill": "^8.1.3",
     "react": ">=16.13.1",
     "react-dom": ">=16.13.1",

--- a/packages/recoil-sync/package.json
+++ b/packages/recoil-sync/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "recoil-sync",
-    "description": "This is the internal package.json enabling CommonJS module",
-    "main": "RecoilSync_index.js",
-    "haste_commonjs": true,
-    "files": [
-      "RecoilSync_index.js"
-    ],
-    "directories": {
-      "": "./"
-    },
-    "repository": "https://github.com/facebookexperimental/Recoil.git",
-    "license": "MIT"
-  }
+  "name": "recoil-sync",
+  "description": "This is the internal package.json enabling CommonJS module",
+  "main": "RecoilSync_index.js",
+  "haste_commonjs": true,
+  "files": [
+    "RecoilSync_index.js"
+  ],
+  "directories": {
+    "": "./"
+  },
+  "repository": "https://github.com/facebookexperimental/Recoil.git",
+  "license": "MIT"
+}

--- a/packages/recoil/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/recoil/__test_utils__/Recoil_TestingUtils.js
@@ -268,36 +268,35 @@ type TestOptions = {
 };
 type TestFn = (string, AssertionsFn, TestOptions | void) => void;
 
-const testGKs = (
-  reloadImports: ReloadImports,
-  gks: Array<Array<string>>,
-): TestFn => (
-  testDescription: string,
-  assertionsFn: AssertionsFn,
-  {gks: additionalGKs = []}: TestOptions = {},
-) => {
-  test.each([
-    ...[...gks, ...additionalGKs].map(gksToTest => [
-      !gksToTest.length
-        ? testDescription
-        : `${testDescription} [${gksToTest.join(', ')}]`,
-      gksToTest,
-    ]),
-  ])('%s', async (_title, gksToTest) => {
-    jest.resetModules();
+const testGKs =
+  (reloadImports: ReloadImports, gks: Array<Array<string>>): TestFn =>
+  (
+    testDescription: string,
+    assertionsFn: AssertionsFn,
+    {gks: additionalGKs = []}: TestOptions = {},
+  ) => {
+    test.each([
+      ...[...gks, ...additionalGKs].map(gksToTest => [
+        !gksToTest.length
+          ? testDescription
+          : `${testDescription} [${gksToTest.join(', ')}]`,
+        gksToTest,
+      ]),
+    ])('%s', async (_title, gksToTest) => {
+      jest.resetModules();
 
-    const gkx = require('../util/Recoil_gkx');
+      const gkx = require('../util/Recoil_gkx');
 
-    gksToTest.forEach(gkx.setPass);
+      gksToTest.forEach(gkx.setPass);
 
-    const after = reloadImports();
-    await assertionsFn(gksToTest);
+      const after = reloadImports();
+      await assertionsFn(gksToTest);
 
-    gksToTest.forEach(gkx.setFail);
+      gksToTest.forEach(gkx.setFail);
 
-    after?.();
-  });
-};
+      after?.();
+    });
+  };
 
 // TODO Remove the recoil_suppress_rerender_in_callback GK checks
 const WWW_GKS_TO_TEST = [

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -244,14 +244,13 @@ class Snapshot {
   };
 
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  asyncMap: (
-    (MutableSnapshot) => Promise<void>,
-  ) => Promise<Snapshot> = async mapper => {
-    this.checkRefCount_INTERNAL();
-    const mutableSnapshot = new MutableSnapshot(this, batchUpdates);
-    await mapper(mutableSnapshot);
-    return cloneSnapshot(mutableSnapshot.getStore_INTERNAL());
-  };
+  asyncMap: ((MutableSnapshot) => Promise<void>) => Promise<Snapshot> =
+    async mapper => {
+      this.checkRefCount_INTERNAL();
+      const mutableSnapshot = new MutableSnapshot(this, batchUpdates);
+      await mapper(mutableSnapshot);
+      return cloneSnapshot(mutableSnapshot.getStore_INTERNAL());
+    };
 }
 
 function cloneStoreState(

--- a/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -116,9 +116,8 @@ testRecoil(
     }
 
     // After reading values
-    const [ReadWriteAtom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(
-      myAtom,
-    );
+    const [ReadWriteAtom, setAtom, resetAtom] =
+      componentThatReadsAndWritesAtom(myAtom);
     const c = renderElements(
       <>
         <GetRecoilValueInfo />

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -128,8 +128,16 @@ describe('useRecoilCallback', () => {
     let setCB, resetCB;
 
     function Component() {
-      setCB = useRecoilCallback(({set}) => value => set(anAtom, value));
-      resetCB = useRecoilCallback(({reset}) => () => reset(anAtom));
+      setCB = useRecoilCallback(
+        ({set}) =>
+          value =>
+            set(anAtom, value),
+      );
+      resetCB = useRecoilCallback(
+        ({reset}) =>
+          () =>
+            reset(anAtom),
+      );
       return null;
     }
 

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilInterface-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilInterface-test.js
@@ -57,9 +57,8 @@ testRecoil('Interface for non-react code - useRecoilState', () => {
 
 testRecoil('Interface for non-react code - useRecoilStateNoThrow', () => {
   function nonReactCode(recoilInterface) {
-    const [loadable, setValue] = recoilInterface.getRecoilStateLoadable(
-      counterAtom,
-    );
+    const [loadable, setValue] =
+      recoilInterface.getRecoilStateLoadable(counterAtom);
     const value = loadable.state === 'hasValue' ? loadable.contents : null;
     return [value, setValue];
   }

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilStateReset-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilStateReset-test.js
@@ -43,9 +43,8 @@ testRecoil('useRecoilValueReset - value default', () => {
     default: 'default',
   });
 
-  const [Component, setValue, resetValue] = componentThatReadsAndWritesAtom(
-    myAtom,
-  );
+  const [Component, setValue, resetValue] =
+    componentThatReadsAndWritesAtom(myAtom);
   const container = renderElements(<Component />);
   expect(container.textContent).toBe('"default"');
   act(() => setValue('set value'));
@@ -64,9 +63,8 @@ testRecoil('useResetRecoilState - sync selector default', () => {
     default: mySelector,
   });
 
-  const [Component, setValue, resetValue] = componentThatReadsAndWritesAtom(
-    myAtom,
-  );
+  const [Component, setValue, resetValue] =
+    componentThatReadsAndWritesAtom(myAtom);
   const container = renderElements(<Component />);
   expect(container.textContent).toBe('"fallback"');
   act(() => setValue('set value'));
@@ -83,9 +81,8 @@ testRecoil('useResetRecoilState - async selector default', () => {
     default: mySelector,
   });
 
-  const [Component, setValue, resetValue] = componentThatReadsAndWritesAtom(
-    myAtom,
-  );
+  const [Component, setValue, resetValue] =
+    componentThatReadsAndWritesAtom(myAtom);
   const container = renderElements(<Component />);
   expect(container.textContent).toBe('loading');
   act(() => setValue('set value'));
@@ -109,9 +106,8 @@ testRecoil('useResetRecoilState - scoped atom', () => {
     ],
   });
 
-  const [Component, setValue, resetValue] = componentThatReadsAndWritesAtom(
-    myAtom,
-  );
+  const [Component, setValue, resetValue] =
+    componentThatReadsAndWritesAtom(myAtom);
   const container = renderElements(<Component />);
   expect(container.textContent).toBe('"default"');
   act(() => setValue('set value'));
@@ -165,9 +161,8 @@ testRecoil('useResetRecoilState - selector', () => {
     set: ({set}, value) => set(myAtom, value),
   });
 
-  const [Component, setValue, resetValue] = componentThatReadsAndWritesAtom(
-    mySelector,
-  );
+  const [Component, setValue, resetValue] =
+    componentThatReadsAndWritesAtom(mySelector);
   const container = renderElements(<Component />);
   expect(container.textContent).toBe('"default"');
   act(() => setValue('set value'));
@@ -183,8 +178,14 @@ testRecoil('useResetRecoilState - parameterized selector', () => {
   });
   const mySelector = selectorFamily({
     key: 'useResetRecoilState/parameterized_selector',
-    get: () => ({get}) => get(myAtom),
-    set: () => ({set}, value) => set(myAtom, value),
+    get:
+      () =>
+      ({get}) =>
+        get(myAtom),
+    set:
+      () =>
+      ({set}, value) =>
+        set(myAtom, value),
   });
 
   const [Component, setValue, resetValue] = componentThatReadsAndWritesAtom(

--- a/packages/recoil/recoil_values/__tests__/Recoil_WaitFor-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_WaitFor-test.js
@@ -167,8 +167,7 @@ testRecoil('waitFor - resolve to values', async () => {
   // waitForAll returns a promise that resolves to the actual values
   expect(get(waitForAll(deps))).toBeInstanceOf(Promise);
   const allTest0 = expect(getPromise(waitForAll(deps))).resolves.toEqual([
-    0,
-    1,
+    0, 1,
   ]);
 
   // Resolve the first dep
@@ -181,8 +180,7 @@ testRecoil('waitFor - resolve to values', async () => {
   expect(get(waitForAll(deps))).toBeInstanceOf(Promise);
 
   const allTest1 = expect(getPromise(waitForAll(deps))).resolves.toEqual([
-    0,
-    1,
+    0, 1,
   ]);
 
   // Resolve the second dep

--- a/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -414,7 +414,10 @@ testRecoil(
       key: 'notDefinedYetAtomFamilyFallbackSel',
       default: selectorFamily({
         key: 'notDefinedYetAtomFamilyFallbackSelFallback',
-        get: ({num}) => () => (num === 1 ? 456 : 789),
+        get:
+          ({num}) =>
+          () =>
+            num === 1 ? 456 : 789,
       }),
       persistence_UNSTABLE: {
         type: 'url',

--- a/packages/recoil/recoil_values/__tests__/Recoil_selectorFamily-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selectorFamily-test.js
@@ -52,7 +52,10 @@ function set(recoilValue, value) {
 testRecoil('selectorFamily - number parameter', () => {
   const mySelector = selectorFamily({
     key: 'selectorFamily/number',
-    get: multiplier => ({get}) => get(myAtom) * multiplier,
+    get:
+      multiplier =>
+      ({get}) =>
+        get(myAtom) * multiplier,
   });
 
   set(myAtom, 1);
@@ -77,7 +80,10 @@ testRecoil('selectorFamily - array parameter', () => {
 testRecoil('selectorFamily - object parameter', () => {
   const mySelector = selectorFamily({
     key: 'selectorFamily/object',
-    get: ({multiplier}) => ({get}) => get(myAtom) * multiplier,
+    get:
+      ({multiplier}) =>
+      ({get}) =>
+        get(myAtom) * multiplier,
   });
 
   set(myAtom, 1);
@@ -91,14 +97,16 @@ testRecoil('selectorFamily - object parameter', () => {
 testRecoil('selectorFamily - date parameter', () => {
   const mySelector = selectorFamily({
     key: 'selectorFamily/date',
-    get: date => ({get}) => {
-      const daysToAdd = get(myAtom);
-      const returnDate = new Date(date);
+    get:
+      date =>
+      ({get}) => {
+        const daysToAdd = get(myAtom);
+        const returnDate = new Date(date);
 
-      returnDate.setDate(returnDate.getDate() + daysToAdd);
+        returnDate.setDate(returnDate.getDate() + daysToAdd);
 
-      return returnDate;
-    },
+        return returnDate;
+      },
   });
 
   set(myAtom, 1);
@@ -112,7 +120,10 @@ testRecoil('selectorFamily - date parameter', () => {
 testRecoil('Works with supersets', () => {
   const mySelector = selectorFamily({
     key: 'selectorFamily/supersets',
-    get: ({multiplier}) => ({get}) => get(myAtom) * multiplier,
+    get:
+      ({multiplier}) =>
+      ({get}) =>
+        get(myAtom) * multiplier,
   });
   set(myAtom, 1);
   expect(getValue(mySelector({multiplier: 10}))).toBe(10);
@@ -123,9 +134,14 @@ testRecoil('Works with supersets', () => {
 testRecoil('selectorFamily - writable', () => {
   const mySelector = selectorFamily({
     key: 'selectorFamily/writable',
-    get: ({multiplier}) => ({get}) => get(myAtom) * multiplier,
-    set: ({multiplier}) => ({set}, num) =>
-      set(myAtom, num instanceof DefaultValue ? num : num / multiplier),
+    get:
+      ({multiplier}) =>
+      ({get}) =>
+        get(myAtom) * multiplier,
+    set:
+      ({multiplier}) =>
+      ({set}, num) =>
+        set(myAtom, num instanceof DefaultValue ? num : num / multiplier),
   });
 
   set(myAtom, 1);
@@ -142,10 +158,12 @@ testRecoil('selectorFamily - value caching', () => {
   let evals = 0;
   const mySelector = selectorFamily({
     key: 'selectorFamily/value caching',
-    get: ({multiplier}) => ({get}) => {
-      evals++;
-      return get(myAtom) * multiplier;
-    },
+    get:
+      ({multiplier}) =>
+      ({get}) => {
+        evals++;
+        return get(myAtom) * multiplier;
+      },
   });
 
   expect(evals).toBe(0);
@@ -177,10 +195,12 @@ testRecoil('selectorFamily - reference caching', () => {
   let evals = 0;
   const mySelector = selectorFamily({
     key: 'selectorFamily/reference caching',
-    get: ({multiplier}) => ({get}) => {
-      evals++;
-      return get(myAtom) * multiplier;
-    },
+    get:
+      ({multiplier}) =>
+      ({get}) => {
+        evals++;
+        return get(myAtom) * multiplier;
+      },
     cachePolicyForParams_UNSTABLE: {
       equality: 'reference',
     },
@@ -241,7 +261,9 @@ testRecoil('selectorFamily - reference caching', () => {
 testRecoil('selectorFamily - mutability', () => {
   const myImmutableSelector = selectorFamily({
     key: 'selectorFamily/immutable',
-    get: ({key}) => ({get}) => ({[key]: get(myAtom)}),
+    get:
+      ({key}) =>
+      ({get}) => ({[key]: get(myAtom)}),
   });
   set(myAtom, 42);
   const immutableResult: {[string]: number, ...} = getValue(
@@ -254,7 +276,9 @@ testRecoil('selectorFamily - mutability', () => {
 
   const myMutableSelector = selectorFamily({
     key: 'selectorFamily/mutable',
-    get: ({key}) => ({get}) => ({[key]: get(myAtom)}),
+    get:
+      ({key}) =>
+      ({get}) => ({[key]: get(myAtom)}),
     dangerouslyAllowMutability: true,
   });
   set(myAtom, 42);
@@ -271,7 +295,7 @@ testRecoil('selectorFamily - evaluate to RecoilValue', () => {
   const atomB = atom({key: 'selectorFamily/const atom B', default: 'B'});
   const mySelector = selectorFamily<string, string>({
     key: 'selectorFamily/',
-    get: param => () => (param === 'a' ? atomA : atomB),
+    get: param => () => param === 'a' ? atomA : atomB,
   });
 
   expect(getValue(mySelector('a'))).toEqual('A');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3978,9 +3978,10 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prettier@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+prettier@^2.1.4:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 pretty-format@^26.0.1:
   version "26.0.1"


### PR DESCRIPTION
- Upgrade prettier to ^2.4.1
- `jsxBracketSameLine` is now `bracketSameLine` according to https://prettier.io/docs/en/options.html#deprecated-jsx-brackets
- format files using `prettier --write` (and manually get rid of unwanted indent changes caused by `@fb-only` lines)