### PR TITLE
useRecoilStoreID()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
+- `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 
 ### Pending

--- a/packages/recoil/Recoil_index.js
+++ b/packages/recoil/Recoil_index.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+export type {StoreID} from './core/Recoil_Keys';
 export type {PersistenceType} from './core/Recoil_Node';
 export type {
   RecoilValue,
@@ -42,7 +43,10 @@ export type {
 
 const {RecoilLoadable} = require('./adt/Recoil_Loadable');
 const {DefaultValue} = require('./core/Recoil_Node');
-const {RecoilRoot} = require('./core/Recoil_RecoilRoot.react');
+const {
+  RecoilRoot,
+  useRecoilStoreID,
+} = require('./core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
 const {retentionZone} = require('./core/Recoil_RetentionZone');
 const {freshSnapshot} = require('./core/Recoil_Snapshot');
@@ -88,6 +92,7 @@ module.exports = {
 
   // Recoil Root
   RecoilRoot,
+  useRecoilStoreID,
   useRecoilBridgeAcrossReactRoots_UNSTABLE: useRecoilBridgeAcrossReactRoots,
 
   // Atoms/Selectors

--- a/packages/recoil/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/recoil/__test_utils__/Recoil_TestingUtils.js
@@ -22,6 +22,7 @@ const ReactDOM = require('ReactDOMLegacy_DEPRECATED');
 const {act} = require('ReactTestUtils');
 
 const {graph} = require('../core/Recoil_Graph');
+const {getNextStoreID} = require('../core/Recoil_Keys');
 const {
   RecoilRoot,
   notifyComponents_FOR_TESTING,
@@ -51,7 +52,8 @@ const IS_INTERNAL = false; // @oss-only
 // TODO Use Snapshot for testing instead of this thunk?
 function makeStore(): Store {
   const storeState = makeEmptyStoreState();
-  const store = {
+  const store: Store = {
+    storeID: getNextStoreID(),
     getState: () => storeState,
     replaceState: replacer => {
       const currentStoreState = store.getState();

--- a/packages/recoil/core/Recoil_Keys.js
+++ b/packages/recoil/core/Recoil_Keys.js
@@ -15,5 +15,15 @@ export type NodeKey = string;
 export type ComponentID = number;
 export type Version = number;
 export type StateID = number;
+export type StoreID = number;
 
-module.exports = ({}: {...});
+let nextTreeStateVersion = 0;
+const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
+
+let nextStoreID = 0;
+const getNextStoreID = (): StoreID => nextStoreID++;
+
+module.exports = {
+  getNextTreeStateVersion,
+  getNextStoreID,
+};

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -34,6 +34,7 @@ const {
   peekNodeInfo,
 } = require('./Recoil_FunctionalCore');
 const {graph} = require('./Recoil_Graph');
+const {getNextStoreID} = require('./Recoil_Keys');
 const {
   DEFAULT_VALUE,
   recoilValues,
@@ -76,6 +77,7 @@ class Snapshot {
 
   constructor(storeState: StoreState) {
     this._store = {
+      storeID: getNextStoreID(),
       getState: () => storeState,
       replaceState: replacer => {
         storeState.currentTree = replacer(storeState.currentTree); // no batching so nextTree is never active

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -14,11 +14,18 @@
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {PersistentMap} from '../adt/Recoil_PersistentMap';
 import type {Graph} from './Recoil_GraphTypes';
-import type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
+import type {
+  ComponentID,
+  NodeKey,
+  StateID,
+  StoreID,
+  Version,
+} from './Recoil_Keys';
 import type {RetentionZone} from './Recoil_RetentionZone';
 
 const {persistentMap} = require('../adt/Recoil_PersistentMap');
 const {graph} = require('./Recoil_Graph');
+const {getNextTreeStateVersion} = require('./Recoil_Keys');
 
 export type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
 
@@ -130,6 +137,7 @@ export type StoreState = {
 // The Store is just the interface that is made available via the context.
 // It is constant within a given Recoil root.
 export type Store = $ReadOnly<{
+  storeID: StoreID,
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
   getGraph: Version => Graph,
@@ -140,9 +148,6 @@ export type Store = $ReadOnly<{
 export type StoreRef = {
   current: Store,
 };
-
-let nextTreeStateVersion = 0;
-const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
 
 function makeEmptyTreeState(): TreeState {
   const version = getNextTreeStateVersion();

--- a/packages/recoil/core/__tests__/Recoil_useRecoilStoreID-test.js
+++ b/packages/recoil/core/__tests__/Recoil_useRecoilStoreID-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
+
+let React, renderElements, RecoilRoot, useRecoilStoreID;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
+  ({RecoilRoot} = require('../Recoil_RecoilRoot.react'));
+  ({useRecoilStoreID} = require('../Recoil_RecoilRoot.react'));
+});
+
+testRecoil('useRecoilStoreID', () => {
+  const storeIDs = {};
+  function StoreID({rootKey}) {
+    const storeID = useRecoilStoreID();
+    storeIDs[rootKey] = storeID;
+    return null;
+  }
+  function MyApp() {
+    return (
+      <div>
+        <RecoilRoot>
+          <StoreID rootKey="A" />
+          <RecoilRoot>
+            <StoreID rootKey="A1" />
+          </RecoilRoot>
+          <RecoilRoot override={false}>
+            <StoreID rootKey="A2" />
+          </RecoilRoot>
+        </RecoilRoot>
+        <RecoilRoot>
+          <StoreID rootKey="B" />
+        </RecoilRoot>
+      </div>
+    );
+  }
+
+  renderElements(<MyApp />);
+
+  expect('A' in storeIDs).toEqual(true);
+  expect('A1' in storeIDs).toEqual(true);
+  expect('A2' in storeIDs).toEqual(true);
+  expect('B' in storeIDs).toEqual(true);
+  expect(storeIDs.A).not.toEqual(storeIDs.B);
+  expect(storeIDs.A).not.toEqual(storeIDs.A1);
+  expect(storeIDs.A).toEqual(storeIDs.A2);
+  expect(storeIDs.B).not.toEqual(storeIDs.A1);
+  expect(storeIDs.B).not.toEqual(storeIDs.A2);
+});

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -283,6 +283,16 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
   */
  export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
 
+ // useRecoilStoreID
+ declare const StoreID_OPAQUE: unique symbol;
+ export interface StoreID {
+  readonly [StoreID_OPAQUE]: true;
+ }
+ /**
+  * Returns an ID for the currently active state store of the host <RecoilRoot>
+  */
+ export function useRecoilStoreID(): StoreID;
+
  // loadable.d.ts
  interface BaseLoadable<T> {
   getValue: () => T;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -29,6 +29,7 @@
   Loadable, RecoilLoadable,
   useRecoilTransaction_UNSTABLE,
   useRecoilRefresher_UNSTABLE,
+  useRecoilStoreID,
 } from 'recoil';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -329,6 +330,14 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
   RecoilBridgeComponent({});
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   RecoilBridgeComponent({initializeState: () => {}}); // $ExpectError
+}
+
+/**
+ * ueRecoilStoreID()
+ */
+{
+  useRecoilStoreID(2); // $ExpectError
+  useRecoilStoreID(); // $ExpectType StoreID
 }
 
 // Other


### PR DESCRIPTION
Summary: Add `useRecoilStoreID()` which will return an opaque ID that is unique for the `<RecoilRoot/>`.  This is a store ID and not a RecoilRoot ID because `<RecoilRoot override={false}>` will cause it to re-use the same store.  A Recoil Bridge will also re-use the same `StoreID`.

Reviewed By: davidmccabe

Differential Revision: D32041425

