### PR TITLE
Atom writes can map to multiple items.

### DIFF
--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -33,27 +33,27 @@ export type StoreKey = string | void;
 export type ItemDiff = Map<ItemKey, ?Loadable<any>>; // null means reset
 export type ItemSnapshot = Map<ItemKey, ?Loadable<mixed>>; // null means default
 export type ReadItem = ItemKey => ?Loadable<mixed>;
-type WriteInterface = {diff: ItemDiff, allItems: ItemSnapshot};
+export type WriteInterface = {diff: ItemDiff, allItems: ItemSnapshot};
 export type WriteItems = WriteInterface => void;
+export type UpdateItem = (ItemKey, ?Loadable<mixed>) => void;
+export type UpdateAllKnownItems = ItemSnapshot => void;
 export type ListenInterface = {
-  updateItem: (ItemKey, ?Loadable<mixed>) => void,
-  updateAllKnownItems: ItemSnapshot => void,
+  updateItem: UpdateItem,
+  updateAllKnownItems: UpdateAllKnownItems,
 };
 export type ListenToItems = ListenInterface => void | (() => void);
 type ActionOnFailure = 'errorState' | 'defaultValue';
 
 const DEFAULT_VALUE = new DefaultValue();
 
+type AtomSyncOptions<T> = {
+  ...SyncEffectOptions<T>,
+  // Mark some items as required
+  itemKey: ItemKey,
+};
 type AtomRegistration<T> = {
   atom: RecoilState<T>,
-  itemKeys: Map<
-    ItemKey,
-    {
-      refine: Checker<T>,
-      syncDefault?: boolean,
-      actionOnFailure: ActionOnFailure,
-    },
-  >,
+  itemKeys: Map<ItemKey, AtomSyncOptions<T>>,
   // In-flight updates to avoid feedback loops
   pendingUpdate?: {value: mixed | DefaultValue},
 };
