### PR TITLE
ignore /docs for oss lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 node_modules
 
 yarn.lock
+
+docs


### PR DESCRIPTION
Summary: When switching between `docs` and `main` branches on a local checkout and building the docs a `/docs` directory can be left behind which has lots of lint failures.  Suppresses this for `yarn lint` to avoid noise.

Differential Revision: D32199533

