### PR TITLE
custom() checker catches errors as failures

### DIFF
--- a/packages/refine/Refine_UtilityCheckers.js
+++ b/packages/refine/Refine_UtilityCheckers.js
@@ -341,10 +341,14 @@ function custom<T>(
   failureMessage: string = `failed to return non-null from custom checker.`,
 ): Checker<T> {
   return (value, path = new Path()) => {
-    const checked = checkValue(value);
-    return checked != null
-      ? success(checked, [])
-      : failure(failureMessage, path);
+    try {
+      const checked = checkValue(value);
+      return checked != null
+        ? success(checked, [])
+        : failure(failureMessage, path);
+    } catch (error) {
+      return failure(error.message, path);
+    }
   };
 }
 

--- a/packages/refine/__tests__/Refine_Utilities-test.js
+++ b/packages/refine/__tests__/Refine_Utilities-test.js
@@ -341,4 +341,13 @@ describe('custom', () => {
     const threeResult = checkOneOrTwo(3);
     invariant(threeResult.type === 'failure', 'should fail');
   });
+
+  it('catch errors as failures', () => {
+    function userValidator() {
+      throw new Error('MY ERROR');
+    }
+    const result = custom(userValidator)();
+    invariant(result.type === 'failure', 'should fail');
+    expect(result.message).toEqual('MY ERROR');
+  });
 });


### PR DESCRIPTION
Summary:
Allow the `custom()` checker to handle thrown errors as failures.  This helps support the user pattern of:
```
effects_UNSTABLE: [
      syncEffect({
        storeKey: 'ods',
        refine: array(
          custom(value => {
            try {
              return validateQueryBuilderState(value);
            } catch {
              return null;
            }
          }),
        ),
      }),
    ],
```
Simply as:
```
effects_UNSTABLE: [
      syncEffect({
        storeKey: 'ods',
        refine: array(custom(validateQueryBuilderState)),
      }),
    ],
```

Reviewed By: bsouthga

Differential Revision: D32116643

