### PR TITLE
Migrate @shared to recoil-shared

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -23,8 +23,6 @@ module.name_mapper='ReactTestUtils' -> '<PROJECT_ROOT>/node_modules/react-dom/te
 module.name_mapper='Recoil' -> '<PROJECT_ROOT>/packages/recoil'
 module.name_mapper='recoil-sync' -> '<PROJECT_ROOT>/packages/recoil-syync'
 module.name_mapper='refine' -> '<PROJECT_ROOT>/packages/refine'
-
-module.name_mapper='@shared' -> '<PROJECT_ROOT>/packages/shared'
 module.name_mapper='recoil-shared' -> '<PROJECT_ROOT>/packages/shared'
 
 exact_by_default=true

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
     __DEV__: true,
   },
   moduleNameMapper: {
-    '^@shared(.*)$': '<rootDir>/packages/shared$1',
     '^recoil-shared(.*)$': '<rootDir>/packages/shared$1',
     '^Recoil$': '<rootDir>/packages/recoil',
     '^recoil-sync$': '<rootDir>/packages/recoil-sync',

--- a/packages/shared/util/Recoil_ReactBatchedUpdates.js
+++ b/packages/shared/util/Recoil_ReactBatchedUpdates.js
@@ -15,6 +15,6 @@
 // @fb-only: const {unstable_batchedUpdates} = require('ReactDOMComet');
 
 // prettier-ignore
-const {unstable_batchedUpdates} = require('@shared/polyfill/ReactBatchedUpdates'); // @oss-only
+const {unstable_batchedUpdates} = require('recoil-shared/polyfill/ReactBatchedUpdates'); // @oss-only
 
 module.exports = {unstable_batchedUpdates};

--- a/packages/shared/util/Recoil_err.js
+++ b/packages/shared/util/Recoil_err.js
@@ -12,6 +12,6 @@
 
 // @fb-only: const {err} = require('fb-error');
 
-const err = require('@shared/polyfill/err.js'); // @oss-only
+const err = require('recoil-shared/polyfill/err.js'); // @oss-only
 
 module.exports = err;

--- a/packages/shared/util/Recoil_expectationViolation.js
+++ b/packages/shared/util/Recoil_expectationViolation.js
@@ -12,6 +12,6 @@
 
 // @fb-only: const expectationViolation = require('expectationViolation');
 
-const expectationViolation = require('@shared/polyfill/expectationViolation.js'); // @oss-only
+const expectationViolation = require('recoil-shared/polyfill/expectationViolation.js'); // @oss-only
 
 module.exports = expectationViolation;

--- a/packages/shared/util/Recoil_invariant.js
+++ b/packages/shared/util/Recoil_invariant.js
@@ -13,6 +13,6 @@
 
 // @fb-only: const invariant = require('invariant');
 
-const invariant = require('@shared/polyfill/invariant.js'); // @oss-only
+const invariant = require('recoil-shared/polyfill/invariant.js'); // @oss-only
 
 module.exports = invariant;

--- a/packages/shared/util/Recoil_recoverableViolation.js
+++ b/packages/shared/util/Recoil_recoverableViolation.js
@@ -13,6 +13,6 @@
 
 // @fb-only: const recoverableViolation = require('recoverableViolation');
 
-const recoverableViolation = require('@shared/polyfill/recoverableViolation.js'); // @oss-only
+const recoverableViolation = require('recoil-shared/polyfill/recoverableViolation.js'); // @oss-only
 
 module.exports = recoverableViolation;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,10 +43,6 @@ const commonPlugins = [
   alias({
     entries: [
       {
-        find: '@shared',
-        replacement: path.resolve(projectRootDir, 'packages/shared'),
-      },
-      {
         find: 'recoil-shared',
         replacement: path.resolve(projectRootDir, 'packages/shared'),
       },


### PR DESCRIPTION
Summary: Migrate OSS imports referencing `shared` to use `recoil-shared`

Differential Revision: D32520696

