### PR TITLE
Add built-in support for Sets with Transit serialization

### DIFF
--- a/packages/recoil-sync/RecoilSync_URLTransit.js
+++ b/packages/recoil-sync/RecoilSync_URLTransit.js
@@ -44,6 +44,12 @@ const BUILTIN_HANDLERS = [
     write: x => x.toISOString(),
     read: str => new Date(str),
   },
+  {
+    tag: 'Set',
+    class: Set,
+    write: x => Array.from(x),
+    read: arr => new Set(arr),
+  },
 ];
 
 function useRecoilURLSyncTransit({

--- a/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
@@ -21,12 +21,18 @@ const {
   array,
   boolean,
   jsonDate,
+  literal,
   number,
   object,
   string,
   tuple,
 } = require('refine');
 
+const atomNull = atom({
+  key: 'null',
+  default: null,
+  effects_UNSTABLE: [syncEffect({refine: literal(null), syncDefault: true})],
+});
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
@@ -68,6 +74,7 @@ async function testJSON(loc, contents, beforeURL, afterURL) {
   const container = renderElements(
     <>
       <RecoilURLSyncJSON location={loc} />
+      <ReadsAtom atom={atomNull} />
       <ReadsAtom atom={atomBoolean} />
       <ReadsAtom atom={atomNumber} />
       <ReadsAtom atom={atomString} />
@@ -85,30 +92,30 @@ describe('URL JSON Encode', () => {
   test('Anchor', async () =>
     testJSON(
       {part: 'hash'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html?foo=bar',
-      '/path/page.html?foo=bar#%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D',
+      '/path/page.html?foo=bar#%7B%22null%22%3Anull%2C%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D',
     ));
   test('Search', async () =>
     testJSON(
       {part: 'search'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html#anchor',
-      '/path/page.html?%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
-    ));
-  test('Query Params', async () =>
-    testJSON(
-      {part: 'queryParams'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
-      '/path/page.html#anchor',
-      '/path/page.html?boolean=true&number=123&string=%22STRING%22&array=%5B1%2C%22a%22%5D&object=%7B%22foo%22%3A%5B1%2C2%5D%7D&date=%221985-10-26T07%3A00%3A00.000Z%22#anchor',
+      '/path/page.html?%7B%22null%22%3Anull%2C%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
     ));
   test('Query Param', async () =>
     testJSON(
       {part: 'queryParams', param: 'param'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
+      '/path/page.html?foo=bar&param=%7B%22null%22%3Anull%2C%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
+    ));
+  test('Query Params', async () =>
+    testJSON(
+      {part: 'queryParams'},
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      '/path/page.html#anchor',
+      '/path/page.html?null=null&boolean=true&number=123&string=%22STRING%22&array=%5B1%2C%22a%22%5D&object=%7B%22foo%22%3A%5B1%2C2%5D%7D&date=%221985-10-26T07%3A00%3A00.000Z%22#anchor',
     ));
 });
 
@@ -116,29 +123,29 @@ describe('URL JSON Parse', () => {
   test('Anchor', async () =>
     testJSON(
       {part: 'hash'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/#{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
-      '/#%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/#{"null":null,"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/#%7B%22null%22%3Anull%2C%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
     ));
   test('Search', async () =>
     testJSON(
       {part: 'search'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/?{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
-      '/?%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
-    ));
-  test('Query Params', async () =>
-    testJSON(
-      {part: 'queryParams'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/?boolean=false&number=456&string="SET"&array=[2,"b"]&object={"foo":[]}&date="1955-11-05T07:00:00.000Z"',
-      '/?boolean=false&number=456&string=%22SET%22&array=%5B2%2C%22b%22%5D&object=%7B%22foo%22%3A%5B%5D%7D&date=%221955-11-05T07%3A00%3A00.000Z%22',
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?{"null":null,"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/?%7B%22null%22%3Anull%2C%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
     ));
   test('Query Param', async () =>
     testJSON(
       {part: 'queryParams', param: 'param'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/?param={"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
-      '/?param=%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?param={"null":null,"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/?param=%7B%22null%22%3Anull%2C%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
+    ));
+  test('Query Params', async () =>
+    testJSON(
+      {part: 'queryParams'},
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?null=null&boolean=false&number=456&string="SET"&array=[2,"b"]&object={"foo":[]}&date="1955-11-05T07:00:00.000Z"',
+      '/?null=null&boolean=false&number=456&string=%22SET%22&array=%5B2%2C%22b%22%5D&object=%7B%22foo%22%3A%5B%5D%7D&date=%221955-11-05T07%3A00%3A00.000Z%22',
     ));
 });

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -21,6 +21,7 @@ const {
   array,
   boolean,
   custom,
+  literal,
   number,
   object,
   string,
@@ -34,6 +35,11 @@ class MyClass {
   }
 }
 
+const atomNull = atom({
+  key: 'null',
+  default: null,
+  effects_UNSTABLE: [syncEffect({refine: literal(null), syncDefault: true})],
+});
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
@@ -104,34 +110,34 @@ describe('URL Transit Encode', () => {
   test('Anchor - primitives', async () =>
     testTransit(
       {part: 'hash'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html?foo=bar',
-      '/path/page.html?foo=bar#%5B%22%5E%20%22%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D',
+      '/path/page.html?foo=bar#%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D',
     ));
   test('Search - primitives', async () =>
     testTransit(
       {part: 'search'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html#anchor',
-      '/path/page.html?%5B%22%5E%20%22%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
+      '/path/page.html?%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
     ));
   test('Query Param - primitives', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22null%22%2Cnull%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
     ));
   test('Query Params - primitives', async () =>
     testTransit(
       {part: 'queryParams'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html#anchor',
-      '/path/page.html?boolean=%5B%22%7E%23%27%22%2Ctrue%5D&number=%5B%22%7E%23%27%22%2C123%5D&string=%5B%22%7E%23%27%22%2C%22STRING%22%5D#anchor',
+      '/path/page.html?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Ctrue%5D&number=%5B%22%7E%23%27%22%2C123%5D&string=%5B%22%7E%23%27%22%2C%22STRING%22%5D#anchor',
     ));
   test('Query Param - containers', async () =>
     testTransit(
@@ -171,34 +177,34 @@ describe('URL Transit Parse', () => {
   test('Anchor - primitives', async () =>
     testTransit(
       {part: 'hash'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/#["^ ","boolean",false,"number",456,"string","SET"]',
-      '/#%5B%22%5E%20%22%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/#["^ ","null",null,"boolean",false,"number",456,"string","SET"]',
+      '/#%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
     ));
   test('Search - primitives', async () =>
     testTransit(
       {part: 'search'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/?["^ ","boolean",false,"number",456,"string","SET"]',
-      '/?%5B%22%5E%20%22%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/?["^ ","null",null,"boolean",false,"number",456,"string","SET"]',
+      '/?%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
     ));
   test('Query Param - primitives', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/?param=["^ ","boolean",false,"number",456,"string","SET"]',
-      '/?param=%5B%22%5E+%22%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/?param=["^ ","null",null,"boolean",false,"number",456,"string","SET"]',
+      '/?param=%5B%22%5E+%22%2C%22null%22%2Cnull%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
     ));
   test('Query Params - primitives', async () =>
     testTransit(
       {part: 'queryParams'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/?boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
-      '/?boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
+      '/?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
     ));
   test('Query Param - containers', async () =>
     testTransit(

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -25,6 +25,7 @@ const {
   literal,
   number,
   object,
+  set,
   string,
   tuple,
 } = require('refine');
@@ -69,6 +70,11 @@ const atomObject = atom({
   effects_UNSTABLE: [
     syncEffect({refine: object({foo: array(number())}), syncDefault: true}),
   ],
+});
+const atomSet = atom({
+  key: 'set',
+  default: new Set([1, 2]),
+  effects_UNSTABLE: [syncEffect({refine: set(number()), syncDefault: true})],
 });
 const atomDate = atom({
   key: 'date',
@@ -144,7 +150,7 @@ describe('URL Transit Encode', () => {
       '/path/page.html#anchor',
       '/path/page.html?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Ctrue%5D&number=%5B%22%7E%23%27%22%2C123%5D&string=%5B%22%7E%23%27%22%2C%22STRING%22%5D#anchor',
     ));
-  test('Query Param - containers', async () =>
+  test('Query Param - objects', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
       [atomArray, atomObject],
@@ -152,13 +158,29 @@ describe('URL Transit Encode', () => {
       '/path/page.html?foo=bar#anchor',
       '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22array%22%2C%5B1%2C%22a%22%5D%2C%22object%22%2C%5B%22%5E+%22%2C%22foo%22%2C%5B1%2C2%5D%5D%5D#anchor',
     ));
-  test('Query Params - containers', async () =>
+  test('Query Params - objects', async () =>
     testTransit(
       {part: 'queryParams'},
       [atomArray, atomObject],
       '[1,"a"]{"foo":[1,2]}',
       '/path/page.html#anchor',
       '/path/page.html?array=%5B1%2C%22a%22%5D&object=%5B%22%5E+%22%2C%22foo%22%2C%5B1%2C2%5D%5D#anchor',
+    ));
+  test('Query Param - containers', async () =>
+    testTransit(
+      {part: 'queryParams', param: 'param'},
+      [atomSet],
+      '[1,2]',
+      '/path/page.html?foo=bar#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D%5D#anchor',
+    ));
+  test('Query Params - containers', async () =>
+    testTransit(
+      {part: 'queryParams'},
+      [atomSet],
+      '[1,2]',
+      '/path/page.html#anchor',
+      '/path/page.html?set=%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D#anchor',
     ));
   test('Query Param - classes', async () =>
     testTransit(
@@ -211,7 +233,7 @@ describe('URL Transit Parse', () => {
       '/?null=["~%23\'",null]&boolean=["~%23\'",false]&number=["~%23\'",456]&string=["~%23\'","SET"]',
       '/?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
     ));
-  test('Query Param - containers', async () =>
+  test('Query Param - objects', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
       [atomArray, atomObject],
@@ -219,13 +241,29 @@ describe('URL Transit Parse', () => {
       '/?param=["^ ","array",[2,"b"],"object",["^ ","foo",[]]]',
       '/?param=%5B%22%5E+%22%2C%22array%22%2C%5B2%2C%22b%22%5D%2C%22object%22%2C%5B%22%5E+%22%2C%22foo%22%2C%5B%5D%5D%5D',
     ));
-  test('Query Params - containers', async () =>
+  test('Query Params - objects', async () =>
     testTransit(
       {part: 'queryParams'},
       [atomArray, atomObject],
       '[2,"b"]{"foo":[]}',
       '/?array=[2,"b"]&object=["^+","foo",[]]',
       '/?array=%5B2%2C%22b%22%5D&object=%5B%22%5E+%22%2C%22foo%22%2C%5B%5D%5D',
+    ));
+  test('Query Param - containers', async () =>
+    testTransit(
+      {part: 'queryParams', param: 'param'},
+      [atomSet],
+      '[3,4]',
+      '/?param=["^+","set",["~%23Set",[3,4]]]',
+      '/?param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D%5D',
+    ));
+  test('Query Params - containers', async () =>
+    testTransit(
+      {part: 'queryParams'},
+      [atomSet],
+      '[3,4]',
+      '/?set=["~%23Set",[3,4]]',
+      '/?set=%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D',
     ));
   test('Query Param - classes', async () =>
     testTransit(


### PR DESCRIPTION
Summary: Add built-in support for `Set` with Transit serialization for URL synchronization.

Differential Revision: D32451884

