### PR TITLE
introduce maybe() checker (#1351)

### DIFF
--- a/packages/refine/Refine_UtilityCheckers.js
+++ b/packages/refine/Refine_UtilityCheckers.js
@@ -144,7 +144,7 @@ function nullable<T>(
 
   return (value, parentPath = new Path()): CheckResult<?T> => {
     if (value == null) {
-      return success(null, []);
+      return success(value, []);
     }
 
     const result = checker(value, parentPath);

--- a/packages/refine/__tests__/Refine_JSON-test.js
+++ b/packages/refine/__tests__/Refine_JSON-test.js
@@ -23,7 +23,7 @@ describe('json', () => {
     );
 
     const result = parse('{"a": "test", "c": true}');
-    expect(result).toEqual({a: 'test', b: null, c: true});
+    expect(result).toEqual({a: 'test', b: undefined, c: true});
     invariant(result != null, 'should not be null');
     expect(result.a).toEqual('test');
   });
@@ -36,7 +36,11 @@ describe('json', () => {
       MESSAGE,
     );
 
-    expect(parse('{"a": "a", "c": true}')).toEqual({a: 'a', b: null, c: true});
+    expect(parse('{"a": "a", "c": true}')).toEqual({
+      a: 'a',
+      b: undefined,
+      c: true,
+    });
     expect(() => parse('{"a": "a", "d": true}')).toThrow(new RegExp(MESSAGE));
     expect(() => parse(null)).toThrow(new RegExp(MESSAGE));
   });

--- a/packages/refine/__tests__/Refine_Utilities-test.js
+++ b/packages/refine/__tests__/Refine_Utilities-test.js
@@ -109,6 +109,14 @@ describe('nullable', () => {
     invariant(result.value === null, 'value should be true');
   });
 
+  it('should correctly parse value when undefined is provided', () => {
+    const coerce = nullable(string());
+    const result = coerce(undefined);
+
+    invariant(result.type === 'success', 'should succeed');
+    invariant(result.value === undefined, 'value should be true');
+  });
+
   it('should correctly parse nullable value when not null', () => {
     const coerce = nullable(string());
     const result = coerce('test');


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexperimental/Recoil/pull/1351

Introduces a new `maybe()` checker that returns a flow [Maybe](https://flow.org/en/docs/types/maybe/) type. The difference between this checker and `nullable()`, is that `nullable()` currently coerces `undefined` to `null`.

Reviewed By: bsouthga

Differential Revision: D31434499

