### PR TITLE
Recoil 0.5.1 - TypeScript fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Change Log
 
 ## UPCOMING
-
 ***Add new changes here as they land***
 
 ### Pending
 - Memory management
 - useTransition() compatibility
 - Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.
+
+## 0.5.1 (2021-11-05)
+
+- Fix TypeScript exports (#1389)
 
 ## 0.5.0 (2021-11-03)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Recoil - A state management library for React",
   "main": "cjs/recoil.js",
   "module": "es/recoil.js",

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -47,7 +47,7 @@
   name: string;
  }
 
- interface AtomInfo<T> {
+ interface RecoilStateInfo<T> {
   loadable?: Loadable<T>;
   isActive: boolean;
   isSet: boolean;
@@ -65,7 +65,7 @@
   getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
   getPromise<T>(recoilValue: RecoilValue<T>): Promise<T>;
   getNodes_UNSTABLE(opts?: { isModified?: boolean, isInitialized?: boolean }): Iterable<RecoilValue<unknown>>;
-  getInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): AtomInfo<T>;
+  getInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): RecoilStateInfo<T>;
   map(cb: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
   asyncMap(cb: (mutableSnapshot: MutableSnapshot) => Promise<void>): Promise<Snapshot>;
   retain(): () => void;
@@ -95,6 +95,11 @@
   onSet: (
     param: (newValue: T, oldValue: T | DefaultValue, isReset: boolean) => void,
   ) => void,
+
+  // Accessors to read other atoms/selectors
+  getPromise: <S>(recoilValue: RecoilValue<S>) => Promise<S>,
+  getLoadable: <S>(recoilValue: RecoilValue<S>) => Loadable<S>,
+  getInfo_UNSTABLE: <S>(recoilValue: RecoilValue<S>) => RecoilStateInfo<S>,
  }) => void | (() => void);
 
  // atom.d.ts
@@ -225,7 +230,7 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
  /**
   * Returns current info about an atom
   */
- export function useGetRecoilValueInfo_UNSTABLE(): <T>(recoilValue: RecoilValue<T>) => AtomInfo<T>;
+ export function useGetRecoilValueInfo_UNSTABLE(): <T>(recoilValue: RecoilValue<T>) => RecoilStateInfo<T>;
 
  /**
   * Returns a function that will run the callback that was passed when

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -224,8 +224,8 @@ useResetRecoilState(readOnlySelectorSel); // $ExpectError
 useResetRecoilState({}); // $ExpectError
 
 useGetRecoilValueInfo_UNSTABLE(myAtom); // $ExpectError
-useGetRecoilValueInfo_UNSTABLE()(myAtom); // $ExpectType AtomInfo<number>
-useGetRecoilValueInfo_UNSTABLE()(mySelector2); // $ExpectType AtomInfo<string>
+useGetRecoilValueInfo_UNSTABLE()(myAtom); // $ExpectType RecoilStateInfo<number>
+useGetRecoilValueInfo_UNSTABLE()(mySelector2); // $ExpectType RecoilStateInfo<string>
 useGetRecoilValueInfo_UNSTABLE()({}); // $ExpectError
 
 useRecoilCallback(({ snapshot, set, reset, gotoSnapshot, transact_UNSTABLE }) => async () => {
@@ -559,7 +559,7 @@ isRecoilValue(mySelector1);
     key: 'thisismyrandomkey',
     default: 0,
     effects_UNSTABLE: [
-      ({setSelf, onSet, resetSelf}) => {
+      ({node, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
         setSelf(1);
         setSelf('a'); // $ExpectError
 
@@ -572,6 +572,16 @@ isRecoilValue(mySelector1);
 
         resetSelf();
         resetSelf('a'); // $ExpectError
+
+        getPromise(); // $ExpectError
+        getPromise('a'); // $ExpectError
+        getPromise(node); // $ExpectType Promise<number>
+        getLoadable(); // $ExpectError
+        getLoadable('a'); // $ExpectError
+        getLoadable(node); // $ExpectType Loadable<number>
+        getInfo_UNSTABLE(); // $ExpectError
+        getInfo_UNSTABLE('a'); // $ExpectError
+        getInfo_UNSTABLE(node); // $ExpectType RecoilStateInfo<number>
       },
     ],
   });
@@ -585,7 +595,7 @@ isRecoilValue(mySelector1);
     key: 'myrandomatomfamilykey',
     default: (param: number) => param,
     effects_UNSTABLE: (param) => [
-      ({setSelf, onSet, resetSelf}) => {
+      ({node, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
         param; // $ExpectType number
 
         setSelf(1);
@@ -598,6 +608,16 @@ isRecoilValue(mySelector1);
 
         resetSelf();
         resetSelf('a'); // $ExpectError
+
+        getPromise(); // $ExpectError
+        getPromise('a'); // $ExpectError
+        getPromise(node); // $ExpectType Promise<number>
+        getLoadable(); // $ExpectError
+        getLoadable('a'); // $ExpectError
+        getLoadable(node); // $ExpectType Loadable<number>
+        getInfo_UNSTABLE(); // $ExpectError
+        getInfo_UNSTABLE('a'); // $ExpectError
+        getInfo_UNSTABLE(node); // $ExpectType RecoilStateInfo<number>
       },
     ],
   });


### PR DESCRIPTION
Summary: Fix atom effect accessors for TypeScript

Differential Revision: D32224762

