### PR TITLE
Temporarily suppress OSS Flow and Jest for recoil-sync

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 .*/__tests__.*
 .*/node_modules.*
 <PROJECT_ROOT>/packages-ext/.*
+<PROJECT_ROOT>/packages/recoil-sync/.*
 
 [include]
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,11 @@ module.exports = {
     '^recoil-sync$': '<rootDir>/packages/recoil-sync',
     '^refine$': '<rootDir>/packages/refine',
   },
-  testPathIgnorePatterns: ['/node_modules/', '/packages-ext/'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/packages-ext/',
+    // Temporarily skip recoil-sync until we enable transit-js dependency
+    '/packages/recoil-sync',
+  ],
   setupFiles: ['./setupJestMock.js'],
 };


### PR DESCRIPTION
Summary: Temporarily suppress Flow and Jest in OSS for `recoil-sync` while we introduce `transit-js` dependency until we resolve infrastructure for handling multiple packages from the GitHub repository

Differential Revision: D32192578

