### PR TITLE
Fix transitive recoil refresher for selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UPCOMING
 ***Add new changes here as they land***
 
+- Fix transitive selector refresh for some cases (#1409)
+
 ### Pending
 - Memory management
 - useTransition() compatibility

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -233,7 +233,7 @@ function selector<T>(
     }
   }
 
-  // This is every discovered dependency across executions
+  // This is every discovered dependency across all executions
   const discoveredDependencyNodeKeys = new Set();
 
   const cache: TreeCacheImplementation<Loadable<T>> = treeCacheFromPolicy(
@@ -670,6 +670,7 @@ function selector<T>(
         store.getState()?.nextTree?.version ??
           store.getState().currentTree.version,
       );
+      deps.forEach(nodeKey => discoveredDependencyNodeKeys.add(nodeKey));
     }
   }
 
@@ -830,13 +831,8 @@ function selector<T>(
         },
         {
           onNodeVisit: node => {
-            if (
-              node.type === 'branch' &&
-              node.nodeKey !== key &&
-              typeof node.nodeKey === 'string'
-            ) {
+            if (node.type === 'branch' && node.nodeKey !== key) {
               depsAfterCacheDone.add(node.nodeKey);
-              discoveredDependencyNodeKeys.add(node.nodeKey);
             }
           },
         },
@@ -1153,6 +1149,7 @@ function selector<T>(
       const node = getNode(nodeKey);
       node.clearCache?.(store, treeState);
     }
+    discoveredDependencyNodeKeys.clear();
     invalidateSelector(treeState);
     cache.clear();
     markRecoilValueModified(store, recoilValue);


### PR DESCRIPTION
Summary: Fix recoil cache clearing work transitively for selector dependencies for some cases.

Differential Revision: D32365058

