### PR TITLE
Add documentation for $Values<> with stringLiterals()

### DIFF
--- a/packages/refine/Refine_PrimitiveCheckers.js
+++ b/packages/refine/Refine_PrimitiveCheckers.js
@@ -102,6 +102,20 @@ function string(regex?: RegExp): Checker<string> {
  *   bar: 'eggs',
  * });
  * ```
+ *
+ * It can be useful to have a single source of truth for your literals.  To
+ * only specify them once and use it for both the Flow union type and the
+ * runtime checker you can use the following pattern:
+ * ```jsx
+ * const suits = {
+ *   heart: 'heart',
+ *   spade: 'spade',
+ *   club: 'club',
+ *   diamond: 'diamond',
+ * };
+ * type Suit = $Values<typeof suits>;
+ * const suitChecker = stringLiterls(suits);
+ * ```
  */
 function stringLiterals<T>(enumValues: {+[string]: T}): Checker<T> {
   return (value, path = new Path()) => {


### PR DESCRIPTION
Summary:
Add documentation for example of using `$Values<>` to get a single source of truth for a Flow union of string literals and the values for a `stringLiterals()` checker.

We usually used `$Keys<>`, but if any values are mapped `$Values<>` would be more appropriate, assuming it works.

Differential Revision: D32191747

