### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 node_modules
 
 yarn.lock
+
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ nightly-build-files
 
 # Mac
 .DS_Store
+
+# NPM Pakcage lock since we use yarn.lock
+package-lock.json


### PR DESCRIPTION
Summary:
Ignore NPM's `package-lock.json` for GitHub source repository since we are using Yarn's `yarn.lock`.

https://stackoverflow.com/questions/44552348/should-i-commit-yarn-lock-and-package-lock-json-files

Differential Revision: D32163952

