### PR TITLE
Add refresh to useRecoilCallback() interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UPCOMING
 ***Add new changes here as they land***
 
+- Add `refresh` to Recoil callback interface
 - Fix transitive selector refresh for some cases (#1409)
 
 ### Pending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UPCOMING
 ***Add new changes here as they land***
 
+- Fix transitive selector refresh for some cases (#1409)
+
 ### Pending
 - Memory management
 - useTransition() compatibility

--- a/packages/recoil/core/Recoil_RecoilValueInterface.js
+++ b/packages/recoil/core/Recoil_RecoilValueInterface.js
@@ -28,7 +28,7 @@ const {
   getNodeLoadable,
   setNodeValue,
 } = require('./Recoil_FunctionalCore');
-const {getNodeMaybe} = require('./Recoil_Node');
+const {getNode, getNodeMaybe} = require('./Recoil_Node');
 const {DefaultValue, RecoilValueNotReady} = require('./Recoil_Node');
 const {
   AbstractRecoilValue,
@@ -322,7 +322,6 @@ function subscribeToRecoilValue<T>(
 
   return {
     release: () => {
-      const storeState = store.getState();
       const subs = storeState.nodeToComponentSubscriptions.get(key);
       if (subs === undefined || !subs.has(subID)) {
         recoverableViolation(
@@ -337,6 +336,15 @@ function subscribeToRecoilValue<T>(
       }
     },
   };
+}
+
+function refreshRecoilValue<T>(
+  store: Store,
+  recoilValue: AbstractRecoilValue<T>,
+): void {
+  const {currentTree} = store.getState();
+  const node = getNode(recoilValue.key);
+  node.clearCache?.(store, currentTree);
 }
 
 module.exports = {
@@ -355,5 +363,6 @@ module.exports = {
   writeLoadableToTreeState,
   invalidateDownstreams,
   copyTreeState,
+  refreshRecoilValue,
   invalidateDownstreams_FOR_TESTING: invalidateDownstreams,
 };

--- a/packages/recoil/hooks/Recoil_useRecoilCallback.js
+++ b/packages/recoil/hooks/Recoil_useRecoilCallback.js
@@ -11,13 +11,16 @@
 'use strict';
 
 import type {TransactionInterface} from '../core/Recoil_AtomicUpdates';
-import type {RecoilState} from '../core/Recoil_RecoilValue';
+import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
 
 const {atomicUpdater} = require('../core/Recoil_AtomicUpdates');
 const {batchUpdates} = require('../core/Recoil_Batching');
 const {DEFAULT_VALUE} = require('../core/Recoil_Node');
 const {useStoreRef} = require('../core/Recoil_RecoilRoot.react');
-const {setRecoilValue} = require('../core/Recoil_RecoilValueInterface');
+const {
+  refreshRecoilValue,
+  setRecoilValue,
+} = require('../core/Recoil_RecoilValueInterface');
 const {Snapshot, cloneSnapshot} = require('../core/Recoil_Snapshot');
 const err = require('../util/Recoil_err');
 const invariant = require('../util/Recoil_invariant');
@@ -27,6 +30,7 @@ const {useCallback} = require('react');
 export type RecoilCallbackInterface = $ReadOnly<{
   set: <T>(RecoilState<T>, (T => T) | T) => void,
   reset: <T>(RecoilState<T>) => void,
+  refresh: <T>(RecoilValue<T>) => void,
   snapshot: Snapshot,
   gotoSnapshot: Snapshot => void,
   transact_UNSTABLE: ((TransactionInterface) => void) => void,
@@ -55,6 +59,10 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
         setRecoilValue(storeRef.current, recoilState, DEFAULT_VALUE);
       }
 
+      function refresh<T>(recoilValue: RecoilValue<T>) {
+        refreshRecoilValue(storeRef.current, recoilValue);
+      }
+
       // Use currentTree for the snapshot to show the currently committed state
       const snapshot = cloneSnapshot(storeRef.current); // FIXME massive gains from doing this lazily
 
@@ -76,6 +84,7 @@ function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
         const cb = (fn: any)({
           set,
           reset,
+          refresh,
           snapshot,
           gotoSnapshot,
           transact_UNSTABLE: atomicUpdate,

--- a/packages/recoil/hooks/Recoil_useRecoilRefresher.js
+++ b/packages/recoil/hooks/Recoil_useRecoilRefresher.js
@@ -12,17 +12,15 @@
 
 import type {RecoilValue} from '../core/Recoil_RecoilValue';
 
-const {getNode} = require('../core/Recoil_Node');
 const {useStoreRef} = require('../core/Recoil_RecoilRoot.react');
+const {refreshRecoilValue} = require('../core/Recoil_RecoilValueInterface');
 const {useCallback} = require('react');
 
 function useRecoilRefresher<T>(recoilValue: RecoilValue<T>): () => void {
   const storeRef = useStoreRef();
   return useCallback(() => {
     const store = storeRef.current;
-    const {currentTree} = store.getState();
-    const node = getNode(recoilValue.key);
-    node.clearCache?.(store, currentTree);
+    refreshRecoilValue(store, recoilValue);
   }, [recoilValue, storeRef]);
 }
 

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -50,306 +50,301 @@ const testRecoil = getRecoilTestFn(() => {
   invariant = require('../../util/Recoil_invariant');
 });
 
-describe('useRecoilCallback', () => {
-  testRecoil('Reads Recoil values', async () => {
-    const anAtom = atom({key: 'atom1', default: 'DEFAULT'});
-    let pTest = Promise.reject(new Error("Callback didn't resolve"));
-    let cb;
+testRecoil('Reads Recoil values', async () => {
+  const anAtom = atom({key: 'atom1', default: 'DEFAULT'});
+  let pTest = Promise.reject(new Error("Callback didn't resolve"));
+  let cb;
 
-    function Component() {
-      cb = useRecoilCallback(({snapshot}) => () => {
-        // eslint-disable-next-line jest/valid-expect
-        pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
-      });
-      return null;
-    }
-    renderElements(<Component />);
-    act(() => void cb());
-    await pTest;
-  });
-
-  testRecoil('Can read Recoil values without throwing', async () => {
-    const anAtom = atom({key: 'atom2', default: 123});
-    const asyncSelector = selector({
-      key: 'sel',
-      get: () => {
-        return new Promise(() => undefined);
-      },
+  function Component() {
+    cb = useRecoilCallback(({snapshot}) => () => {
+      // eslint-disable-next-line jest/valid-expect
+      pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
     });
-    let didRun = false;
-    let cb;
+    return null;
+  }
+  renderElements(<Component />);
+  act(() => void cb());
+  await pTest;
+});
 
-    function Component() {
-      cb = useRecoilCallback(({snapshot}) => () => {
-        expect(snapshot.getLoadable(anAtom)).toMatchObject({
-          state: 'hasValue',
-          contents: 123,
-        });
-        expect(snapshot.getLoadable(asyncSelector)).toMatchObject({
-          state: 'loading',
-        });
-        didRun = true; // ensure these assertions do get made
-      });
-      return null;
-    }
-    renderElements(<Component />);
-    act(() => void cb());
-    expect(didRun).toBe(true);
-  });
-
-  testRecoil('Sets Recoil values (by queueing them)', async () => {
-    const anAtom = atom({key: 'atom3', default: 'DEFAULT'});
-    let cb;
-    let pTest = Promise.reject(new Error("Callback didn't resolve"));
-
-    function Component() {
-      cb = useRecoilCallback(({snapshot, set}) => value => {
-        set(anAtom, value);
-        // eslint-disable-next-line jest/valid-expect
-        pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
-      });
-      return null;
-    }
-
-    const container = renderElements(
-      <>
-        <Component />
-        <ReadsAtom atom={anAtom} />
-      </>,
-    );
-    expect(container.textContent).toBe('"DEFAULT"');
-    act(() => void cb(123));
-    expect(container.textContent).toBe('123');
-    await pTest;
-  });
-
-  testRecoil('Reset Recoil values', async () => {
-    const anAtom = atom({key: 'atomReset', default: 'DEFAULT'});
-    let setCB, resetCB;
-
-    function Component() {
-      setCB = useRecoilCallback(
-        ({set}) =>
-          value =>
-            set(anAtom, value),
-      );
-      resetCB = useRecoilCallback(
-        ({reset}) =>
-          () =>
-            reset(anAtom),
-      );
-      return null;
-    }
-
-    const container = renderElements(
-      <>
-        <Component />
-        <ReadsAtom atom={anAtom} />
-      </>,
-    );
-    expect(container.textContent).toBe('"DEFAULT"');
-    act(() => void setCB(123));
-    expect(container.textContent).toBe('123');
-    act(() => void resetCB());
-    expect(container.textContent).toBe('"DEFAULT"');
-  });
-
-  testRecoil('Sets Recoil values from async callback', async () => {
-    const anAtom = atom({key: 'set async callback', default: 'DEFAULT'});
-    let cb;
-    const pTest = [];
-
-    function Component() {
-      cb = useRecoilCallback(({snapshot, set}) => async value => {
-        set(anAtom, value);
-        pTest.push(
-          // eslint-disable-next-line jest/valid-expect
-          expect(snapshot.getPromise(anAtom)).resolves.toBe(
-            value === 123 ? 'DEFAULT' : 123,
-          ),
-        );
-      });
-      return null;
-    }
-
-    const container = renderElements([
-      <Component />,
-      <ReadsAtom atom={anAtom} />,
-    ]);
-
-    expect(container.textContent).toBe('"DEFAULT"');
-    act(() => void cb(123));
-    expect(container.textContent).toBe('123');
-    act(() => void cb(456));
-    expect(container.textContent).toBe('456');
-    for (const aTest of pTest) {
-      await aTest;
-    }
-  });
-
-  testRecoil(
-    'Reads from a snapshot created at callback call time',
-    async () => {
-      const anAtom = atom({key: 'atom4', default: 123});
-      let cb;
-      let setter;
-      let seenValue = null;
-
-      let delay = () => new Promise(r => r()); // no delay initially
-
-      function Component() {
-        setter = useSetRecoilState(anAtom);
-        cb = useRecoilCallback(({snapshot}) => async () => {
-          snapshot.retain();
-          await delay();
-          seenValue = await snapshot.getPromise(anAtom);
-        });
-        return null;
-      }
-
-      // It sees an update flushed after the cb is created:
-      renderElements(<Component />);
-      act(() => setter(345));
-      act(() => void cb());
-      await flushPromisesAndTimers();
-      await flushPromisesAndTimers();
-
-      expect(seenValue).toBe(345);
-
-      // But does not see an update flushed while the cb is in progress:
-      seenValue = null;
-      let resumeCallback = () => invariant(false, 'must be initialized');
-      delay = () => {
-        return new Promise(resolve => {
-          resumeCallback = resolve;
-        });
-      };
-      act(() => void cb());
-      act(() => setter(678));
-      resumeCallback();
-      await flushPromisesAndTimers();
-      await flushPromisesAndTimers();
-      expect(seenValue).toBe(345);
+testRecoil('Can read Recoil values without throwing', async () => {
+  const anAtom = atom({key: 'atom2', default: 123});
+  const asyncSelector = selector({
+    key: 'sel',
+    get: () => {
+      return new Promise(() => undefined);
     },
+  });
+  let didRun = false;
+  let cb;
+
+  function Component() {
+    cb = useRecoilCallback(({snapshot}) => () => {
+      expect(snapshot.getLoadable(anAtom)).toMatchObject({
+        state: 'hasValue',
+        contents: 123,
+      });
+      expect(snapshot.getLoadable(asyncSelector)).toMatchObject({
+        state: 'loading',
+      });
+      didRun = true; // ensure these assertions do get made
+    });
+    return null;
+  }
+  renderElements(<Component />);
+  act(() => void cb());
+  expect(didRun).toBe(true);
+});
+
+testRecoil('Sets Recoil values (by queueing them)', async () => {
+  const anAtom = atom({key: 'atom3', default: 'DEFAULT'});
+  let cb;
+  let pTest = Promise.reject(new Error("Callback didn't resolve"));
+
+  function Component() {
+    cb = useRecoilCallback(({snapshot, set}) => value => {
+      set(anAtom, value);
+      // eslint-disable-next-line jest/valid-expect
+      pTest = expect(snapshot.getPromise(anAtom)).resolves.toBe('DEFAULT');
+    });
+    return null;
+  }
+
+  const container = renderElements(
+    <>
+      <Component />
+      <ReadsAtom atom={anAtom} />
+    </>,
+  );
+  expect(container.textContent).toBe('"DEFAULT"');
+  act(() => void cb(123));
+  expect(container.textContent).toBe('123');
+  await pTest;
+});
+
+testRecoil('Reset Recoil values', async () => {
+  const anAtom = atom({key: 'atomReset', default: 'DEFAULT'});
+  let setCB, resetCB;
+
+  function Component() {
+    setCB = useRecoilCallback(
+      ({set}) =>
+        value =>
+          set(anAtom, value),
+    );
+    resetCB = useRecoilCallback(
+      ({reset}) =>
+        () =>
+          reset(anAtom),
+    );
+    return null;
+  }
+
+  const container = renderElements(
+    <>
+      <Component />
+      <ReadsAtom atom={anAtom} />
+    </>,
+  );
+  expect(container.textContent).toBe('"DEFAULT"');
+  act(() => void setCB(123));
+  expect(container.textContent).toBe('123');
+  act(() => void resetCB());
+  expect(container.textContent).toBe('"DEFAULT"');
+});
+
+testRecoil('Sets Recoil values from async callback', async () => {
+  const anAtom = atom({key: 'set async callback', default: 'DEFAULT'});
+  let cb;
+  const pTest = [];
+
+  function Component() {
+    cb = useRecoilCallback(({snapshot, set}) => async value => {
+      set(anAtom, value);
+      pTest.push(
+        // eslint-disable-next-line jest/valid-expect
+        expect(snapshot.getPromise(anAtom)).resolves.toBe(
+          value === 123 ? 'DEFAULT' : 123,
+        ),
+      );
+    });
+    return null;
+  }
+
+  const container = renderElements([
+    <Component />,
+    <ReadsAtom atom={anAtom} />,
+  ]);
+
+  expect(container.textContent).toBe('"DEFAULT"');
+  act(() => void cb(123));
+  expect(container.textContent).toBe('123');
+  act(() => void cb(456));
+  expect(container.textContent).toBe('456');
+  for (const aTest of pTest) {
+    await aTest;
+  }
+});
+
+testRecoil('Reads from a snapshot created at callback call time', async () => {
+  const anAtom = atom({key: 'atom4', default: 123});
+  let cb;
+  let setter;
+  let seenValue = null;
+
+  let delay = () => new Promise(r => r()); // no delay initially
+
+  function Component() {
+    setter = useSetRecoilState(anAtom);
+    cb = useRecoilCallback(({snapshot}) => async () => {
+      snapshot.retain();
+      await delay();
+      seenValue = await snapshot.getPromise(anAtom);
+    });
+    return null;
+  }
+
+  // It sees an update flushed after the cb is created:
+  renderElements(<Component />);
+  act(() => setter(345));
+  act(() => void cb());
+  await flushPromisesAndTimers();
+  await flushPromisesAndTimers();
+
+  expect(seenValue).toBe(345);
+
+  // But does not see an update flushed while the cb is in progress:
+  seenValue = null;
+  let resumeCallback = () => invariant(false, 'must be initialized');
+  delay = () => {
+    return new Promise(resolve => {
+      resumeCallback = resolve;
+    });
+  };
+  act(() => void cb());
+  act(() => setter(678));
+  resumeCallback();
+  await flushPromisesAndTimers();
+  await flushPromisesAndTimers();
+  expect(seenValue).toBe(345);
+});
+
+testRecoil('Setter updater sees current state', () => {
+  const myAtom = atom({key: 'useRecoilCallback updater', default: 'DEFAULT'});
+
+  let setAtom;
+  let cb;
+  function Component() {
+    setAtom = useSetRecoilState(myAtom);
+    cb = useRecoilCallback(({snapshot, set}) => prevValue => {
+      // snapshot sees the stable snapshot from batch at beginning of transaction
+      expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
+
+      // Test that callback sees value updates from within the same transaction
+      set(myAtom, value => {
+        expect(value).toEqual(prevValue);
+        return 'UPDATE';
+      });
+      set(myAtom, value => {
+        expect(value).toEqual('UPDATE');
+        return 'UPDATE AGAIN';
+      });
+    });
+    return null;
+  }
+
+  const c = renderElements(
+    <>
+      <ReadsAtom atom={myAtom} />
+      <Component />
+    </>,
   );
 
-  testRecoil('Setter updater sees current state', () => {
-    const myAtom = atom({key: 'useRecoilCallback updater', default: 'DEFAULT'});
+  expect(c.textContent).toEqual('"DEFAULT"');
 
-    let setAtom;
-    let cb;
-    function Component() {
-      setAtom = useSetRecoilState(myAtom);
-      cb = useRecoilCallback(({snapshot, set}) => prevValue => {
-        // snapshot sees the stable snapshot from batch at beginning of transaction
-        expect(snapshot.getLoadable(myAtom).contents).toEqual('DEFAULT');
+  // Set then callback in the same transaction
+  act(() => {
+    setAtom('SET');
+    cb('SET');
+    cb('UPDATE AGAIN');
+  });
+  expect(c.textContent).toEqual('"UPDATE AGAIN"');
+});
 
-        // Test that callback sees value updates from within the same transaction
-        set(myAtom, value => {
-          expect(value).toEqual(prevValue);
-          return 'UPDATE';
-        });
-        set(myAtom, value => {
-          expect(value).toEqual('UPDATE');
-          return 'UPDATE AGAIN';
-        });
-      });
-      return null;
-    }
-
-    const c = renderElements(
-      <>
-        <ReadsAtom atom={myAtom} />
-        <Component />
-      </>,
-    );
-
-    expect(c.textContent).toEqual('"DEFAULT"');
-
-    // Set then callback in the same transaction
-    act(() => {
-      setAtom('SET');
-      cb('SET');
-      cb('UPDATE AGAIN');
-    });
-    expect(c.textContent).toEqual('"UPDATE AGAIN"');
+testRecoil('goes to snapshot', async () => {
+  const myAtom = atom({
+    key: 'Goto Snapshot From Callback',
+    default: 'DEFAULT',
   });
 
-  testRecoil('goes to snapshot', async () => {
-    const myAtom = atom({
-      key: 'Goto Snapshot From Callback',
-      default: 'DEFAULT',
-    });
-
-    let cb;
-    function RecoilCallback() {
-      cb = useRecoilCallback(({snapshot, gotoSnapshot}) => () => {
-        const updatedSnapshot = snapshot.map(({set}) => {
-          set(myAtom, 'SET IN SNAPSHOT');
-        });
-        expect(updatedSnapshot.getLoadable(myAtom).contents).toEqual(
-          'SET IN SNAPSHOT',
-        );
-        gotoSnapshot(updatedSnapshot);
+  let cb;
+  function RecoilCallback() {
+    cb = useRecoilCallback(({snapshot, gotoSnapshot}) => () => {
+      const updatedSnapshot = snapshot.map(({set}) => {
+        set(myAtom, 'SET IN SNAPSHOT');
       });
-      return null;
-    }
+      expect(updatedSnapshot.getLoadable(myAtom).contents).toEqual(
+        'SET IN SNAPSHOT',
+      );
+      gotoSnapshot(updatedSnapshot);
+    });
+    return null;
+  }
 
-    const c = renderElements(
-      <>
-        <ReadsAtom atom={myAtom} />
-        <RecoilCallback />
-      </>,
-    );
+  const c = renderElements(
+    <>
+      <ReadsAtom atom={myAtom} />
+      <RecoilCallback />
+    </>,
+  );
 
-    expect(c.textContent).toEqual('"DEFAULT"');
+  expect(c.textContent).toEqual('"DEFAULT"');
 
-    act(() => void cb());
-    await flushPromisesAndTimers();
-    expect(c.textContent).toEqual('"SET IN SNAPSHOT"');
+  act(() => void cb());
+  await flushPromisesAndTimers();
+  expect(c.textContent).toEqual('"SET IN SNAPSHOT"');
+});
+
+testRecoil('Updates are batched', () => {
+  const family = atomFamily({
+    key: 'useRecoilCallback/batching/family',
+    default: 0,
   });
 
-  testRecoil('Updates are batched', () => {
-    const family = atomFamily({
-      key: 'useRecoilCallback/batching/family',
-      default: 0,
+  let cb;
+  function RecoilCallback() {
+    cb = useRecoilCallback(({set}) => () => {
+      for (let i = 0; i < 100; i++) {
+        set(family(i), 1);
+      }
     });
+    return null;
+  }
 
-    let cb;
-    function RecoilCallback() {
-      cb = useRecoilCallback(({set}) => () => {
-        for (let i = 0; i < 100; i++) {
-          set(family(i), 1);
-        }
-      });
-      return null;
-    }
+  let store: any; // flowlint-line unclear-type:off
+  function GetStore() {
+    store = useStoreRef().current;
+    return null;
+  }
 
-    let store: any; // flowlint-line unclear-type:off
-    function GetStore() {
-      store = useStoreRef().current;
-      return null;
-    }
+  renderElements(
+    <>
+      <RecoilCallback />
+      <GetStore />
+    </>,
+  );
 
-    renderElements(
-      <>
-        <RecoilCallback />
-        <GetStore />
-      </>,
-    );
+  invariant(store, 'store should be initialized');
+  const originalReplaceState = store.replaceState;
+  // $FlowFixMe[cannot-write]
+  store.replaceState = jest.fn(originalReplaceState);
 
-    invariant(store, 'store should be initialized');
-    const originalReplaceState = store.replaceState;
-    // $FlowFixMe[cannot-write]
-    store.replaceState = jest.fn(originalReplaceState);
+  expect(store.replaceState).toHaveBeenCalledTimes(0);
+  act(() => cb());
+  expect(store.replaceState).toHaveBeenCalledTimes(1);
 
-    expect(store.replaceState).toHaveBeenCalledTimes(0);
-    act(() => cb());
-    expect(store.replaceState).toHaveBeenCalledTimes(1);
-
-    // $FlowFixMe[cannot-write]
-    store.replaceState = originalReplaceState;
-  });
+  // $FlowFixMe[cannot-write]
+  store.replaceState = originalReplaceState;
 });
 
 // Test that we always get a consistent instance of the callback function
@@ -455,3 +450,79 @@ testRecoil(
     expect(numTimesEffectInit).toBe(1);
   },
 );
+
+testRecoil('Refresh selector cache - transitive', () => {
+  const getA = jest.fn(() => 'A');
+  const selectorA = selector({
+    key: 'useRecoilCallback refresh ancestors A',
+    get: getA,
+  });
+
+  const getB = jest.fn(({get}) => get(selectorA) + 'B');
+  const selectorB = selector({
+    key: 'useRecoilCallback refresh ancestors B',
+    get: getB,
+  });
+
+  const getC = jest.fn(({get}) => get(selectorB) + 'C');
+  const selectorC = selector({
+    key: 'useRecoilCallback refresh ancestors C',
+    get: getC,
+  });
+
+  let refreshSelector;
+  function Component() {
+    refreshSelector = useRecoilCallback(({refresh}) => () => {
+      refresh(selectorC);
+    });
+    return useRecoilValue(selectorC);
+  }
+
+  const container = renderElements(<Component />);
+  expect(container.textContent).toBe('ABC');
+  expect(getC).toHaveBeenCalledTimes(1);
+  expect(getB).toHaveBeenCalledTimes(1);
+  expect(getA).toHaveBeenCalledTimes(1);
+
+  act(() => refreshSelector());
+  expect(container.textContent).toBe('ABC');
+  expect(getC).toHaveBeenCalledTimes(2);
+  expect(getB).toHaveBeenCalledTimes(2);
+  expect(getA).toHaveBeenCalledTimes(2);
+});
+
+testRecoil('Refresh selector cache - clears entire cache', async () => {
+  const myatom = atom({
+    key: 'useRecoilCallback refresh entire cache atom',
+    default: 'a',
+  });
+
+  let i = 0;
+  const myselector = selector({
+    key: 'useRecoilCallback refresh entire cache selector',
+    get: ({get}) => [get(myatom), i++],
+  });
+
+  let setMyAtom;
+  let refreshSelector;
+  function Component() {
+    const [atomValue, iValue] = useRecoilValue(myselector);
+    refreshSelector = useRecoilCallback(({refresh}) => () => {
+      refresh(myselector);
+    });
+    setMyAtom = useSetRecoilState(myatom);
+    return `${atomValue}-${iValue}`;
+  }
+
+  const container = renderElements(<Component />);
+  expect(container.textContent).toBe('a-0');
+
+  act(() => setMyAtom('b'));
+  expect(container.textContent).toBe('b-1');
+
+  act(() => refreshSelector());
+  expect(container.textContent).toBe('b-2');
+
+  act(() => setMyAtom('a'));
+  expect(container.textContent).toBe('a-3');
+});

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -233,7 +233,7 @@ function selector<T>(
     }
   }
 
-  // This is every discovered dependency across executions
+  // This is every discovered dependency across all executions
   const discoveredDependencyNodeKeys = new Set();
 
   const cache: TreeCacheImplementation<Loadable<T>> = treeCacheFromPolicy(
@@ -670,6 +670,7 @@ function selector<T>(
         store.getState()?.nextTree?.version ??
           store.getState().currentTree.version,
       );
+      deps.forEach(nodeKey => discoveredDependencyNodeKeys.add(nodeKey));
     }
   }
 
@@ -830,13 +831,8 @@ function selector<T>(
         },
         {
           onNodeVisit: node => {
-            if (
-              node.type === 'branch' &&
-              node.nodeKey !== key &&
-              typeof node.nodeKey === 'string'
-            ) {
+            if (node.type === 'branch' && node.nodeKey !== key) {
               depsAfterCacheDone.add(node.nodeKey);
-              discoveredDependencyNodeKeys.add(node.nodeKey);
             }
           },
         },
@@ -1153,6 +1149,7 @@ function selector<T>(
       const node = getNode(nodeKey);
       node.clearCache?.(store, treeState);
     }
+    discoveredDependencyNodeKeys.clear();
     invalidateSelector(treeState);
     cache.clear();
     markRecoilValueModified(store, recoilValue);

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -183,6 +183,7 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
  export type CallbackInterface = Readonly<{
   set: <T>(recoilVal: RecoilState<T>, valOrUpdater: ((currVal: T) => T) | T) => void;
   reset: (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  refresh: (recoilValue: RecoilValue<any>) => void;
   snapshot: Snapshot,
   gotoSnapshot: (snapshot: Snapshot) => void,
   transact_UNSTABLE: (cb: (i: TransactionInterface_UNSTABLE) => void) => void;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -228,7 +228,7 @@ useGetRecoilValueInfo_UNSTABLE()(myAtom); // $ExpectType RecoilStateInfo<number>
 useGetRecoilValueInfo_UNSTABLE()(mySelector2); // $ExpectType RecoilStateInfo<string>
 useGetRecoilValueInfo_UNSTABLE()({}); // $ExpectError
 
-useRecoilCallback(({ snapshot, set, reset, gotoSnapshot, transact_UNSTABLE }) => async () => {
+useRecoilCallback(({ snapshot, set, reset, refresh, gotoSnapshot, transact_UNSTABLE }) => async () => {
   snapshot; // $ExpectType Snapshot
   snapshot.getID(); // $ExpectType SnapshotID
   await snapshot.getPromise(mySelector1); // $ExpectType number
@@ -245,6 +245,7 @@ useRecoilCallback(({ snapshot, set, reset, gotoSnapshot, transact_UNSTABLE }) =>
   set(myAtom, 5);
   set(myAtom, 'hello'); // $ExpectError
   reset(myAtom);
+  refresh(myAtom);
 
   const release = snapshot.retain(); // $ExpectType () => void
   release(); // $ExpectType void


### PR DESCRIPTION
Summary:
Add selector `refresh()` to the callback interface for `useRecoilCallback()`

```
useRecoilCallback(({refresh}) => () => {
  refresh(mySelector);
});
```

Differential Revision: D32366108

