### PR TITLE
Recoil 0.5.2 - TypeScript fix for useRecoilRefresher()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - useTransition() compatibility
 - Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.
 
+## 0.5.2 (2021-11-07)
+
+- Fix TypeScript exports (#1397)
+
 ## 0.5.1 (2021-11-05)
 
 - Fix TypeScript exports (#1389)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Recoil - A state management library for React",
   "main": "cjs/recoil.js",
   "module": "es/recoil.js",

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -272,7 +272,7 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
  /**
   * Clears the cache for a selector causing it to be reevaluated.
   */
- export function useRecoilRefresher_UNSTABLE(): (recoilValue: RecoilValue<any>) => void;
+ export function useRecoilRefresher_UNSTABLE(recoilValue: RecoilValue<any>): () => void;
 
  // useRecoilBridgeAcrossReactRoots.d.ts
  export const RecoilBridge: React.FC;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -312,10 +312,12 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
  * useRecoilRefresher()
  */
 {
+  useRecoilRefresher_UNSTABLE(); // $ExpectError
   useRecoilRefresher_UNSTABLE(false); // $ExpectError
-  const refresher = useRecoilRefresher_UNSTABLE();
+  const refresher = useRecoilRefresher_UNSTABLE(mySelector1);
   refresher(false); // $ExpectError
-  refresher(mySelector1); // $ExpectType void
+  refresher(mySelector1); // $ExpectError
+  refresher(); // $ExpectType void
 }
 
 /**


### PR DESCRIPTION
Summary: Fix TypeScript for `useRecoilRefresher_UNSTABLE()` to match Flow implementation.

Differential Revision: D32238323