@@ -115,21 +115,32 @@ const registries: Registries = new Registries();
 
 const validateLoadable = <T>(
   loadable: Loadable<mixed>,
-  {
-    refine,
-    actionOnFailure,
-  }: {refine: Checker<T>, actionOnFailure: ActionOnFailure, ...},
+  {refine, actionOnFailure_UNSTABLE}: AtomSyncOptions<T>,
 ): Loadable<T | DefaultValue> =>
   loadable.map<T | DefaultValue>(x => {
     const result = refine(x);
     if (result.type === 'success') {
       return result.value;
     }
-    if (actionOnFailure === 'defaultValue') {
+    if (actionOnFailure_UNSTABLE === 'defaultValue') {
       return new DefaultValue();
     }
     throw err(`[${result.path.toString()}]: ${result.message}`);
   });
+
+function writeAtomItems<T>(
+  diff: ItemDiff,
+  options: AtomSyncOptions<T>,
+  loadable: ?Loadable<T>,
+) {
+  if (options.write != null) {
+    const write = (k, l) => void diff.set(k, l);
+    options.write({write}, loadable);
+  } else {
+    diff.set(options.itemKey, loadable);
+  }
+  return diff;
+}
 
 const itemsFromSnapshot = (
   recoilStoreID: StoreID,
@@ -141,17 +152,37 @@ const itemsFromSnapshot = (
     recoilStoreID,
     storeKey,
   )) {
-    // TODO syncEffect()'s write()
-    for (const [itemKey, {syncDefault}] of itemKeys) {
+    for (const [, opt] of itemKeys) {
       const atomInfo = getInfo(atom);
-      items.set(
-        itemKey,
-        atomInfo.isSet || syncDefault === true ? atomInfo.loadable : null,
+      writeAtomItems(
+        items,
+        opt,
+        atomInfo.isSet || opt.syncDefault === true ? atomInfo.loadable : null,
       );
     }
   }
   return items;
 };
+
+function writeInterfaceItems(
+  recoilStoreID: StoreID,
+  storeKey: StoreKey,
+  diff: ItemDiff,
+  getInfo,
+): WriteInterface {
+  // Use a Proxy so we only generate `allItems` if it's actually used
+  return new Proxy(
+    ({diff, allItems: (null: any)}: WriteInterface), // flowlint-line unclear-type:off
+    {
+      get: (target, prop) => {
+        if (prop === 'allItems' && target.allItems == null) {
+          target.allItems = itemsFromSnapshot(recoilStoreID, storeKey, getInfo);
+        }
+        return target[prop];
+      },
+    },
+  );
+}
 
 ///////////////////////
 // useRecoilSync()
@@ -190,19 +221,17 @@ function useRecoilSync({
           // Avoid feedback loops:
           // Don't write to storage updates that came from listening to storage
           if (
-            !(
-              (atomInfo.isSet &&
-                atomInfo.loadable?.contents ===
-                  registration.pendingUpdate?.value) ||
-              (!atomInfo.isSet &&
-                registration.pendingUpdate?.value instanceof DefaultValue)
-            )
+            (atomInfo.isSet &&
+              atomInfo.loadable?.contents !==
+                registration.pendingUpdate?.value) ||
+            (!atomInfo.isSet &&
+              !(registration.pendingUpdate?.value instanceof DefaultValue))
           ) {
-            // TODO syncEffect()'s write()
-            for (const [itemKey, {syncDefault}] of registration.itemKeys) {
-              diff.set(
-                itemKey,
-                atomInfo.isSet || syncDefault === true
+            for (const [, options] of registration.itemKeys) {
+              writeAtomItems(
+                diff,
+                options,
+                atomInfo.isSet || options.syncDefault === true
                   ? atomInfo.loadable
                   : null,
               );
@@ -211,24 +240,15 @@ function useRecoilSync({
           delete registration.pendingUpdate;
         }
       }
-      // Lazy load "allItems" only if needed.
-      const writeInterface = new Proxy(
-        ({diff, allItems: (null: any)}: WriteInterface), // flowlint-line unclear-type:off
-        {
-          get: (target, prop) => {
-            if (prop === 'allItems' && target.allItems == null) {
-              target.allItems = itemsFromSnapshot(
-                recoilStoreID,
-                storeKey,
-                snapshot.getInfo_UNSTABLE,
-              );
-            }
-            return target[prop];
-          },
-        },
-      );
       if (diff.size) {
-        write(writeInterface);
+        write(
+          writeInterfaceItems(
+            recoilStoreID,
+            storeKey,
+            diff,
+            snapshot.getInfo_UNSTABLE,
+          ),
+        );
       }
     }
   }, [recoilStoreID, snapshot, storeKey, write]);
@@ -241,11 +261,12 @@ function useRecoilSync({
           recoilStoreID,
           storeKey,
         );
+        // TODO syncEffect() read
         for (const [, registration] of atomRegistry) {
           let resetAtom = false;
           // Go through registered item keys in reverse order so later syncEffects
           // take priority if multiple keys are specified for the same storage
-          for (const [itemKey, entry] of Array.from(
+          for (const [itemKey, options] of Array.from(
             registration.itemKeys,
           ).reverse()) {
             if (diff.has(itemKey)) {
@@ -257,7 +278,7 @@ function useRecoilSync({
             const loadable = diff.get(itemKey);
             if (loadable != null) {
               resetAtom = false;
-              const validated = validateLoadable(loadable, entry);
+              const validated = validateLoadable(loadable, options);
               switch (validated.state) {
                 case 'hasValue':
                   registration.pendingUpdate = {
@@ -266,7 +287,7 @@ function useRecoilSync({
                   set(registration.atom, validated.contents);
                   break;
                 case 'hasError':
-                  if (entry.actionOnFailure === 'errorState') {
+                  if (options.actionOnFailure_UNSTABLE === 'errorState') {
                     // TODO Async atom support to allow setting atom to error state
                     // in the meantime we can just reset it to default value...
                     registration.pendingUpdate = {value: DEFAULT_VALUE};
@@ -291,7 +312,7 @@ function useRecoilSync({
     [recoilStoreID, storeKey],
   );
   const updateItem = useCallback(
-    (itemKey: ItemKey, loadable: ?Loadable<mixed>) => {
+    <T>(itemKey: ItemKey, loadable: ?Loadable<T>) => {
       updateItems(new Map([[itemKey, loadable]]));
     },
     [updateItems],
@@ -336,6 +357,12 @@ function RecoilSync(props: RecoilSyncOptions): React.Node {
 ///////////////////////
 // syncEffect()
 ///////////////////////
+export type WriteItem = (ItemKey, ?Loadable<mixed>) => void;
+export type WriteAtomInterface = {
+  write: WriteItem,
+  // read: ReadItem, // TODO
+};
+type WriteAtom<T> = (WriteAtomInterface, ?Loadable<T>) => void;
 export type SyncEffectOptions<T> = {
   storeKey?: StoreKey,
   itemKey?: ItemKey,
@@ -343,7 +370,7 @@ export type SyncEffectOptions<T> = {
   refine: Checker<T>,
 
   read?: ({read: ReadItem}) => mixed,
-  write?: (Loadable<T>, {read: ReadItem}) => ItemDiff,
+  write?: WriteAtom<T>,
 
   // Sync actual default value instead of empty when atom is in default state
   syncDefault?: boolean,
@@ -353,42 +380,40 @@ export type SyncEffectOptions<T> = {
   actionOnFailure_UNSTABLE?: ActionOnFailure,
 };
 
-function syncEffect<T>({
-  storeKey,
-  itemKey,
-  refine,
-  syncDefault,
-  actionOnFailure_UNSTABLE: actionOnFailure = 'errorState',
-}: SyncEffectOptions<T>): AtomEffect<T> {
+function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
   return ({node, trigger, storeID, setSelf, getLoadable, getInfo_UNSTABLE}) => {
-    const key = itemKey ?? node.key;
+    const options: AtomSyncOptions<T> = {
+      itemKey: node.key,
+      syncDefault: false,
+      actionOnFailure_UNSTABLE: 'errorState',
+      ...opt,
+    };
+    const {storeKey, itemKey} = options;
+    const storage = registries.getStorage(storeID, storeKey);
 
     // Register Atom
     const atomRegistry = registries.getAtomRegistry(storeID, storeKey);
     const registration = atomRegistry.get(node.key);
-    const entry = {refine, syncDefault, actionOnFailure};
     registration != null
-      ? registration.itemKeys.set(key, entry)
+      ? registration.itemKeys.set(itemKey, options)
       : atomRegistry.set(node.key, {
           atom: node,
-          itemKeys: new Map([[key, entry]]),
+          itemKeys: new Map([[itemKey, options]]),
         });
 
     if (trigger === 'get') {
       // Initialize Atom value
-      const readFromStorage = registries.getStorage(storeID, storeKey)?.read;
+      const readFromStorage = storage?.read;
       if (readFromStorage != null) {
         try {
-          const loadable = readFromStorage(key);
+          // TODO syncEffect() read
+          const loadable = readFromStorage(itemKey);
           if (loadable != null) {
             if (!RecoilLoadable.isLoadable(loadable)) {
               throw err('Sync read must provide a Loadable');
             }
 
-            const validated = validateLoadable<T>(loadable, {
-              refine,
-              actionOnFailure,
-            });
+            const validated = validateLoadable<T>(loadable, options);
             switch (validated.state) {
               case 'hasValue':
                 if (!(validated.contents instanceof DefaultValue)) {
@@ -396,7 +421,7 @@ function syncEffect<T>({
                 }
                 break;
               case 'hasError':
-                if (actionOnFailure === 'errorState') {
+                if (options.actionOnFailure_UNSTABLE === 'errorState') {
                   throw validated.contents;
                 }
                 break;
@@ -406,43 +431,24 @@ function syncEffect<T>({
             }
           }
         } catch (error) {
-          if (actionOnFailure === 'errorState') {
+          if (options.actionOnFailure_UNSTABLE === 'errorState') {
             throw error;
           }
         }
       }
 
       // Persist on Initial Read
-      const writeToStorage = registries.getStorage(storeID, storeKey)?.write;
-      if (syncDefault === true && writeToStorage != null) {
-        setTimeout(() => {
+      const writeToStorage = storage?.write;
+      if (options.syncDefault === true && writeToStorage != null) {
+        setImmediate(() => {
           const loadable = getLoadable(node);
           if (loadable.state === 'hasValue') {
-            // TODO Atom syncEffect() Write
-
-            // Lazy load "allItems" only if needed.
-            const writeInterface = new Proxy(
-              ({
-                diff: new Map([[key, loadable]]),
-                allItems: (null: any), // flowlint-line unclear-type:off
-              }: WriteInterface),
-              {
-                get: (target, prop) => {
-                  if (prop === 'allItems' && target.allItems == null) {
-                    target.allItems = itemsFromSnapshot(
-                      storeID,
-                      storeKey,
-                      getInfo_UNSTABLE,
-                    );
-                  }
-                  return target[prop];
-                },
-              },
+            const diff = writeAtomItems(new Map(), options, loadable);
+            writeToStorage(
+              writeInterfaceItems(storeID, storeKey, diff, getInfo_UNSTABLE),
             );
-
-            writeToStorage(writeInterface);
           }
-        }, 0);
+        });
       }
     }
 


### PR DESCRIPTION
Summary:
Atoms can map to multiple items when reading using the optional `write` property in the `syncEffect()` options:

```
export type WriteItem = (ItemKey, ?Loadable<mixed>) => void;
export type WriteAtomInterface = {
  write: WriteItem,
  // read: ReadItem, // TODO
};

export type SyncEffectOptions<T> = {
  ...
  write?: (WriteAtomInterface, ?Loadable<T>) => void,
};
```

# Example usage:
```
syncEffect({
  refine: string(),
  write: ({write}, loadable) => {
    write('key1', loadable?.map(x => x.prop1);
    write('key2', loadable?.map(x => x.prop2);
  },
})
```

Differential Revision: D32524058

