### PR TITLE
Abstract Browser URL interface

### DIFF
--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -22,7 +22,7 @@ const {
 
 const err = require('./util/RecoilSync_err');
 const React = require('react');
-const {useCallback, useEffect} = require('react');
+const {useCallback, useEffect, useRef} = require('react');
 
 type NodeKey = string;
 export type ItemKey = string;
@@ -135,8 +135,14 @@ function useRecoilSync({
 }: RecoilSyncOptions): void {
   // Subscribe to Recoil state changes
   const snapshot = useRecoilSnapshot();
+  const previousSnapshotRef = useRef(snapshot);
   useEffect(() => {
     if (write != null) {
+      if (snapshot === previousSnapshotRef.current) {
+        return;
+      } else {
+        previousSnapshotRef.current = snapshot;
+      }
       const diff: ItemDiff = new Map();
       const atomRegistry = registries.getAtomRegistry(storeKey);
       const modifiedAtoms = snapshot.getNodes_UNSTABLE({isModified: true});

--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -9,7 +9,7 @@
 
 // TODO UPDATE IMPORTS TO USE PUBLIC INTERFACE
 
-import type {LocationOption} from '../RecoilSync_URL';
+import type {BrowserInterface, LocationOption} from '../RecoilSync_URL';
 
 const {
   flushPromisesAndTimers,
@@ -25,9 +25,11 @@ const React = require('react');
 function TestURLSync({
   storeKey,
   location,
+  browserInterface,
 }: {
   storeKey?: string,
   location: LocationOption,
+  browserInterface?: BrowserInterface,
 }): React.Node {
   useRecoilURLSync({
     storeKey,
@@ -49,6 +51,7 @@ function TestURLSync({
       }
       return JSON.parse(stateStr);
     },
+    browserInterface,
   });
   return null;
 }
@@ -88,16 +91,22 @@ function encodeURLPart(href: string, loc: LocationOption, obj): string {
   return url.href;
 }
 
-function encodeURL(parts: Array<[LocationOption, {...}]>): string {
-  let href = window.location.href;
+function encodeURL(
+  parts: Array<[LocationOption, {...}]>,
+  url: string = window.location.href,
+): string {
+  let href = url;
   for (const [loc, obj] of parts) {
     href = encodeURLPart(href, loc, obj);
   }
   return href;
 }
 
-function expectURL(parts: Array<[LocationOption, {...}]>) {
-  expect(window.location.href).toBe(encodeURL(parts));
+function expectURL(
+  parts: Array<[LocationOption, {...}]>,
+  url: string = window.location.href,
+) {
+  expect(url).toBe(encodeURL(parts, url));
 }
 
 async function gotoURL(parts: Array<[LocationOption, {...}]>) {

--- a/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {act} = require('ReactTestUtils');
+const {atom} = require('Recoil');
+
+const {
+  TestURLSync,
+  expectURL: testExpectURL,
+} = require('../__test_utils__/RecoilSync_MockURLSerialization');
+const {
+  componentThatReadsAndWritesAtom,
+  renderElements,
+} = require('../../../packages/recoil/__test_utils__/Recoil_TestingUtils');
+const {urlSyncEffect} = require('../RecoilSync_URL');
+const React = require('react');
+const {string} = require('refine');
+
+const urls: Array<string> = [];
+const subscriptions: Set<() => void> = new Set();
+const currentURL = () => urls[urls.length - 1];
+const link = window.document.createElement('a');
+const absoluteURL = url => {
+  link.href = url;
+  return link.href;
+};
+const expectURL = parts => testExpectURL(parts, currentURL());
+const mockBrowserURL = {
+  replaceURL: url => {
+    urls[urls.length - 1] = absoluteURL(url);
+  },
+  pushURL: url => void urls.push(absoluteURL(url)),
+  getURL: () => new URL(absoluteURL(currentURL())),
+  listenChangeURL: handler => {
+    subscriptions.add(handler);
+    return () => void subscriptions.delete(handler);
+  },
+};
+const goBack = () => {
+  urls.pop();
+  subscriptions.forEach(handler => handler());
+};
+
+test('Push URLs in mock history', async () => {
+  const loc = {part: 'queryParams'};
+
+  const atomA = atom({
+    key: 'recoil-url-sync replace',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'replace'})],
+  });
+  const atomB = atom({
+    key: 'recoil-url-sync push',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'push'})],
+  });
+  const atomC = atom({
+    key: 'recoil-url-sync push 2',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'push'})],
+  });
+
+  const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);
+  const [AtomB, setB, resetB] = componentThatReadsAndWritesAtom(atomB);
+  const [AtomC, setC] = componentThatReadsAndWritesAtom(atomC);
+  const container = renderElements(
+    <>
+      <TestURLSync location={loc} browserInterface={mockBrowserURL} />
+      <AtomA />
+      <AtomB />
+      <AtomC />
+    </>,
+  );
+
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  const baseHistory = history.length;
+
+  // Replace A
+  // 1: A__
+  act(() => setA('A'));
+  expect(container.textContent).toBe('"A""DEFAULT""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+      },
+    ],
+  ]);
+  expect(history.length).toBe(baseHistory);
+
+  // Push B
+  // 1: A__
+  // 2: AB_
+  act(() => setB('B'));
+  expect(container.textContent).toBe('"A""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Push C
+  // 1: A__
+  // 2: AB_
+  // 3: ABC
+  act(() => setC('C'));
+  expect(container.textContent).toBe('"A""B""C"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+        'recoil-url-sync push': 'B',
+        'recoil-url-sync push 2': 'C',
+      },
+    ],
+  ]);
+
+  // Pop and confirm C is reset
+  // 1: A__
+  // 2: AB_
+  await act(goBack);
+  expect(container.textContent).toBe('"A""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Replace Reset A
+  // 1: A__
+  // 2: _B_
+  act(resetA);
+  expect(container.textContent).toBe('"DEFAULT""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Push a Reset
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  act(resetB);
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  expectURL([[loc, {}]]);
+
+  // Push BB
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  // 4: _BB_
+  act(() => setB('BB'));
+  expect(container.textContent).toBe('"DEFAULT""BB""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync push': 'BB',
+      },
+    ],
+  ]);
+
+  // Replace AA
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  // 4: AABB_
+  act(() => setA('AA'));
+  expect(container.textContent).toBe('"AA""BB""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'AA',
+        'recoil-url-sync push': 'BB',
+      },
+    ],
+  ]);
+
+  // Replace AAA
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  // 4: AAABB_
+  act(() => setA('AAA'));
+  expect(container.textContent).toBe('"AAA""BB""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'AAA',
+        'recoil-url-sync push': 'BB',
+      },
+    ],
+  ]);
+
+  // Pop
+  // 1: A__
+  // 2: _B_
+  // 3: ___
+  await act(goBack);
+  expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
+  expectURL([[loc, {}]]);
+
+  // Pop
+  // 1: A__
+  // 2: _B_
+  await act(goBack);
+  expect(container.textContent).toBe('"DEFAULT""B""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync push': 'B',
+      },
+    ],
+  ]);
+
+  // Pop
+  // 1: A__
+  await act(goBack);
+  expect(container.textContent).toBe('"A""DEFAULT""DEFAULT"');
+  expectURL([
+    [
+      loc,
+      {
+        'recoil-url-sync replace': 'A',
+      },
+    ],
+  ]);
+});


### PR DESCRIPTION
Summary:
Abstract the interface for working with the browser URL and allow the user to override it.  This can be useful to mock-out the browser, add hooks, or alter the behavior.

```
export type BrowserInterface = {
  replaceURL?: string => void,
  pushURL?: string => void,
  getURL?: () => URL,
  listenChangeURL?: (handler: () => void) => () => void,
};
```

Differential Revision: D32167597

