### PR TITLE
Ignore generated /cjs for `yarn flow`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 node_modules
 
 yarn.lock
+
+docs

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/__tests__.*
 .*/node_modules.*
+<PROJECT_ROOT>/cjs/.*
 <PROJECT_ROOT>/packages-ext/.*
 <PROJECT_ROOT>/packages/recoil-sync/.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ nightly-build-files
 
 # Mac
 .DS_Store
+
+# NPM Package lock since we use yarn.lock
+package-lock.json


### PR DESCRIPTION
Summary: After building the packages on a local checkout a `/cjs` directory is created which has many flow errors.  Exclude this directory from `yarn flow` checks

Differential Revision: D32225306

