### PR TITLE
Add storeID to Atom Effects interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
 - `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
+- `storeID` added to atom effects interface (#1414)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 
 ### Pending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
+- `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 
 ### Pending

--- a/packages/recoil/Recoil_index.js
+++ b/packages/recoil/Recoil_index.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+export type {StoreID} from './core/Recoil_Keys';
 export type {PersistenceType} from './core/Recoil_Node';
 export type {
   RecoilValue,
@@ -42,7 +43,10 @@ export type {
 
 const {RecoilLoadable} = require('./adt/Recoil_Loadable');
 const {DefaultValue} = require('./core/Recoil_Node');
-const {RecoilRoot} = require('./core/Recoil_RecoilRoot.react');
+const {
+  RecoilRoot,
+  useRecoilStoreID,
+} = require('./core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
 const {retentionZone} = require('./core/Recoil_RetentionZone');
 const {freshSnapshot} = require('./core/Recoil_Snapshot');
@@ -88,6 +92,7 @@ module.exports = {
 
   // Recoil Root
   RecoilRoot,
+  useRecoilStoreID,
   useRecoilBridgeAcrossReactRoots_UNSTABLE: useRecoilBridgeAcrossReactRoots,
 
   // Atoms/Selectors

--- a/packages/recoil/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/recoil/__test_utils__/Recoil_TestingUtils.js
@@ -22,6 +22,7 @@ const ReactDOM = require('ReactDOMLegacy_DEPRECATED');
 const {act} = require('ReactTestUtils');
 
 const {graph} = require('../core/Recoil_Graph');
+const {getNextStoreID} = require('../core/Recoil_Keys');
 const {
   RecoilRoot,
   notifyComponents_FOR_TESTING,
@@ -51,7 +52,8 @@ const IS_INTERNAL = false; // @oss-only
 // TODO Use Snapshot for testing instead of this thunk?
 function makeStore(): Store {
   const storeState = makeEmptyStoreState();
-  const store = {
+  const store: Store = {
+    storeID: getNextStoreID(),
     getState: () => storeState,
     replaceState: replacer => {
       const currentStoreState = store.getState();

--- a/packages/recoil/core/Recoil_Graph.js
+++ b/packages/recoil/core/Recoil_Graph.js
@@ -12,7 +12,7 @@
 'use strict';
 
 import type {DependencyMap, Graph} from './Recoil_GraphTypes';
-import type {NodeKey, Version} from './Recoil_Keys';
+import type {NodeKey, StateID} from './Recoil_Keys';
 import type {Store} from './Recoil_State';
 
 const differenceSets = require('../util/Recoil_differenceSets');
@@ -21,7 +21,7 @@ const nullthrows = require('../util/Recoil_nullthrows');
 const recoverableViolation = require('../util/Recoil_recoverableViolation');
 export type {DependencyMap, Graph} from './Recoil_GraphTypes';
 
-function graph(): Graph {
+function makeGraph(): Graph {
   return {
     nodeDeps: new Map(),
     nodeToNodeSubscriptions: new Map(),
@@ -96,7 +96,7 @@ function mergeDependencyMapIntoGraph(
 function saveDependencyMapToStore(
   dependencyMap: DependencyMap,
   store: Store,
-  version: Version,
+  version: StateID,
 ): void {
   const storeState = store.getState();
   if (
@@ -162,7 +162,7 @@ function addToDependencyMap(
 module.exports = {
   addToDependencyMap,
   cloneGraph,
-  graph,
+  graph: makeGraph,
   mergeDepsIntoDependencyMap,
   saveDependencyMapToStore,
 };

--- a/packages/recoil/core/Recoil_Keys.js
+++ b/packages/recoil/core/Recoil_Keys.js
@@ -8,22 +8,24 @@
  * @flow strict
  * @format
  */
-
 'use strict';
 
 export type NodeKey = string;
-export type ComponentID = number;
-export type Version = number;
-export type StateID = number;
-export type StoreID = number;
+export opaque type StateID = number;
+export opaque type StoreID = number;
+export opaque type ComponentID = number;
 
 let nextTreeStateVersion = 0;
-const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
+const getNextTreeStateVersion: () => StateID = () => nextTreeStateVersion++;
 
 let nextStoreID = 0;
-const getNextStoreID = (): StoreID => nextStoreID++;
+const getNextStoreID: () => StoreID = () => nextStoreID++;
+
+let nextComponentID = 0;
+const getNextComponentID: () => ComponentID = () => nextComponentID++;
 
 module.exports = {
   getNextTreeStateVersion,
   getNextStoreID,
+  getNextComponentID,
 };

--- a/packages/recoil/core/Recoil_Keys.js
+++ b/packages/recoil/core/Recoil_Keys.js
@@ -15,5 +15,15 @@ export type NodeKey = string;
 export type ComponentID = number;
 export type Version = number;
 export type StateID = number;
+export type StoreID = number;
 
-module.exports = ({}: {...});
+let nextTreeStateVersion = 0;
+const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
+
+let nextStoreID = 0;
+const getNextStoreID = (): StoreID => nextStoreID++;
+
+module.exports = {
+  getNextTreeStateVersion,
+  getNextStoreID,
+};

--- a/packages/recoil/core/Recoil_RecoilRoot.react.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.react.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-import type {StoreID as InternalStoreID} from './Recoil_Keys';
+import type {StoreID} from './Recoil_Keys';
 import type {RecoilValue} from './Recoil_RecoilValue';
 import type {MutableSnapshot} from './Recoil_Snapshot';
 import type {Store, StoreRef, StoreState, TreeState} from './Recoil_State';
@@ -540,8 +540,6 @@ function RecoilRoot(props: Props): React.Node {
   return <RecoilRoot_INTERNAL {...propsExceptOverride} />;
 }
 
-// Opaque at this surface because it's part of the public API from here.
-export opaque type StoreID = InternalStoreID;
 function useRecoilStoreID(): StoreID {
   return useStoreRef().current.storeID;
 }

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -53,7 +53,7 @@ const {
 } = require('./Recoil_State');
 
 // Opaque at this surface because it's part of the public API from here.
-export opaque type SnapshotID = StateID;
+export type SnapshotID = StateID;
 
 const retainWarning = `
 Recoil Snapshots only last for the duration of the callback they are provided to. To keep a Snapshot longer, do this:
@@ -164,11 +164,6 @@ class Snapshot {
   }
 
   getID(): SnapshotID {
-    this.checkRefCount_INTERNAL();
-    return this.getID_INTERNAL();
-  }
-
-  getID_INTERNAL(): StateID {
     this.checkRefCount_INTERNAL();
     return this._store.getState().currentTree.stateID;
   }

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -34,6 +34,7 @@ const {
   peekNodeInfo,
 } = require('./Recoil_FunctionalCore');
 const {graph} = require('./Recoil_Graph');
+const {getNextStoreID} = require('./Recoil_Keys');
 const {
   DEFAULT_VALUE,
   recoilValues,
@@ -76,6 +77,7 @@ class Snapshot {
 
   constructor(storeState: StoreState) {
     this._store = {
+      storeID: getNextStoreID(),
       getState: () => storeState,
       replaceState: replacer => {
         storeState.currentTree = replacer(storeState.currentTree); // no batching so nextTree is never active

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -14,11 +14,18 @@
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {PersistentMap} from '../adt/Recoil_PersistentMap';
 import type {Graph} from './Recoil_GraphTypes';
-import type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
+import type {
+  ComponentID,
+  NodeKey,
+  StateID,
+  StoreID,
+  Version,
+} from './Recoil_Keys';
 import type {RetentionZone} from './Recoil_RetentionZone';
 
 const {persistentMap} = require('../adt/Recoil_PersistentMap');
 const {graph} = require('./Recoil_Graph');
+const {getNextTreeStateVersion} = require('./Recoil_Keys');
 
 export type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
 
@@ -130,6 +137,7 @@ export type StoreState = {
 // The Store is just the interface that is made available via the context.
 // It is constant within a given Recoil root.
 export type Store = $ReadOnly<{
+  storeID: StoreID,
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
   getGraph: Version => Graph,
@@ -140,9 +148,6 @@ export type Store = $ReadOnly<{
 export type StoreRef = {
   current: Store,
 };
-
-let nextTreeStateVersion = 0;
-const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
 
 function makeEmptyTreeState(): TreeState {
   const version = getNextTreeStateVersion();

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -8,26 +8,19 @@
  * @flow strict
  * @format
  */
-
 'use strict';
 
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {PersistentMap} from '../adt/Recoil_PersistentMap';
 import type {Graph} from './Recoil_GraphTypes';
-import type {
-  ComponentID,
-  NodeKey,
-  StateID,
-  StoreID,
-  Version,
-} from './Recoil_Keys';
+import type {ComponentID, NodeKey, StateID, StoreID} from './Recoil_Keys';
 import type {RetentionZone} from './Recoil_RetentionZone';
 
 const {persistentMap} = require('../adt/Recoil_PersistentMap');
 const {graph} = require('./Recoil_Graph');
 const {getNextTreeStateVersion} = require('./Recoil_Keys');
 
-export type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
+export type {ComponentID, NodeKey, StateID, StoreID} from './Recoil_Keys';
 
 // flowlint-next-line unclear-type:off
 export type AtomValues = PersistentMap<NodeKey, Loadable<any>>;
@@ -44,7 +37,7 @@ export type Retainable = RetentionZone | NodeKey;
 export type TreeState = $ReadOnly<{
   // Version always increments when moving from one state to another, even
   // if the same state has been seen before.
-  version: Version,
+  version: StateID,
 
   // State ID usually increments, but when going to a snapshot that was
   // previously rendered the state ID will be re-used:
@@ -87,7 +80,7 @@ export type StoreState = {
   // Added to when components commit or suspend after reading a version.
   // Removed from when components (1) unmount (2) commit another version
   // or (3) wake from suspense.
-  +versionsUsedByComponent: Map<ComponentID, Version>,
+  +versionsUsedByComponent: Map<ComponentID, StateID>,
 
   +retention: {
     referenceCounts: Map<NodeKey | RetentionZone, number>,
@@ -116,7 +109,7 @@ export type StoreState = {
   // In case of async request completion, we walk downward from updated selector
   // In (future) case of component subscriptions updated, we walk upwards from
   // component and then downward from any no-longer-depended on nodes
-  +graphsByVersion: Map<Version, Graph>,
+  +graphsByVersion: Map<StateID, Graph>,
   // Side note: it would be useful to consider async request completion as
   // another type of transaction since it should increase version etc. and many
   // things have to happen in both of these cases.
@@ -140,7 +133,7 @@ export type Store = $ReadOnly<{
   storeID: StoreID,
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
-  getGraph: Version => Graph,
+  getGraph: StateID => Graph,
   subscribeToTransactions: ((Store) => void, ?NodeKey) => {release: () => void},
   addTransactionMetadata: ({...}) => void,
 }>;

--- a/packages/recoil/core/__tests__/Recoil_useRecoilStoreID-test.js
+++ b/packages/recoil/core/__tests__/Recoil_useRecoilStoreID-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
+
+let React, renderElements, RecoilRoot, useRecoilStoreID;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
+  ({RecoilRoot} = require('../Recoil_RecoilRoot.react'));
+  ({useRecoilStoreID} = require('../Recoil_RecoilRoot.react'));
+});
+
+testRecoil('useRecoilStoreID', () => {
+  const storeIDs = {};
+  function StoreID({rootKey}) {
+    const storeID = useRecoilStoreID();
+    storeIDs[rootKey] = storeID;
+    return null;
+  }
+  function MyApp() {
+    return (
+      <div>
+        <RecoilRoot>
+          <StoreID rootKey="A" />
+          <RecoilRoot>
+            <StoreID rootKey="A1" />
+          </RecoilRoot>
+          <RecoilRoot override={false}>
+            <StoreID rootKey="A2" />
+          </RecoilRoot>
+        </RecoilRoot>
+        <RecoilRoot>
+          <StoreID rootKey="B" />
+        </RecoilRoot>
+      </div>
+    );
+  }
+
+  renderElements(<MyApp />);
+
+  expect('A' in storeIDs).toEqual(true);
+  expect('A1' in storeIDs).toEqual(true);
+  expect('A2' in storeIDs).toEqual(true);
+  expect('B' in storeIDs).toEqual(true);
+  expect(storeIDs.A).not.toEqual(storeIDs.B);
+  expect(storeIDs.A).not.toEqual(storeIDs.A1);
+  expect(storeIDs.A).toEqual(storeIDs.A2);
+  expect(storeIDs.B).not.toEqual(storeIDs.A1);
+  expect(storeIDs.B).not.toEqual(storeIDs.A2);
+});

--- a/packages/recoil/hooks/Recoil_SnapshotHooks.js
+++ b/packages/recoil/hooks/Recoil_SnapshotHooks.js
@@ -236,7 +236,7 @@ function useGotoRecoilSnapshot(): Snapshot => void {
         storeRef.current.replaceState(state => {
           return {
             ...state,
-            stateID: snapshot.getID_INTERNAL(),
+            stateID: snapshot.getID(),
           };
         });
       });

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -60,6 +60,7 @@
 // @fb-only: import type {ScopeRules} from 'Recoil_ScopedAtom';
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {RecoilValueInfo} from '../core/Recoil_FunctionalCore';
+import type {StoreID} from '../core/Recoil_Keys';
 import type {
   PersistenceInfo,
   ReadWriteNodeOptions,
@@ -115,6 +116,7 @@ type NewValueOrUpdater<T> =
 // Effect is called the first time a node is used with a <RecoilRoot>
 export type AtomEffect<T> = ({
   node: RecoilState<T>,
+  storeID: StoreID,
   trigger: Trigger,
 
   // Call synchronously to initialize value or async to change it later
@@ -394,6 +396,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       for (const effect of options.effects_UNSTABLE ?? []) {
         const cleanup = effect({
           node,
+          storeID: store.storeID,
           trigger,
           setSelf: setSelf(effect),
           resetSelf: resetSelf(effect),

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -59,6 +59,7 @@ import type {
   NodeCacheRoute,
   TreeCacheImplementation,
 } from '../caches/Recoil_TreeCacheImplementationType';
+import type {StateID} from '../core/Recoil_Keys';
 import type {DefaultValue} from '../core/Recoil_Node';
 import type {
   RecoilState,
@@ -174,7 +175,7 @@ type ExecutionInfo<T> = {
   depValuesDiscoveredSoFarDuringAsyncWork: ?DepValues,
   latestLoadable: ?Loadable<T>,
   latestExecutionId: ?ExecutionId,
-  stateVersion: ?number,
+  stateVersion: ?StateID,
 };
 
 // An object to hold the current state for loading dependencies for a particular

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -24,6 +24,7 @@ let React,
   useRecoilState,
   useRecoilCallback,
   useRecoilValue,
+  useRecoilStoreID,
   selector,
   useRecoilTransactionObserver,
   useResetRecoilState,
@@ -44,7 +45,10 @@ const testRecoil = getRecoilTestFn(() => {
   ({act} = require('ReactTestUtils'));
 
   ({DEFAULT_VALUE, DefaultValue} = require('../../core/Recoil_Node'));
-  ({RecoilRoot} = require('../../core/Recoil_RecoilRoot.react'));
+  ({
+    RecoilRoot,
+    useRecoilStoreID,
+  } = require('../../core/Recoil_RecoilRoot.react'));
   ({
     getRecoilValueAsLoadable,
     setRecoilValue,
@@ -1190,6 +1194,37 @@ describe('Effects', () => {
       act(() => setMyAtom('SET_ATOM'));
       await setTest;
     });
+  });
+
+  testRecoil('storeID matches <RecoilRoot>', async () => {
+    let effectStoreID;
+    const myAtom = atom({
+      key: 'atom effect - storeID',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        ({storeID, setSelf}) => {
+          effectStoreID = storeID;
+          setSelf('INIT');
+        },
+      ],
+    });
+
+    let rootStoreID;
+    function StoreID() {
+      rootStoreID = useRecoilStoreID();
+      return null;
+    }
+
+    const c = renderElements(
+      <div>
+        <StoreID />
+        <ReadsAtom atom={myAtom} />
+      </div>,
+    );
+
+    expect(c.textContent).toEqual('"INIT"');
+    expect(effectStoreID).not.toEqual(undefined);
+    expect(effectStoreID).toEqual(rootStoreID);
   });
 });
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -283,6 +283,16 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
   */
  export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
 
+ // useRecoilStoreID
+ declare const StoreID_OPAQUE: unique symbol;
+ export interface StoreID {
+  readonly [StoreID_OPAQUE]: true;
+ }
+ /**
+  * Returns an ID for the currently active state store of the host <RecoilRoot>
+  */
+ export function useRecoilStoreID(): StoreID;
+
  // loadable.d.ts
  interface BaseLoadable<T> {
   getValue: () => T;

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -79,6 +79,7 @@
  // Effect is called the first time a node is used with a <RecoilRoot>
  export type AtomEffect<T> = (param: {
   node: RecoilState<T>,
+  storeID: StoreID,
   trigger: 'set' | 'get',
 
   // Call synchronously to initialize value or async to change it later

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -571,7 +571,11 @@ isRecoilValue(mySelector1);
     key: 'thisismyrandomkey',
     default: 0,
     effects_UNSTABLE: [
-      ({node, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+      ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+        node; // $ExpectType RecoilState<number>
+        storeID; // $ExpectType StoreID
+        trigger; // $ExpectType "get" | "set"
+
         setSelf(1);
         setSelf('a'); // $ExpectError
 
@@ -607,8 +611,12 @@ isRecoilValue(mySelector1);
     key: 'myrandomatomfamilykey',
     default: (param: number) => param,
     effects_UNSTABLE: (param) => [
-      ({node, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+      ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
         param; // $ExpectType number
+
+        node; // $ExpectType RecoilState<number>
+        storeID; // $ExpectType StoreID
+        trigger; // $ExpectType "get" | "set"
 
         setSelf(1);
         setSelf('a'); // $ExpectError

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -29,6 +29,7 @@
   Loadable, RecoilLoadable,
   useRecoilTransaction_UNSTABLE,
   useRecoilRefresher_UNSTABLE,
+  useRecoilStoreID,
 } from 'recoil';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -329,6 +330,14 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
   RecoilBridgeComponent({});
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   RecoilBridgeComponent({initializeState: () => {}}); // $ExpectError
+}
+
+/**
+ * ueRecoilStoreID()
+ */
+{
+  useRecoilStoreID(2); // $ExpectError
+  useRecoilStoreID(); // $ExpectType StoreID
 }
 
 // Other


### PR DESCRIPTION
Summary: Add `storeID` to Atom effects interface.  This `storeID` is opaque but should match up with the current ID returned by `useRecoilStoreID()` hook for the host `<RecoilRoot>`

Differential Revision: D32405538

