### PR TITLE
Support atoms with fallback selectors for Transit serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
 - `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
+- `storeID` added to atom effects interface (#1414)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 
 ### Pending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## UPCOMING
 ***Add new changes here as they land***
 
-- Add `refresh` to Recoil callback interface
+- Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
+- `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 
 ### Pending
 - Memory management
@@ -32,6 +33,7 @@
 - Improved dev-mode checks:
   - Atoms freeze default, initialized, and async values.  Selectors should not freeze upstream dependencies. (#1261, #1259)
   - Perform runtime check that required options are provided when creating atoms and selectors. (#1324)
+- Fix user-thrown promises in selectors for some cases.
 - Allow class instances in family parameters for Flow
 
 ## 0.4.1 (2021-08-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
+- `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 
 ### Pending

--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -86,7 +86,7 @@ class Registries {
     return newRegistry;
   }
 }
-const registries = new Registries();
+const registries: Registries = new Registries();
 
 type Storage = {
   write?: WriteItems,
@@ -435,4 +435,5 @@ module.exports = {
   useRecoilSync,
   RecoilSync,
   syncEffect,
+  registries_FOR_TESTING: registries,
 };

--- a/packages/recoil-sync/RecoilSync_URLJSON.js
+++ b/packages/recoil-sync/RecoilSync_URLJSON.js
@@ -16,6 +16,7 @@ const {useRecoilURLSync} = require('./RecoilSync_URL');
 const err = require('./util/RecoilSync_err');
 const nullthrows = require('./util/RecoilSync_nullthrows');
 const React = require('react');
+const {useCallback} = require('react');
 
 export type RecoilURLSyncJSONOptions = $Rest<
   RecoilURLSyncOptions,
@@ -29,12 +30,12 @@ function useRecoilURLSyncJSON(options: RecoilURLSyncJSONOptions): void {
   if (options.location.part === 'href') {
     throw err('"href" location is not supported for JSON encoding');
   }
-  useRecoilURLSync({
-    ...options,
-    serialize: x =>
-      nullthrows(JSON.stringify(x), 'Unable to serialize state with JSON'),
-    deserialize: x => JSON.parse(x),
-  });
+  const serialize = useCallback(
+    x => nullthrows(JSON.stringify(x), 'Unable to serialize state with JSON'),
+    [],
+  );
+  const deserialize = useCallback(x => JSON.parse(x), []);
+  useRecoilURLSync({...options, serialize, deserialize});
 }
 
 function RecoilURLSyncJSON(props: RecoilURLSyncJSONOptions): React.Node {

--- a/packages/recoil-sync/RecoilSync_URLTransit.js
+++ b/packages/recoil-sync/RecoilSync_URLTransit.js
@@ -44,6 +44,12 @@ const BUILTIN_HANDLERS = [
     write: x => x.toISOString(),
     read: str => new Date(str),
   },
+  {
+    tag: 'Set',
+    class: Set,
+    write: x => Array.from(x),
+    read: arr => new Set(arr),
+  },
 ];
 
 function useRecoilURLSyncTransit({

--- a/packages/recoil-sync/RecoilSync_URLTransit.js
+++ b/packages/recoil-sync/RecoilSync_URLTransit.js
@@ -50,6 +50,12 @@ const BUILTIN_HANDLERS = [
     write: x => Array.from(x),
     read: arr => new Set(arr),
   },
+  {
+    tag: 'Map',
+    class: Map,
+    write: x => Array.from(x.entries()),
+    read: arr => new Map(arr),
+  },
 ];
 
 function useRecoilURLSyncTransit({

--- a/packages/recoil-sync/RecoilSync_URLTransit.js
+++ b/packages/recoil-sync/RecoilSync_URLTransit.js
@@ -12,6 +12,8 @@
 
 import type {RecoilURLSyncOptions} from './RecoilSync_URL';
 
+const {DefaultValue} = require('Recoil');
+
 const {useRecoilURLSync} = require('./RecoilSync_URL');
 const err = require('./util/RecoilSync_err');
 const React = require('react');
@@ -55,6 +57,12 @@ const BUILTIN_HANDLERS = [
     class: Map,
     write: x => Array.from(x.entries()),
     read: arr => new Map(arr),
+  },
+  {
+    tag: '__DV',
+    class: DefaultValue,
+    write: () => 0, // number encodes the smallest in URL
+    read: () => new DefaultValue(),
   },
 ];
 

--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -17,6 +17,7 @@ const {
 const {useRecoilURLSync} = require('../RecoilSync_URL');
 const nullthrows = require('../util/RecoilSync_nullthrows');
 const React = require('react');
+const {useCallback} = require('react');
 
 // ////////////////////////////
 // // Mock Serialization
@@ -31,16 +32,17 @@ function TestURLSync({
   location: LocationOption,
   browserInterface?: BrowserInterface,
 }): React.Node {
-  useRecoilURLSync({
-    storeKey,
-    location,
-    serialize: items => {
+  const serialize = useCallback(
+    items => {
       const str = nullthrows(JSON.stringify(items));
       return location.part === 'href'
         ? `/TEST#${encodeURIComponent(str)}`
         : str;
     },
-    deserialize: str => {
+    [location.part],
+  );
+  const deserialize = useCallback(
+    str => {
       const stateStr =
         location.part === 'href' ? decodeURIComponent(str.split('#')[1]) : str;
       // Skip the default URL parts which don't conform to the serialized standard.
@@ -51,6 +53,13 @@ function TestURLSync({
       }
       return JSON.parse(stateStr);
     },
+    [location.part],
+  );
+  useRecoilURLSync({
+    storeKey,
+    location,
+    serialize,
+    deserialize,
     browserInterface,
   });
   return null;

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -26,8 +26,13 @@ const {
   flushPromisesAndTimers,
   renderElements,
 } = require('../../../packages/recoil/__test_utils__/Recoil_TestingUtils');
-const {syncEffect, useRecoilSync} = require('../RecoilSync');
+const {
+  registries_FOR_TESTING,
+  syncEffect,
+  useRecoilSync,
+} = require('../RecoilSync');
 const React = require('react');
+const {useCallback, useState} = require('react');
 const {asType, match, number, string} = require('refine');
 
 ////////////////////////////
@@ -999,4 +1004,99 @@ test('Sibling <RecoilRoot>', async () => {
   expect(storageB.size).toBe(1);
   expect(storageA.get('a')?.contents).toBe('A');
   expect(storageB.get('b')?.contents).toBe('DEFAULT');
+});
+
+test('Unregister store and atoms', () => {
+  const key = 'recoil-sync unregister';
+  const atomCleanups = [];
+  const myAtom = atom({
+    key,
+    default: 'DEFAULT',
+    effects_UNSTABLE: [
+      ({storeID}) => {
+        expect(registries_FOR_TESTING.getAtomRegistry(storeID).has(key)).toBe(
+          false,
+        );
+      },
+      syncEffect({refine: string()}),
+      ({storeID}) => {
+        expect(registries_FOR_TESTING.getAtomRegistry(storeID).has(key)).toBe(
+          true,
+        );
+        return () => {
+          expect(registries_FOR_TESTING.getAtomRegistry(storeID).has(key)).toBe(
+            false,
+          );
+          atomCleanups.push(true);
+        };
+      },
+    ],
+  });
+
+  const subscriberRefCounts = [];
+  const unregister = jest.fn(idx => {
+    subscriberRefCounts[idx]--;
+  });
+  const register = jest.fn(idx => {
+    subscriberRefCounts[idx] = (subscriberRefCounts[idx] ?? 0) + 1;
+    return () => unregister(idx);
+  });
+  function TestSyncUnregister({idx}) {
+    const listen = useCallback(() => register(idx), [idx]);
+    useRecoilSync({listen});
+    return null;
+  }
+
+  let setNumRoots;
+  function MyRoots() {
+    const [roots, setRoots] = useState(0);
+    setNumRoots = setRoots;
+    return Array.from(Array(roots).keys()).map(i => (
+      <RecoilRoot key={i}>
+        {i}
+        <TestSyncUnregister idx={i} />
+        <ReadsAtom atom={myAtom} />
+      </RecoilRoot>
+    ));
+  }
+
+  const container = renderElements(<MyRoots />);
+  expect(container.textContent).toEqual('');
+  expect(register).toHaveBeenCalledTimes(0);
+  expect(unregister).toHaveBeenCalledTimes(0);
+  expect(subscriberRefCounts[0]).toEqual(undefined);
+  expect(subscriberRefCounts[1]).toEqual(undefined);
+  expect(atomCleanups.length).toEqual(0);
+
+  act(() => setNumRoots(1));
+  expect(container.textContent).toEqual('0"DEFAULT"');
+  expect(register).toHaveBeenCalledTimes(1);
+  expect(unregister).toHaveBeenCalledTimes(0);
+  expect(subscriberRefCounts[0]).toEqual(1);
+  expect(subscriberRefCounts[1]).toEqual(undefined);
+  expect(atomCleanups.length).toEqual(0);
+
+  act(() => setNumRoots(2));
+  expect(container.textContent).toEqual('0"DEFAULT"1"DEFAULT"');
+  expect(register).toHaveBeenCalledTimes(2);
+  expect(unregister).toHaveBeenCalledTimes(0);
+  expect(subscriberRefCounts[0]).toEqual(1);
+  expect(subscriberRefCounts[1]).toEqual(1);
+  expect(atomCleanups.length).toEqual(0);
+
+  act(() => setNumRoots(1));
+  expect(container.textContent).toEqual('0"DEFAULT"');
+  expect(register).toHaveBeenCalledTimes(2);
+  expect(unregister).toHaveBeenCalledTimes(1);
+  expect(subscriberRefCounts[0]).toEqual(1);
+  expect(subscriberRefCounts[1]).toEqual(0);
+  expect(atomCleanups.length).toEqual(1);
+
+  act(() => setNumRoots(0));
+  expect(container.textContent).toEqual('');
+  expect(register).toHaveBeenCalledTimes(2);
+  expect(unregister).toHaveBeenCalledTimes(2);
+  expect(subscriberRefCounts[0]).toEqual(0);
+  expect(subscriberRefCounts[1]).toEqual(0);
+  expect(atomCleanups.length).toEqual(2);
 });

--- a/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
@@ -21,12 +21,18 @@ const {
   array,
   boolean,
   jsonDate,
+  literal,
   number,
   object,
   string,
   tuple,
 } = require('refine');
 
+const atomNull = atom({
+  key: 'null',
+  default: null,
+  effects_UNSTABLE: [syncEffect({refine: literal(null), syncDefault: true})],
+});
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
@@ -68,6 +74,7 @@ async function testJSON(loc, contents, beforeURL, afterURL) {
   const container = renderElements(
     <>
       <RecoilURLSyncJSON location={loc} />
+      <ReadsAtom atom={atomNull} />
       <ReadsAtom atom={atomBoolean} />
       <ReadsAtom atom={atomNumber} />
       <ReadsAtom atom={atomString} />
@@ -85,30 +92,30 @@ describe('URL JSON Encode', () => {
   test('Anchor', async () =>
     testJSON(
       {part: 'hash'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html?foo=bar',
-      '/path/page.html?foo=bar#%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D',
+      '/path/page.html?foo=bar#%7B%22null%22%3Anull%2C%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D',
     ));
   test('Search', async () =>
     testJSON(
       {part: 'search'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html#anchor',
-      '/path/page.html?%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
-    ));
-  test('Query Params', async () =>
-    testJSON(
-      {part: 'queryParams'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
-      '/path/page.html#anchor',
-      '/path/page.html?boolean=true&number=123&string=%22STRING%22&array=%5B1%2C%22a%22%5D&object=%7B%22foo%22%3A%5B1%2C2%5D%7D&date=%221985-10-26T07%3A00%3A00.000Z%22#anchor',
+      '/path/page.html?%7B%22null%22%3Anull%2C%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
     ));
   test('Query Param', async () =>
     testJSON(
       {part: 'queryParams', param: 'param'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
+      '/path/page.html?foo=bar&param=%7B%22null%22%3Anull%2C%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
+    ));
+  test('Query Params', async () =>
+    testJSON(
+      {part: 'queryParams'},
+      'nulltrue123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
+      '/path/page.html#anchor',
+      '/path/page.html?null=null&boolean=true&number=123&string=%22STRING%22&array=%5B1%2C%22a%22%5D&object=%7B%22foo%22%3A%5B1%2C2%5D%7D&date=%221985-10-26T07%3A00%3A00.000Z%22#anchor',
     ));
 });
 
@@ -116,29 +123,29 @@ describe('URL JSON Parse', () => {
   test('Anchor', async () =>
     testJSON(
       {part: 'hash'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/#{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
-      '/#%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/#{"null":null,"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/#%7B%22null%22%3Anull%2C%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
     ));
   test('Search', async () =>
     testJSON(
       {part: 'search'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/?{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
-      '/?%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
-    ));
-  test('Query Params', async () =>
-    testJSON(
-      {part: 'queryParams'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/?boolean=false&number=456&string="SET"&array=[2,"b"]&object={"foo":[]}&date="1955-11-05T07:00:00.000Z"',
-      '/?boolean=false&number=456&string=%22SET%22&array=%5B2%2C%22b%22%5D&object=%7B%22foo%22%3A%5B%5D%7D&date=%221955-11-05T07%3A00%3A00.000Z%22',
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?{"null":null,"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/?%7B%22null%22%3Anull%2C%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
     ));
   test('Query Param', async () =>
     testJSON(
       {part: 'queryParams', param: 'param'},
-      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
-      '/?param={"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
-      '/?param=%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?param={"null":null,"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/?param=%7B%22null%22%3Anull%2C%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
+    ));
+  test('Query Params', async () =>
+    testJSON(
+      {part: 'queryParams'},
+      'nullfalse456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?null=null&boolean=false&number=456&string="SET"&array=[2,"b"]&object={"foo":[]}&date="1955-11-05T07:00:00.000Z"',
+      '/?null=null&boolean=false&number=456&string=%22SET%22&array=%5B2%2C%22b%22%5D&object=%7B%22foo%22%3A%5B%5D%7D&date=%221955-11-05T07%3A00%3A00.000Z%22',
     ));
 });

--- a/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
@@ -17,7 +17,15 @@ const {
 const {syncEffect} = require('../RecoilSync');
 const {RecoilURLSyncJSON} = require('../RecoilSync_URLJSON');
 const React = require('react');
-const {array, boolean, number, object, string, tuple} = require('refine');
+const {
+  array,
+  boolean,
+  jsonDate,
+  number,
+  object,
+  string,
+  tuple,
+} = require('refine');
 
 const atomBoolean = atom({
   key: 'boolean',
@@ -48,6 +56,11 @@ const atomObject = atom({
     syncEffect({refine: object({foo: array(number())}), syncDefault: true}),
   ],
 });
+const atomDate = atom({
+  key: 'date',
+  default: new Date('October 26, 1985'),
+  effects_UNSTABLE: [syncEffect({refine: jsonDate(), syncDefault: true})],
+});
 
 async function testJSON(loc, contents, beforeURL, afterURL) {
   history.replaceState(null, '', beforeURL);
@@ -60,6 +73,7 @@ async function testJSON(loc, contents, beforeURL, afterURL) {
       <ReadsAtom atom={atomString} />
       <ReadsAtom atom={atomArray} />
       <ReadsAtom atom={atomObject} />
+      <ReadsAtom atom={atomDate} />
     </>,
   );
   expect(container.textContent).toBe(contents);
@@ -71,30 +85,30 @@ describe('URL JSON Encode', () => {
   test('Anchor', async () =>
     testJSON(
       {part: 'hash'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}',
+      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html?foo=bar',
-      '/path/page.html?foo=bar#%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%7D',
+      '/path/page.html?foo=bar#%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D',
     ));
   test('Search', async () =>
     testJSON(
       {part: 'search'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}',
+      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html#anchor',
-      '/path/page.html?%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%7D#anchor',
+      '/path/page.html?%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
     ));
   test('Query Params', async () =>
     testJSON(
       {part: 'queryParams'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}',
+      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html#anchor',
-      '/path/page.html?boolean=true&number=123&string=%22STRING%22&array=%5B1%2C%22a%22%5D&object=%7B%22foo%22%3A%5B1%2C2%5D%7D#anchor',
+      '/path/page.html?boolean=true&number=123&string=%22STRING%22&array=%5B1%2C%22a%22%5D&object=%7B%22foo%22%3A%5B1%2C2%5D%7D&date=%221985-10-26T07%3A00%3A00.000Z%22#anchor',
     ));
   test('Query Param', async () =>
     testJSON(
       {part: 'queryParams', param: 'param'},
-      'true123"STRING"[1,"a"]{"foo":[1,2]}',
+      'true123"STRING"[1,"a"]{"foo":[1,2]}"1985-10-26T07:00:00.000Z"',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%7D#anchor',
+      '/path/page.html?foo=bar&param=%7B%22boolean%22%3Atrue%2C%22number%22%3A123%2C%22string%22%3A%22STRING%22%2C%22array%22%3A%5B1%2C%22a%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B1%2C2%5D%7D%2C%22date%22%3A%221985-10-26T07%3A00%3A00.000Z%22%7D#anchor',
     ));
 });
 
@@ -102,29 +116,29 @@ describe('URL JSON Parse', () => {
   test('Anchor', async () =>
     testJSON(
       {part: 'hash'},
-      'false456"SET"[2,"b"]{"foo":[]}',
-      '/#{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]}}',
-      '/#%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%7D',
+      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/#{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/#%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
     ));
   test('Search', async () =>
     testJSON(
       {part: 'search'},
-      'false456"SET"[2,"b"]{"foo":[]}',
-      '/?{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]}}',
-      '/?%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%7D',
+      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?{"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/?%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
     ));
   test('Query Params', async () =>
     testJSON(
       {part: 'queryParams'},
-      'false456"SET"[2,"b"]{"foo":[]}',
-      '/?boolean=false&number=456&string="SET"&array=[2,"b"]&object={"foo":[]}',
-      '/?boolean=false&number=456&string=%22SET%22&array=%5B2%2C%22b%22%5D&object=%7B%22foo%22%3A%5B%5D%7D',
+      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?boolean=false&number=456&string="SET"&array=[2,"b"]&object={"foo":[]}&date="1955-11-05T07:00:00.000Z"',
+      '/?boolean=false&number=456&string=%22SET%22&array=%5B2%2C%22b%22%5D&object=%7B%22foo%22%3A%5B%5D%7D&date=%221955-11-05T07%3A00%3A00.000Z%22',
     ));
   test('Query Param', async () =>
     testJSON(
       {part: 'queryParams', param: 'param'},
-      'false456"SET"[2,"b"]{"foo":[]}',
-      '/?param={"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]}}',
-      '/?param=%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%7D',
+      'false456"SET"[2,"b"]{"foo":[]}"1955-11-05T07:00:00.000Z"',
+      '/?param={"boolean":false,"number":456,"string":"SET","array":[2,"b"],"object":{"foo":[]},"date":"1955-11-05T07:00:00.000Z"}',
+      '/?param=%7B%22boolean%22%3Afalse%2C%22number%22%3A456%2C%22string%22%3A%22SET%22%2C%22array%22%3A%5B2%2C%22b%22%5D%2C%22object%22%3A%7B%22foo%22%3A%5B%5D%7D%2C%22date%22%3A%221955-11-05T07%3A00%3A00.000Z%22%7D',
     ));
 });

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -21,6 +21,7 @@ const {
   array,
   boolean,
   custom,
+  literal,
   number,
   object,
   string,
@@ -34,6 +35,11 @@ class MyClass {
   }
 }
 
+const atomNull = atom({
+  key: 'null',
+  default: null,
+  effects_UNSTABLE: [syncEffect({refine: literal(null), syncDefault: true})],
+});
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
@@ -104,34 +110,34 @@ describe('URL Transit Encode', () => {
   test('Anchor - primitives', async () =>
     testTransit(
       {part: 'hash'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html?foo=bar',
-      '/path/page.html?foo=bar#%5B%22%5E%20%22%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D',
+      '/path/page.html?foo=bar#%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D',
     ));
   test('Search - primitives', async () =>
     testTransit(
       {part: 'search'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html#anchor',
-      '/path/page.html?%5B%22%5E%20%22%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
+      '/path/page.html?%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
     ));
   test('Query Param - primitives', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22null%22%2Cnull%2C%22boolean%22%2Ctrue%2C%22number%22%2C123%2C%22string%22%2C%22STRING%22%5D#anchor',
     ));
   test('Query Params - primitives', async () =>
     testTransit(
       {part: 'queryParams'},
-      [atomBoolean, atomNumber, atomString],
-      'true123"STRING"',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nulltrue123"STRING"',
       '/path/page.html#anchor',
-      '/path/page.html?boolean=%5B%22%7E%23%27%22%2Ctrue%5D&number=%5B%22%7E%23%27%22%2C123%5D&string=%5B%22%7E%23%27%22%2C%22STRING%22%5D#anchor',
+      '/path/page.html?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Ctrue%5D&number=%5B%22%7E%23%27%22%2C123%5D&string=%5B%22%7E%23%27%22%2C%22STRING%22%5D#anchor',
     ));
   test('Query Param - containers', async () =>
     testTransit(
@@ -171,34 +177,34 @@ describe('URL Transit Parse', () => {
   test('Anchor - primitives', async () =>
     testTransit(
       {part: 'hash'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/#["^ ","boolean",false,"number",456,"string","SET"]',
-      '/#%5B%22%5E%20%22%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/#["^ ","null",null,"boolean",false,"number",456,"string","SET"]',
+      '/#%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
     ));
   test('Search - primitives', async () =>
     testTransit(
       {part: 'search'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/?["^ ","boolean",false,"number",456,"string","SET"]',
-      '/?%5B%22%5E%20%22%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/?["^ ","null",null,"boolean",false,"number",456,"string","SET"]',
+      '/?%5B%22%5E%20%22%2C%22null%22%2Cnull%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
     ));
   test('Query Param - primitives', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/?param=["^ ","boolean",false,"number",456,"string","SET"]',
-      '/?param=%5B%22%5E+%22%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/?param=["^ ","null",null,"boolean",false,"number",456,"string","SET"]',
+      '/?param=%5B%22%5E+%22%2C%22null%22%2Cnull%2C%22boolean%22%2Cfalse%2C%22number%22%2C456%2C%22string%22%2C%22SET%22%5D',
     ));
   test('Query Params - primitives', async () =>
     testTransit(
       {part: 'queryParams'},
-      [atomBoolean, atomNumber, atomString],
-      'false456"SET"',
-      '/?boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
-      '/?boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
+      [atomNull, atomBoolean, atomNumber, atomString],
+      'nullfalse456"SET"',
+      '/?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
+      '/?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
     ));
   test('Query Param - containers', async () =>
     testTransit(

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -23,6 +23,7 @@ const {
   custom,
   date,
   literal,
+  map,
   number,
   object,
   set,
@@ -75,6 +76,13 @@ const atomSet = atom({
   key: 'set',
   default: new Set([1, 2]),
   effects_UNSTABLE: [syncEffect({refine: set(number()), syncDefault: true})],
+});
+const atomMap = atom({
+  key: 'map',
+  default: new Map([[1, 'a']]),
+  effects_UNSTABLE: [
+    syncEffect({refine: map(number(), string()), syncDefault: true}),
+  ],
 });
 const atomDate = atom({
   key: 'date',
@@ -169,18 +177,18 @@ describe('URL Transit Encode', () => {
   test('Query Param - containers', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
-      [atomSet],
-      '[1,2]',
+      [atomSet, atomMap],
+      '[1,2]{"1":"a"}',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D%5D#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D%2C%22map%22%2C%5B%22%7E%23Map%22%2C%5B%5B1%2C%22a%22%5D%5D%5D%5D#anchor',
     ));
   test('Query Params - containers', async () =>
     testTransit(
       {part: 'queryParams'},
-      [atomSet],
-      '[1,2]',
+      [atomSet, atomMap],
+      '[1,2]{"1":"a"}',
       '/path/page.html#anchor',
-      '/path/page.html?set=%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D#anchor',
+      '/path/page.html?set=%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D&map=%5B%22%7E%23Map%22%2C%5B%5B1%2C%22a%22%5D%5D%5D#anchor',
     ));
   test('Query Param - classes', async () =>
     testTransit(
@@ -252,18 +260,18 @@ describe('URL Transit Parse', () => {
   test('Query Param - containers', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
-      [atomSet],
-      '[3,4]',
-      '/?param=["^+","set",["~%23Set",[3,4]]]',
-      '/?param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D%5D',
+      [atomSet, atomMap],
+      '[3,4]{"2":"b"}',
+      '/?param=["^+","set",["~%23Set",[3,4]],"map",["~%23Map",[[2,"b"]]]]',
+      '/?param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D%2C%22map%22%2C%5B%22%7E%23Map%22%2C%5B%5B2%2C%22b%22%5D%5D%5D%5D',
     ));
   test('Query Params - containers', async () =>
     testTransit(
       {part: 'queryParams'},
-      [atomSet],
-      '[3,4]',
-      '/?set=["~%23Set",[3,4]]',
-      '/?set=%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D',
+      [atomSet, atomMap],
+      '[3,4]{"2":"b"}',
+      '/?set=["~%23Set",[3,4]]&map=["~%23Map",[[2,"b"]]]',
+      '/?set=%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D&map=%5B%22%7E%23Map%22%2C%5B%5B2%2C%22b%22%5D%5D%5D',
     ));
   test('Query Param - classes', async () =>
     testTransit(

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -7,7 +7,7 @@
  */
 'use strict';
 
-const {atom} = require('Recoil');
+const {atom, selector} = require('Recoil');
 
 const {
   ReadsAtom,
@@ -99,6 +99,11 @@ const atomUser = atom({
     }),
   ],
 });
+const atomWithFallback = atom({
+  key: 'withFallback',
+  default: selector({key: 'fallback selector', get: () => 'FALLBACK'}),
+  effects_UNSTABLE: [syncEffect({refine: string(), syncDefault: true})],
+});
 
 const HANDLERS = [
   {
@@ -158,6 +163,7 @@ describe('URL Transit Encode', () => {
       '/path/page.html#anchor',
       '/path/page.html?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Ctrue%5D&number=%5B%22%7E%23%27%22%2C123%5D&string=%5B%22%7E%23%27%22%2C%22STRING%22%5D#anchor',
     ));
+
   test('Query Param - objects', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
@@ -174,6 +180,7 @@ describe('URL Transit Encode', () => {
       '/path/page.html#anchor',
       '/path/page.html?array=%5B1%2C%22a%22%5D&object=%5B%22%5E+%22%2C%22foo%22%2C%5B1%2C2%5D%5D#anchor',
     ));
+
   test('Query Param - containers', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
@@ -190,6 +197,7 @@ describe('URL Transit Encode', () => {
       '/path/page.html#anchor',
       '/path/page.html?set=%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D&map=%5B%22%7E%23Map%22%2C%5B%5B1%2C%22a%22%5D%5D%5D#anchor',
     ));
+
   test('Query Param - classes', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
@@ -205,6 +213,23 @@ describe('URL Transit Encode', () => {
       '"1985-10-26T07:00:00.000Z"{"prop":"CUSTOM"}',
       '/path/page.html#anchor',
       '/path/page.html?date=%5B%22%7E%23Date%22%2C%221985-10-26T07%3A00%3A00.000Z%22%5D&user=%5B%22%7E%23USER%22%2C%5B%22CUSTOM%22%5D%5D#anchor',
+    ));
+
+  test('Query Param - fallback', async () =>
+    testTransit(
+      {part: 'queryParams', param: 'param'},
+      [atomWithFallback],
+      '"FALLBACK"',
+      '/path/page.html?foo=bar#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22withFallback%22%2C%5B%22%7E%23__DV%22%2C0%5D%5D#anchor',
+    ));
+  test('Query Params - fallback', async () =>
+    testTransit(
+      {part: 'queryParams'},
+      [atomWithFallback],
+      '"FALLBACK"',
+      '/path/page.html#anchor',
+      '/path/page.html?withFallback=%5B%22%7E%23__DV%22%2C0%5D#anchor',
     ));
 });
 
@@ -241,6 +266,7 @@ describe('URL Transit Parse', () => {
       '/?null=["~%23\'",null]&boolean=["~%23\'",false]&number=["~%23\'",456]&string=["~%23\'","SET"]',
       '/?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
     ));
+
   test('Query Param - objects', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
@@ -257,6 +283,7 @@ describe('URL Transit Parse', () => {
       '/?array=[2,"b"]&object=["^+","foo",[]]',
       '/?array=%5B2%2C%22b%22%5D&object=%5B%22%5E+%22%2C%22foo%22%2C%5B%5D%5D',
     ));
+
   test('Query Param - containers', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
@@ -273,6 +300,7 @@ describe('URL Transit Parse', () => {
       '/?set=["~%23Set",[3,4]]&map=["~%23Map",[[2,"b"]]]',
       '/?set=%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D&map=%5B%22%7E%23Map%22%2C%5B%5B2%2C%22b%22%5D%5D%5D',
     ));
+
   test('Query Param - classes', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
@@ -288,5 +316,22 @@ describe('URL Transit Parse', () => {
       '"1955-11-05T07:00:00.000Z"{"prop":"PROP"}',
       '/?date=["~%23Date","1955-11-05T07:00:00.000Z"]&user=["~%23USER",["PROP"]]',
       '/?date=%5B%22%7E%23Date%22%2C%221955-11-05T07%3A00%3A00.000Z%22%5D&user=%5B%22%7E%23USER%22%2C%5B%22PROP%22%5D%5D',
+    ));
+
+  test('Query Param - fallback', async () =>
+    testTransit(
+      {part: 'queryParams', param: 'param'},
+      [atomWithFallback],
+      '"SET"',
+      '/?param=["^ ","withFallback","SET"]',
+      '/?param=%5B%22%5E+%22%2C%22withFallback%22%2C%22SET%22%5D',
+    ));
+  test('Query Params - fallback', async () =>
+    testTransit(
+      {part: 'queryParams'},
+      [atomWithFallback],
+      '"SET"',
+      '/?withFallback="SET"',
+      '/?withFallback=%5B%22%7E%23%27%22%2C%22SET%22%5D',
     ));
 });

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -25,6 +25,7 @@ const {
   literal,
   number,
   object,
+  set,
   string,
   tuple,
 } = require('refine');
@@ -69,6 +70,11 @@ const atomObject = atom({
   effects_UNSTABLE: [
     syncEffect({refine: object({foo: array(number())}), syncDefault: true}),
   ],
+});
+const atomSet = atom({
+  key: 'set',
+  default: new Set([1, 2]),
+  effects_UNSTABLE: [syncEffect({refine: set(number()), syncDefault: true})],
 });
 const atomDate = atom({
   key: 'date',
@@ -144,7 +150,7 @@ describe('URL Transit Encode', () => {
       '/path/page.html#anchor',
       '/path/page.html?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Ctrue%5D&number=%5B%22%7E%23%27%22%2C123%5D&string=%5B%22%7E%23%27%22%2C%22STRING%22%5D#anchor',
     ));
-  test('Query Param - containers', async () =>
+  test('Query Param - objects', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
       [atomArray, atomObject],
@@ -152,13 +158,29 @@ describe('URL Transit Encode', () => {
       '/path/page.html?foo=bar#anchor',
       '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22array%22%2C%5B1%2C%22a%22%5D%2C%22object%22%2C%5B%22%5E+%22%2C%22foo%22%2C%5B1%2C2%5D%5D%5D#anchor',
     ));
-  test('Query Params - containers', async () =>
+  test('Query Params - objects', async () =>
     testTransit(
       {part: 'queryParams'},
       [atomArray, atomObject],
       '[1,"a"]{"foo":[1,2]}',
       '/path/page.html#anchor',
       '/path/page.html?array=%5B1%2C%22a%22%5D&object=%5B%22%5E+%22%2C%22foo%22%2C%5B1%2C2%5D%5D#anchor',
+    ));
+  test('Query Param - containers', async () =>
+    testTransit(
+      {part: 'queryParams', param: 'param'},
+      [atomSet],
+      '[1,2]',
+      '/path/page.html?foo=bar#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D%5D#anchor',
+    ));
+  test('Query Params - containers', async () =>
+    testTransit(
+      {part: 'queryParams'},
+      [atomSet],
+      '[1,2]',
+      '/path/page.html#anchor',
+      '/path/page.html?set=%5B%22%7E%23Set%22%2C%5B1%2C2%5D%5D#anchor',
     ));
   test('Query Param - classes', async () =>
     testTransit(
@@ -211,7 +233,7 @@ describe('URL Transit Parse', () => {
       '/?null=["~%23\'",null]&boolean=["~%23\'",false]&number=["~%23\'",456]&string=["~%23\'","SET"]',
       '/?null=%5B%22%7E%23%27%22%2Cnull%5D&boolean=%5B%22%7E%23%27%22%2Cfalse%5D&number=%5B%22%7E%23%27%22%2C456%5D&string=%5B%22%7E%23%27%22%2C%22SET%22%5D',
     ));
-  test('Query Param - containers', async () =>
+  test('Query Param - objects', async () =>
     testTransit(
       {part: 'queryParams', param: 'param'},
       [atomArray, atomObject],
@@ -219,13 +241,29 @@ describe('URL Transit Parse', () => {
       '/?param=["^ ","array",[2,"b"],"object",["^ ","foo",[]]]',
       '/?param=%5B%22%5E+%22%2C%22array%22%2C%5B2%2C%22b%22%5D%2C%22object%22%2C%5B%22%5E+%22%2C%22foo%22%2C%5B%5D%5D%5D',
     ));
-  test('Query Params - containers', async () =>
+  test('Query Params - objects', async () =>
     testTransit(
       {part: 'queryParams'},
       [atomArray, atomObject],
       '[2,"b"]{"foo":[]}',
       '/?array=[2,"b"]&object=["^+","foo",[]]',
       '/?array=%5B2%2C%22b%22%5D&object=%5B%22%5E+%22%2C%22foo%22%2C%5B%5D%5D',
+    ));
+  test('Query Param - containers', async () =>
+    testTransit(
+      {part: 'queryParams', param: 'param'},
+      [atomSet],
+      '[3,4]',
+      '/?param=["^+","set",["~%23Set",[3,4]]]',
+      '/?param=%5B%22%5E+%22%2C%22set%22%2C%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D%5D',
+    ));
+  test('Query Params - containers', async () =>
+    testTransit(
+      {part: 'queryParams'},
+      [atomSet],
+      '[3,4]',
+      '/?set=["~%23Set",[3,4]]',
+      '/?set=%5B%22%7E%23Set%22%2C%5B3%2C4%5D%5D',
     ));
   test('Query Param - classes', async () =>
     testTransit(

--- a/packages/recoil/Recoil_index.js
+++ b/packages/recoil/Recoil_index.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+export type {StoreID} from './core/Recoil_Keys';
 export type {PersistenceType} from './core/Recoil_Node';
 export type {
   RecoilValue,
@@ -42,7 +43,10 @@ export type {
 
 const {RecoilLoadable} = require('./adt/Recoil_Loadable');
 const {DefaultValue} = require('./core/Recoil_Node');
-const {RecoilRoot} = require('./core/Recoil_RecoilRoot.react');
+const {
+  RecoilRoot,
+  useRecoilStoreID,
+} = require('./core/Recoil_RecoilRoot.react');
 const {isRecoilValue} = require('./core/Recoil_RecoilValue');
 const {retentionZone} = require('./core/Recoil_RetentionZone');
 const {freshSnapshot} = require('./core/Recoil_Snapshot');
@@ -90,6 +94,7 @@ module.exports = {
 
   // Recoil Root
   RecoilRoot,
+  useRecoilStoreID,
   useRecoilBridgeAcrossReactRoots_UNSTABLE: useRecoilBridgeAcrossReactRoots,
 
   // Atoms/Selectors

--- a/packages/recoil/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/recoil/__test_utils__/Recoil_TestingUtils.js
@@ -22,6 +22,7 @@ const ReactDOM = require('ReactDOMLegacy_DEPRECATED');
 const {act} = require('ReactTestUtils');
 
 const {graph} = require('../core/Recoil_Graph');
+const {getNextStoreID} = require('../core/Recoil_Keys');
 const {
   RecoilRoot,
   notifyComponents_FOR_TESTING,
@@ -51,7 +52,8 @@ const IS_INTERNAL = false; // @oss-only
 // TODO Use Snapshot for testing instead of this thunk?
 function makeStore(): Store {
   const storeState = makeEmptyStoreState();
-  const store = {
+  const store: Store = {
+    storeID: getNextStoreID(),
     getState: () => storeState,
     replaceState: replacer => {
       const currentStoreState = store.getState();

--- a/packages/recoil/core/Recoil_Graph.js
+++ b/packages/recoil/core/Recoil_Graph.js
@@ -12,7 +12,7 @@
 'use strict';
 
 import type {DependencyMap, Graph} from './Recoil_GraphTypes';
-import type {NodeKey, Version} from './Recoil_Keys';
+import type {NodeKey, StateID} from './Recoil_Keys';
 import type {Store} from './Recoil_State';
 
 const differenceSets = require('../util/Recoil_differenceSets');
@@ -21,7 +21,7 @@ const nullthrows = require('../util/Recoil_nullthrows');
 const recoverableViolation = require('../util/Recoil_recoverableViolation');
 export type {DependencyMap, Graph} from './Recoil_GraphTypes';
 
-function graph(): Graph {
+function makeGraph(): Graph {
   return {
     nodeDeps: new Map(),
     nodeToNodeSubscriptions: new Map(),
@@ -96,7 +96,7 @@ function mergeDependencyMapIntoGraph(
 function saveDependencyMapToStore(
   dependencyMap: DependencyMap,
   store: Store,
-  version: Version,
+  version: StateID,
 ): void {
   const storeState = store.getState();
   if (
@@ -162,7 +162,7 @@ function addToDependencyMap(
 module.exports = {
   addToDependencyMap,
   cloneGraph,
-  graph,
+  graph: makeGraph,
   mergeDepsIntoDependencyMap,
   saveDependencyMapToStore,
 };

--- a/packages/recoil/core/Recoil_Keys.js
+++ b/packages/recoil/core/Recoil_Keys.js
@@ -8,22 +8,24 @@
  * @flow strict
  * @format
  */
-
 'use strict';
 
 export type NodeKey = string;
-export type ComponentID = number;
-export type Version = number;
-export type StateID = number;
-export type StoreID = number;
+export opaque type StateID = number;
+export opaque type StoreID = number;
+export opaque type ComponentID = number;
 
 let nextTreeStateVersion = 0;
-const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
+const getNextTreeStateVersion: () => StateID = () => nextTreeStateVersion++;
 
 let nextStoreID = 0;
-const getNextStoreID = (): StoreID => nextStoreID++;
+const getNextStoreID: () => StoreID = () => nextStoreID++;
+
+let nextComponentID = 0;
+const getNextComponentID: () => ComponentID = () => nextComponentID++;
 
 module.exports = {
   getNextTreeStateVersion,
   getNextStoreID,
+  getNextComponentID,
 };

--- a/packages/recoil/core/Recoil_Keys.js
+++ b/packages/recoil/core/Recoil_Keys.js
@@ -15,5 +15,15 @@ export type NodeKey = string;
 export type ComponentID = number;
 export type Version = number;
 export type StateID = number;
+export type StoreID = number;
 
-module.exports = ({}: {...});
+let nextTreeStateVersion = 0;
+const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
+
+let nextStoreID = 0;
+const getNextStoreID = (): StoreID => nextStoreID++;
+
+module.exports = {
+  getNextTreeStateVersion,
+  getNextStoreID,
+};

--- a/packages/recoil/core/Recoil_RecoilRoot.react.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.react.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-import type {StoreID as InternalStoreID} from './Recoil_Keys';
+import type {StoreID} from './Recoil_Keys';
 import type {RecoilValue} from './Recoil_RecoilValue';
 import type {MutableSnapshot} from './Recoil_Snapshot';
 import type {Store, StoreRef, StoreState, TreeState} from './Recoil_State';
@@ -540,8 +540,6 @@ function RecoilRoot(props: Props): React.Node {
   return <RecoilRoot_INTERNAL {...propsExceptOverride} />;
 }
 
-// Opaque at this surface because it's part of the public API from here.
-export opaque type StoreID = InternalStoreID;
 function useRecoilStoreID(): StoreID {
   return useStoreRef().current.storeID;
 }

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -53,7 +53,7 @@ const {
 } = require('./Recoil_State');
 
 // Opaque at this surface because it's part of the public API from here.
-export opaque type SnapshotID = StateID;
+export type SnapshotID = StateID;
 
 const retainWarning = `
 Recoil Snapshots only last for the duration of the callback they are provided to. To keep a Snapshot longer, do this:
@@ -164,11 +164,6 @@ class Snapshot {
   }
 
   getID(): SnapshotID {
-    this.checkRefCount_INTERNAL();
-    return this.getID_INTERNAL();
-  }
-
-  getID_INTERNAL(): StateID {
     this.checkRefCount_INTERNAL();
     return this._store.getState().currentTree.stateID;
   }

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -34,6 +34,7 @@ const {
   peekNodeInfo,
 } = require('./Recoil_FunctionalCore');
 const {graph} = require('./Recoil_Graph');
+const {getNextStoreID} = require('./Recoil_Keys');
 const {
   DEFAULT_VALUE,
   recoilValues,
@@ -76,6 +77,7 @@ class Snapshot {
 
   constructor(storeState: StoreState) {
     this._store = {
+      storeID: getNextStoreID(),
       getState: () => storeState,
       replaceState: replacer => {
         storeState.currentTree = replacer(storeState.currentTree); // no batching so nextTree is never active

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -14,11 +14,18 @@
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {PersistentMap} from '../adt/Recoil_PersistentMap';
 import type {Graph} from './Recoil_GraphTypes';
-import type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
+import type {
+  ComponentID,
+  NodeKey,
+  StateID,
+  StoreID,
+  Version,
+} from './Recoil_Keys';
 import type {RetentionZone} from './Recoil_RetentionZone';
 
 const {persistentMap} = require('../adt/Recoil_PersistentMap');
 const {graph} = require('./Recoil_Graph');
+const {getNextTreeStateVersion} = require('./Recoil_Keys');
 
 export type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
 
@@ -130,6 +137,7 @@ export type StoreState = {
 // The Store is just the interface that is made available via the context.
 // It is constant within a given Recoil root.
 export type Store = $ReadOnly<{
+  storeID: StoreID,
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
   getGraph: Version => Graph,
@@ -140,9 +148,6 @@ export type Store = $ReadOnly<{
 export type StoreRef = {
   current: Store,
 };
-
-let nextTreeStateVersion = 0;
-const getNextTreeStateVersion = (): Version => nextTreeStateVersion++;
 
 function makeEmptyTreeState(): TreeState {
   const version = getNextTreeStateVersion();

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -8,26 +8,19 @@
  * @flow strict
  * @format
  */
-
 'use strict';
 
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {PersistentMap} from '../adt/Recoil_PersistentMap';
 import type {Graph} from './Recoil_GraphTypes';
-import type {
-  ComponentID,
-  NodeKey,
-  StateID,
-  StoreID,
-  Version,
-} from './Recoil_Keys';
+import type {ComponentID, NodeKey, StateID, StoreID} from './Recoil_Keys';
 import type {RetentionZone} from './Recoil_RetentionZone';
 
 const {persistentMap} = require('../adt/Recoil_PersistentMap');
 const {graph} = require('./Recoil_Graph');
 const {getNextTreeStateVersion} = require('./Recoil_Keys');
 
-export type {ComponentID, NodeKey, StateID, Version} from './Recoil_Keys';
+export type {ComponentID, NodeKey, StateID, StoreID} from './Recoil_Keys';
 
 // flowlint-next-line unclear-type:off
 export type AtomValues = PersistentMap<NodeKey, Loadable<any>>;
@@ -44,7 +37,7 @@ export type Retainable = RetentionZone | NodeKey;
 export type TreeState = $ReadOnly<{
   // Version always increments when moving from one state to another, even
   // if the same state has been seen before.
-  version: Version,
+  version: StateID,
 
   // State ID usually increments, but when going to a snapshot that was
   // previously rendered the state ID will be re-used:
@@ -87,7 +80,7 @@ export type StoreState = {
   // Added to when components commit or suspend after reading a version.
   // Removed from when components (1) unmount (2) commit another version
   // or (3) wake from suspense.
-  +versionsUsedByComponent: Map<ComponentID, Version>,
+  +versionsUsedByComponent: Map<ComponentID, StateID>,
 
   +retention: {
     referenceCounts: Map<NodeKey | RetentionZone, number>,
@@ -116,7 +109,7 @@ export type StoreState = {
   // In case of async request completion, we walk downward from updated selector
   // In (future) case of component subscriptions updated, we walk upwards from
   // component and then downward from any no-longer-depended on nodes
-  +graphsByVersion: Map<Version, Graph>,
+  +graphsByVersion: Map<StateID, Graph>,
   // Side note: it would be useful to consider async request completion as
   // another type of transaction since it should increase version etc. and many
   // things have to happen in both of these cases.
@@ -140,7 +133,7 @@ export type Store = $ReadOnly<{
   storeID: StoreID,
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
-  getGraph: Version => Graph,
+  getGraph: StateID => Graph,
   subscribeToTransactions: ((Store) => void, ?NodeKey) => {release: () => void},
   addTransactionMetadata: ({...}) => void,
 }>;

--- a/packages/recoil/core/__tests__/Recoil_useRecoilStoreID-test.js
+++ b/packages/recoil/core/__tests__/Recoil_useRecoilStoreID-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {getRecoilTestFn} = require('../../__test_utils__/Recoil_TestingUtils');
+
+let React, renderElements, RecoilRoot, useRecoilStoreID;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({renderElements} = require('../../__test_utils__/Recoil_TestingUtils'));
+  ({RecoilRoot} = require('../Recoil_RecoilRoot.react'));
+  ({useRecoilStoreID} = require('../Recoil_RecoilRoot.react'));
+});
+
+testRecoil('useRecoilStoreID', () => {
+  const storeIDs = {};
+  function StoreID({rootKey}) {
+    const storeID = useRecoilStoreID();
+    storeIDs[rootKey] = storeID;
+    return null;
+  }
+  function MyApp() {
+    return (
+      <div>
+        <RecoilRoot>
+          <StoreID rootKey="A" />
+          <RecoilRoot>
+            <StoreID rootKey="A1" />
+          </RecoilRoot>
+          <RecoilRoot override={false}>
+            <StoreID rootKey="A2" />
+          </RecoilRoot>
+        </RecoilRoot>
+        <RecoilRoot>
+          <StoreID rootKey="B" />
+        </RecoilRoot>
+      </div>
+    );
+  }
+
+  renderElements(<MyApp />);
+
+  expect('A' in storeIDs).toEqual(true);
+  expect('A1' in storeIDs).toEqual(true);
+  expect('A2' in storeIDs).toEqual(true);
+  expect('B' in storeIDs).toEqual(true);
+  expect(storeIDs.A).not.toEqual(storeIDs.B);
+  expect(storeIDs.A).not.toEqual(storeIDs.A1);
+  expect(storeIDs.A).toEqual(storeIDs.A2);
+  expect(storeIDs.B).not.toEqual(storeIDs.A1);
+  expect(storeIDs.B).not.toEqual(storeIDs.A2);
+});

--- a/packages/recoil/hooks/Recoil_SnapshotHooks.js
+++ b/packages/recoil/hooks/Recoil_SnapshotHooks.js
@@ -236,7 +236,7 @@ function useGotoRecoilSnapshot(): Snapshot => void {
         storeRef.current.replaceState(state => {
           return {
             ...state,
-            stateID: snapshot.getID_INTERNAL(),
+            stateID: snapshot.getID(),
           };
         });
       });

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -60,6 +60,7 @@
 // @fb-only: import type {ScopeRules} from 'Recoil_ScopedAtom';
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {RecoilValueInfo} from '../core/Recoil_FunctionalCore';
+import type {StoreID} from '../core/Recoil_Keys';
 import type {
   PersistenceInfo,
   ReadWriteNodeOptions,
@@ -115,6 +116,7 @@ type NewValueOrUpdater<T> =
 // Effect is called the first time a node is used with a <RecoilRoot>
 export type AtomEffect<T> = ({
   node: RecoilState<T>,
+  storeID: StoreID,
   trigger: Trigger,
 
   // Call synchronously to initialize value or async to change it later
@@ -394,6 +396,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       for (const effect of options.effects_UNSTABLE ?? []) {
         const cleanup = effect({
           node,
+          storeID: store.storeID,
           trigger,
           setSelf: setSelf(effect),
           resetSelf: resetSelf(effect),

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -59,6 +59,7 @@ import type {
   NodeCacheRoute,
   TreeCacheImplementation,
 } from '../caches/Recoil_TreeCacheImplementationType';
+import type {StateID} from '../core/Recoil_Keys';
 import type {DefaultValue} from '../core/Recoil_Node';
 import type {
   RecoilState,
@@ -174,7 +175,7 @@ type ExecutionInfo<T> = {
   depValuesDiscoveredSoFarDuringAsyncWork: ?DepValues,
   latestLoadable: ?Loadable<T>,
   latestExecutionId: ?ExecutionId,
-  stateVersion: ?number,
+  stateVersion: ?StateID,
 };
 
 // An object to hold the current state for loading dependencies for a particular

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -24,6 +24,7 @@ let React,
   useRecoilState,
   useRecoilCallback,
   useRecoilValue,
+  useRecoilStoreID,
   selector,
   useRecoilTransactionObserver,
   useResetRecoilState,
@@ -44,7 +45,10 @@ const testRecoil = getRecoilTestFn(() => {
   ({act} = require('ReactTestUtils'));
 
   ({DEFAULT_VALUE, DefaultValue} = require('../../core/Recoil_Node'));
-  ({RecoilRoot} = require('../../core/Recoil_RecoilRoot.react'));
+  ({
+    RecoilRoot,
+    useRecoilStoreID,
+  } = require('../../core/Recoil_RecoilRoot.react'));
   ({
     getRecoilValueAsLoadable,
     setRecoilValue,
@@ -1190,6 +1194,37 @@ describe('Effects', () => {
       act(() => setMyAtom('SET_ATOM'));
       await setTest;
     });
+  });
+
+  testRecoil('storeID matches <RecoilRoot>', async () => {
+    let effectStoreID;
+    const myAtom = atom({
+      key: 'atom effect - storeID',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        ({storeID, setSelf}) => {
+          effectStoreID = storeID;
+          setSelf('INIT');
+        },
+      ],
+    });
+
+    let rootStoreID;
+    function StoreID() {
+      rootStoreID = useRecoilStoreID();
+      return null;
+    }
+
+    const c = renderElements(
+      <div>
+        <StoreID />
+        <ReadsAtom atom={myAtom} />
+      </div>,
+    );
+
+    expect(c.textContent).toEqual('"INIT"');
+    expect(effectStoreID).not.toEqual(undefined);
+    expect(effectStoreID).toEqual(rootStoreID);
   });
 });
 

--- a/packages/refine/Refine_index.js
+++ b/packages/refine/Refine_index.js
@@ -39,6 +39,7 @@ const {jsonParser, jsonParserEnforced} = require('./Refine_JSON');
 const {
   boolean,
   date,
+  jsonDate,
   literal,
   mixed,
   number,
@@ -73,6 +74,7 @@ module.exports = {
   string,
   stringLiterals,
   date,
+  jsonDate,
 
   // Checkers - Utility
   asType,

--- a/packages/refine/__tests__/Refine_Primitives-test.js
+++ b/packages/refine/__tests__/Refine_Primitives-test.js
@@ -17,6 +17,7 @@ const {coercion} = require('../Refine_API');
 const {
   boolean,
   date,
+  jsonDate,
   literal,
   number,
   string,
@@ -172,5 +173,15 @@ describe('date', () => {
     const myDate = new Date();
     expect(coerce(myDate)).toEqual(myDate);
     expect(coerce(new Date('invalid'))).toEqual(null);
+  });
+});
+
+describe('jsonDate', () => {
+  it('should parse date strings', () => {
+    const coerce = coercion(jsonDate());
+    expect(coerce('Oct 26, 1985')).toEqual(new Date('Oct 26, 1985'));
+    expect(coerce('1955-11-05T07:00:00.000Z')).toEqual(
+      new Date('1955-11-05T07:00:00.000Z'),
+    );
   });
 });

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -283,6 +283,16 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
   */
  export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
 
+ // useRecoilStoreID
+ declare const StoreID_OPAQUE: unique symbol;
+ export interface StoreID {
+  readonly [StoreID_OPAQUE]: true;
+ }
+ /**
+  * Returns an ID for the currently active state store of the host <RecoilRoot>
+  */
+ export function useRecoilStoreID(): StoreID;
+
  // loadable.d.ts
  interface BaseLoadable<T> {
   getValue: () => T;

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -79,6 +79,7 @@
  // Effect is called the first time a node is used with a <RecoilRoot>
  export type AtomEffect<T> = (param: {
   node: RecoilState<T>,
+  storeID: StoreID,
   trigger: 'set' | 'get',
 
   // Call synchronously to initialize value or async to change it later

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -571,7 +571,11 @@ isRecoilValue(mySelector1);
     key: 'thisismyrandomkey',
     default: 0,
     effects_UNSTABLE: [
-      ({node, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+      ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+        node; // $ExpectType RecoilState<number>
+        storeID; // $ExpectType StoreID
+        trigger; // $ExpectType "get" | "set"
+
         setSelf(1);
         setSelf('a'); // $ExpectError
 
@@ -607,8 +611,12 @@ isRecoilValue(mySelector1);
     key: 'myrandomatomfamilykey',
     default: (param: number) => param,
     effects_UNSTABLE: (param) => [
-      ({node, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+      ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
         param; // $ExpectType number
+
+        node; // $ExpectType RecoilState<number>
+        storeID; // $ExpectType StoreID
+        trigger; // $ExpectType "get" | "set"
 
         setSelf(1);
         setSelf('a'); // $ExpectError

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -29,6 +29,7 @@
   Loadable, RecoilLoadable,
   useRecoilTransaction_UNSTABLE,
   useRecoilRefresher_UNSTABLE,
+  useRecoilStoreID,
 } from 'recoil';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -329,6 +330,14 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
   RecoilBridgeComponent({});
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   RecoilBridgeComponent({initializeState: () => {}}); // $ExpectError
+}
+
+/**
+ * ueRecoilStoreID()
+ */
+{
+  useRecoilStoreID(2); // $ExpectError
+  useRecoilStoreID(); // $ExpectType StoreID
 }
 
 // Other


### PR DESCRIPTION
Summary:
Support serializing atoms with selector defaults for Transit serialization for URL synchronization.  Note that we are only serializing the explicitly set state of the atom or the state that it should use the fallback selector, not the state of the fallback selector itself.

When an atom has a fallback selector it technicall creates a wrapper selector and the base atom retains the value of `DefaultValue` until it is explicitly set.  Thus, we need to support serialization of `DefaultValue` to handle this state.

Differential Revision: D32452527

