### PR TITLE
Add integration tests for real-world scenarios for compound mappings

### DIFF
--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -28,6 +28,7 @@ const err = require('recoil-shared/util/Recoil_err');
 type NodeKey = string;
 export type ItemKey = string;
 export type StoreKey = string | void;
+type EffectKey = number;
 
 // $FlowIssue[unclear-type]
 export type ItemDiff = Map<ItemKey, ?Loadable<any>>; // null means reset
@@ -47,6 +48,23 @@ type ActionOnFailure = 'errorState' | 'defaultValue';
 
 const DEFAULT_VALUE = new DefaultValue();
 
+function setIntersectsMap<U, V>(a: Set<U>, b: Map<U, V>): boolean {
+  if (a.size <= b.size) {
+    for (const x of a) {
+      if (b.has(x)) {
+        return true;
+      }
+    }
+  } else {
+    for (const x of b.keys()) {
+      if (a.has(x)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 type AtomSyncOptions<T> = {
   ...SyncEffectOptions<T>,
   // Mark some items as required
@@ -54,9 +72,13 @@ type AtomSyncOptions<T> = {
   read: ReadAtom,
   write: WriteAtom<T>,
 };
+type EffectRegistration<T> = {
+  options: AtomSyncOptions<T>,
+  subscribedItemKeys: Set<ItemKey>,
+};
 type AtomRegistration<T> = {
   atom: RecoilState<T>,
-  itemKeys: Map<ItemKey, AtomSyncOptions<T>>,
+  effects: Map<EffectKey, EffectRegistration<T>>,
   // In-flight updates to avoid feedback loops
   pendingUpdate?: {value: mixed | DefaultValue},
 };
@@ -74,6 +96,7 @@ class Registries {
       Map<NodeKey, AtomRegistration<any>>, // flowlint-line unclear-type:off
     >,
   > = new Map();
+  nextEffectKey: EffectKey = 0;
 
   getAtomRegistry(
     recoilStoreID: StoreID,
@@ -93,6 +116,24 @@ class Registries {
     return newRegistry;
   }
 
+  setAtomEffect<T>(
+    recoilStoreID: StoreID,
+    externalStoreKey: StoreKey,
+    node: RecoilState<T>,
+    options: AtomSyncOptions<T>,
+  ): () => void {
+    const atomRegistry = this.getAtomRegistry(recoilStoreID, externalStoreKey);
+    if (!atomRegistry.has(node.key)) {
+      atomRegistry.set(node.key, {atom: node, effects: new Map()});
+    }
+    const effectKey = this.nextEffectKey++;
+    atomRegistry.get(node.key)?.effects.set(effectKey, {
+      options,
+      subscribedItemKeys: new Set([options.itemKey]),
+    });
+    return () => void atomRegistry.get(node.key)?.effects.delete(effectKey);
+  }
+
   storageRegistries: Map<StoreID, Map<StoreKey, Storage>> = new Map();
 
   getStorage(recoilStoreID: StoreID, externalStoreKey: StoreKey): ?Storage {
@@ -103,24 +144,25 @@ class Registries {
     recoilStoreID: StoreID,
     externalStoreKey: StoreKey,
     storage: Storage,
-  ) {
+  ): () => void {
     if (!this.storageRegistries.has(recoilStoreID)) {
       this.storageRegistries.set(recoilStoreID, new Map());
     }
     this.storageRegistries.get(recoilStoreID)?.set(externalStoreKey, storage);
-  }
-
-  clrStorage(recoilStoreID: StoreID, externalStoreKey: StoreKey) {
-    this.storageRegistries.get(recoilStoreID)?.delete(externalStoreKey);
+    return () =>
+      void this.storageRegistries.get(recoilStoreID)?.delete(externalStoreKey);
   }
 }
 const registries: Registries = new Registries();
 
-const validateLoadable = <T>(
+function validateLoadable<T>(
   loadable: Loadable<mixed>,
   {refine, actionOnFailure_UNSTABLE}: AtomSyncOptions<T>,
-): Loadable<T | DefaultValue> =>
-  loadable.map<T | DefaultValue>(x => {
+): Loadable<T | DefaultValue> {
+  if (!RecoilLoadable.isLoadable(loadable)) {
+    throw err('Sync read must provide a Loadable');
+  }
+  return loadable.map<T | DefaultValue>(x => {
     const result = refine(x);
     if (result.type === 'success') {
       return result.value;
@@ -130,6 +172,7 @@ const validateLoadable = <T>(
     }
     throw err(`[${result.path.toString()}]: ${result.message}`);
   });
+}
 
 function writeAtomItems<T>(
   diff: ItemDiff,
@@ -160,17 +203,19 @@ const itemsFromSnapshot = (
   getInfo,
 ): ItemSnapshot => {
   const items: ItemSnapshot = new Map();
-  for (const [, {atom, itemKeys}] of registries.getAtomRegistry(
+  for (const [, {atom, effects}] of registries.getAtomRegistry(
     recoilStoreID,
     storeKey,
   )) {
-    for (const [, opt] of itemKeys) {
+    for (const [, {options}] of effects) {
       const atomInfo = getInfo(atom);
       writeAtomItems(
         items,
-        opt,
+        options,
         registries.getStorage(recoilStoreID, storeKey)?.read,
-        atomInfo.isSet || opt.syncDefault === true ? atomInfo.loadable : null,
+        atomInfo.isSet || options.syncDefault === true
+          ? atomInfo.loadable
+          : null,
       );
     }
   }
@@ -236,7 +281,7 @@ function useRecoilSync({
             (!atomInfo.isSet &&
               !(registration.pendingUpdate?.value instanceof DefaultValue))
           ) {
-            for (const [, options] of registration.itemKeys) {
+            for (const [, {options}] of registration.effects) {
               writeAtomItems(
                 diff,
                 options,
@@ -263,7 +308,6 @@ function useRecoilSync({
     }
   }, [read, recoilStoreID, snapshot, storeKey, write]);
 
-  // Subscribe to Sync storage changes
   const updateItems = useRecoilTransaction_UNSTABLE(
     ({set, reset}) =>
       (diff: ItemDiff) => {
@@ -271,55 +315,69 @@ function useRecoilSync({
           recoilStoreID,
           storeKey,
         );
-        // TODO syncEffect() read
+        const readFromStorageRequired =
+          read ??
+          (itemKey =>
+            RecoilLoadable.error(
+              `Read functionality not provided for ${
+                storeKey != null ? `"${storeKey}" ` : ''
+              }store in useRecoilSync() hook while updating item "${itemKey}".`,
+            ));
+        const readFromDiff = itemKey =>
+          diff.has(itemKey)
+            ? diff.get(itemKey)
+            : readFromStorageRequired(itemKey);
+        // TODO iterating over all atoms registered with the store could be
+        // optimized if we maintain a reverse look-up map of subscriptions.
         for (const [, registration] of atomRegistry) {
-          let resetAtom = false;
-          // Go through registered item keys in reverse order so later syncEffects
-          // take priority if multiple keys are specified for the same storage
-          for (const [itemKey, options] of Array.from(
-            registration.itemKeys,
+          // Iterate through the effects for this storage in reverse order as
+          // the last effect takes priority.
+          for (const [, {options, subscribedItemKeys}] of Array.from(
+            registration.effects,
           ).reverse()) {
-            if (diff.has(itemKey)) {
-              // null entry means to reset atom, but let's first check if there
-              // is a fallback syncEffect for the same storage with another key
-              // that may provide backup instructions.
-              resetAtom = true;
-            }
-            const loadable = diff.get(itemKey);
-            if (loadable != null) {
-              resetAtom = false;
-              const validated = validateLoadable(loadable, options);
-              switch (validated.state) {
-                case 'hasValue':
-                  registration.pendingUpdate = {
-                    value: validated.contents,
-                  };
-                  set(registration.atom, validated.contents);
-                  break;
-                case 'hasError':
-                  if (options.actionOnFailure_UNSTABLE === 'errorState') {
-                    // TODO Async atom support to allow setting atom to error state
-                    // in the meantime we can just reset it to default value...
-                    registration.pendingUpdate = {value: DEFAULT_VALUE};
-                    reset(registration.atom);
-                  }
-                  break;
-                case 'loading':
-                  // TODO Async atom support
-                  throw err(
-                    'Recoil does not yet support setting atoms to an asynchronous state',
-                  );
+            // Only consider updating this atom if it subscribes to any items
+            // specified in the diff.
+            if (setIntersectsMap(subscribedItemKeys, diff)) {
+              const loadable = options.read({read: readFromDiff});
+              if (loadable != null) {
+                const validated = validateLoadable(loadable, options);
+                switch (validated.state) {
+                  case 'hasValue':
+                    registration.pendingUpdate = {
+                      value: validated.contents,
+                    };
+                    set(registration.atom, validated.contents);
+                    break;
+                  case 'hasError':
+                    if (options.actionOnFailure_UNSTABLE === 'errorState') {
+                      // TODO Async atom support to allow setting atom to error state
+                      // in the meantime we can just reset it to default value...
+                      registration.pendingUpdate = {value: DEFAULT_VALUE};
+                      reset(registration.atom);
+                    }
+                    break;
+                  case 'loading':
+                    // TODO Async atom support
+                    throw err(
+                      'Recoil does not yet support setting atoms to an asynchronous state',
+                    );
+                }
+                // If this effect set the atom, don't bother with lower-priority
+                // effects. But, if the item didn't have a value then reset
+                // below but ontinue falling back on other effects for the same
+                // storage.  This can happen if multiple effects are used to
+                // migrate to a new itemKey and we want to read from the
+                // older key as a fallback.
+                break;
+              } else {
+                registration.pendingUpdate = {value: DEFAULT_VALUE};
+                reset(registration.atom);
               }
-              break;
             }
-          }
-          if (resetAtom) {
-            registration.pendingUpdate = {value: DEFAULT_VALUE};
-            reset(registration.atom);
           }
         }
       },
-    [recoilStoreID, storeKey],
+    [recoilStoreID, storeKey, read],
   );
   const updateItem = useCallback(
     <T>(itemKey: ItemKey, loadable: ?Loadable<T>) => {
@@ -327,15 +385,18 @@ function useRecoilSync({
     },
     [updateItems],
   );
+
   const updateAllKnownItems = useCallback(
     itemSnapshot => {
       // Reset the value of any items that are registered and not included in
       // the user-provided snapshot.
       const atomRegistry = registries.getAtomRegistry(recoilStoreID, storeKey);
       for (const [, registration] of atomRegistry) {
-        for (const [itemKey] of registration.itemKeys) {
-          if (!itemSnapshot.has(itemKey)) {
-            itemSnapshot.set(itemKey);
+        for (const [, {subscribedItemKeys}] of registration.effects) {
+          for (const itemKey of subscribedItemKeys) {
+            if (!itemSnapshot.has(itemKey)) {
+              itemSnapshot.set(itemKey, null);
+            }
           }
         }
       }
@@ -353,10 +414,10 @@ function useRecoilSync({
   // Register Storage
   // Save before effects so that we can initialize atoms for initial render
   registries.setStorage(recoilStoreID, storeKey, {write, read});
-  useEffect(() => {
-    registries.setStorage(recoilStoreID, storeKey, {write, read});
-    return () => registries.clrStorage(recoilStoreID, storeKey);
-  }, [recoilStoreID, storeKey, read, write]);
+  useEffect(
+    () => registries.setStorage(recoilStoreID, storeKey, {write, read}),
+    [recoilStoreID, storeKey, read, write],
+  );
 }
 
 function RecoilSync(props: RecoilSyncOptions): React.Node {
@@ -391,6 +452,7 @@ export type SyncEffectOptions<T> = {
 
 function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
   return ({node, trigger, storeID, setSelf, getLoadable, getInfo_UNSTABLE}) => {
+    // Get options with defaults
     const itemKey = opt.itemKey ?? node.key;
     const options: AtomSyncOptions<T> = {
       itemKey,
@@ -403,16 +465,6 @@ function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
     const {storeKey} = options;
     const storage = registries.getStorage(storeID, storeKey);
 
-    // Register Atom
-    const atomRegistry = registries.getAtomRegistry(storeID, storeKey);
-    const registration = atomRegistry.get(node.key);
-    registration != null
-      ? registration.itemKeys.set(itemKey, options)
-      : atomRegistry.set(node.key, {
-          atom: node,
-          itemKeys: new Map([[itemKey, options]]),
-        });
-
     if (trigger === 'get') {
       // Initialize Atom value
       const readFromStorage = storage?.read;
@@ -420,10 +472,6 @@ function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
         try {
           const loadable = options.read({read: readFromStorage});
           if (loadable != null) {
-            if (!RecoilLoadable.isLoadable(loadable)) {
-              throw err('Sync read must provide a Loadable');
-            }
-
             const validated = validateLoadable<T>(loadable, options);
             switch (validated.state) {
               case 'hasValue':
@@ -468,10 +516,8 @@ function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
       }
     }
 
-    // Unregister atom
-    return () => {
-      atomRegistry.delete(node.key);
-    };
+    // Register Atom
+    return registries.setAtomEffect(storeID, storeKey, node, options);
   };
 }
 

--- a/packages/recoil-sync/RecoilSync_URLTransit.js
+++ b/packages/recoil-sync/RecoilSync_URLTransit.js
@@ -20,18 +20,18 @@ const {useCallback, useMemo} = require('react');
 const err = require('recoil-shared/util/Recoil_err');
 const transit = require('transit-js');
 
-type Handler<T, S> = {
+export type TransitHandler<T, S> = {
   tag: string,
   class: Class<T>,
   write: T => S,
   read: S => T,
 };
 
-type RecoilURLSyncTrnsitOptions = $Rest<
+export type RecoilURLSyncTransitOptions = $Rest<
   {
     ...RecoilURLSyncOptions,
     // $FlowIssue[unclear-type]
-    handlers?: $ReadOnlyArray<Handler<any, any>>,
+    handlers?: $ReadOnlyArray<TransitHandler<any, any>>,
   },
   {
     serialize: mixed => string,
@@ -69,7 +69,7 @@ const BUILTIN_HANDLERS = [
 function useRecoilURLSyncTransit({
   handlers: handlersProp = [],
   ...options
-}: RecoilURLSyncTrnsitOptions): void {
+}: RecoilURLSyncTransitOptions): void {
   if (options.location.part === 'href') {
     throw err('"href" location is not supported for Transit encoding');
   }
@@ -121,7 +121,7 @@ function useRecoilURLSyncTransit({
   useRecoilURLSync({...options, serialize, deserialize});
 }
 
-function RecoilURLSyncTransit(props: RecoilURLSyncTrnsitOptions): React.Node {
+function RecoilURLSyncTransit(props: RecoilURLSyncTransitOptions): React.Node {
   useRecoilURLSyncTransit(props);
   return null;
 }

--- a/packages/recoil-sync/RecoilSync_index.js
+++ b/packages/recoil-sync/RecoilSync_index.js
@@ -10,8 +10,25 @@
  */
 'use strict';
 
+import type {
+  ItemKey,
+  ListenToItems,
+  ReadAtom,
+  ReadAtomInterface,
+  ReadItem,
+  RecoilSyncOptions,
+  StoreKey,
+  SyncEffectOptions,
+  WriteAtom,
+  WriteAtomInterface,
+  WriteItems,
+} from './RecoilSync';
 import type {RecoilURLSyncOptions} from './RecoilSync_URL';
 import type {RecoilURLSyncJSONOptions} from './RecoilSync_URLJSON';
+import type {
+  RecoilURLSyncTransitOptions,
+  TransitHandler,
+} from './RecoilSync_URLTransit';
 
 const {RecoilSync, syncEffect, useRecoilSync} = require('./RecoilSync');
 const {
@@ -23,9 +40,32 @@ const {
   RecoilURLSyncJSON,
   useRecoilURLSyncJSON,
 } = require('./RecoilSync_URLJSON');
+const {
+  RecoilURLSyncTransit,
+  useRecoilURLSyncTransit,
+} = require('./RecoilSync_URLTransit');
 
-export type {RecoilURLSyncOptions};
-export type {RecoilURLSyncJSONOptions};
+export type {
+  // Keys
+  ItemKey,
+  StoreKey,
+  // Core useRecoilSync() options
+  RecoilSyncOptions,
+  ReadItem,
+  WriteItems,
+  ListenToItems,
+  // Core syncEffect() options
+  SyncEffectOptions,
+  ReadAtomInterface,
+  ReadAtom,
+  WriteAtomInterface,
+  WriteAtom,
+  // URL Synchronization
+  RecoilURLSyncOptions,
+  RecoilURLSyncJSONOptions,
+  RecoilURLSyncTransitOptions,
+  TransitHandler,
+};
 
 module.exports = {
   // Core Recoil Sync
@@ -36,7 +76,9 @@ module.exports = {
   // Recoil Sync URL
   useRecoilURLSync,
   useRecoilURLSyncJSON,
+  useRecoilURLSyncTransit,
   RecoilURLSync,
   RecoilURLSyncJSON,
+  RecoilURLSyncTransit,
   urlSyncEffect,
 };

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -1091,10 +1091,16 @@ describe('Complex Mappings', () => {
     // Test mapping while initializing values
     expect(container.textContent).toBe('{"a":1,"b":2}');
 
-    // TODO
     // Test subscribing to multiple items
     act(() => updateItem('a', RecoilLoadable.of(10)));
-    // expect(container.textContent).toBe('{"a":10,"b":2}');
+    expect(container.textContent).toBe('{"a":10,"b":2}');
+
+    // Avoid feedback loops
+    expect(storage.get('a')?.contents).toEqual(1);
+    storage.set('a', RecoilLoadable.of(10)); // Keep storage in sync
+
+    act(() => updateItem('b', RecoilLoadable.of(20)));
+    expect(container.textContent).toBe('{"a":10,"b":20}');
   });
 });
 

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {act} = require('ReactTestUtils');
+const {RecoilLoadable, atom, atomFamily} = require('Recoil');
+
+const {
+  encodeURL,
+  expectURL,
+  gotoURL,
+} = require('../__test_utils__/RecoilSync_MockURLSerialization');
+const {syncEffect} = require('../RecoilSync');
+const {RecoilURLSyncJSON} = require('../RecoilSync_URLJSON');
+const React = require('react');
+const {
+  componentThatReadsAndWritesAtom,
+  renderElements,
+} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
+const {assertion, dict, nullable, number, string} = require('refine');
+
+test('Upgrade item ID', async () => {
+  const loc = {part: 'queryParams'};
+
+  const myAtom = atom({
+    key: 'recoil-url-sync upgrade itemID',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [
+      syncEffect({
+        refine: string(),
+        itemKey: 'new_key',
+        read: ({read}) => read('old_key') ?? read('new_key'),
+      }),
+    ],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {old_key: 'OLD'}]]));
+
+  const [Atom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(myAtom);
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Atom />
+    </>,
+  );
+
+  // Test that we can load based on old key
+  expect(container.textContent).toEqual('"OLD"');
+
+  // Test that we can save to the new key
+  act(() => setAtom('NEW'));
+  expect(container.textContent).toEqual('"NEW"');
+  expectURL([[loc, {new_key: 'NEW'}]]);
+
+  // Test that we can reset the atom and get the default instead of the old key's value
+  act(resetAtom);
+  expect(container.textContent).toEqual('"DEFAULT"');
+  expectURL([[loc, {}]]);
+});
+
+test('Many items to one atom', async () => {
+  const loc = {part: 'queryParams'};
+
+  const manyToOneSyncEffct = () =>
+    syncEffect({
+      refine: dict(nullable(number())),
+      read: ({read}) =>
+        RecoilLoadable.all({foo: read('foo'), bar: read('bar')}),
+      write: ({write}, loadable) => {
+        if (loadable == null) {
+          write('foo');
+          write('bar');
+        }
+        if (loadable?.state === 'hasValue') {
+          for (const key of Object.keys(loadable.contents)) {
+            write(key, RecoilLoadable.of(loadable.contents[key]));
+          }
+        }
+      },
+    });
+
+  const myAtom = atom({
+    key: 'recoil-url-sync many-to-one',
+    default: {},
+    effects_UNSTABLE: [manyToOneSyncEffct()],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {foo: 1}]]));
+
+  const [Atom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(myAtom);
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Atom />
+    </>,
+  );
+
+  // Test initialize value from URL
+  expect(container.textContent).toBe('{"foo":1}');
+
+  // Test subscribe to URL updates
+  gotoURL([[loc, {foo: 1, bar: 2}]]);
+  expect(container.textContent).toBe('{"bar":2,"foo":1}');
+
+  // Test mutating atoms will update URL
+  act(() => setAtom({foo: 3, bar: 4}));
+  expectURL([[loc, {foo: 3, bar: 4}]]);
+
+  // Test reseting atoms will update URL
+  act(resetAtom);
+  expectURL([[loc, {}]]);
+});
+
+test('One item to multiple atoms', async () => {
+  const loc = {part: 'queryParams'};
+  const input = assertion(dict(nullable(number())));
+
+  const oneToManySyncEffect = (prop: string) =>
+    syncEffect({
+      refine: nullable(number()),
+      read: ({read}) => read('compound')?.map(x => input(x)[prop]),
+      write: ({write, read}, loadable) =>
+        write(
+          'compound',
+          read('compound')?.map(compound => {
+            const x = {...input(compound)};
+            if (loadable == null) {
+              delete x[prop];
+              return x;
+            }
+            return loadable.map(newValue => ({...x, [prop]: newValue}));
+          }),
+        ),
+    });
+
+  const fooAtom = atom({
+    key: 'recoil-url-sync one-to-many foo',
+    default: 0,
+    effects_UNSTABLE: [oneToManySyncEffect('foo')],
+  });
+
+  const barAtom = atom({
+    key: 'recoil-url-sync one-to-many bar',
+    default: undefined,
+    effects_UNSTABLE: [oneToManySyncEffect('bar')],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {compound: {foo: 1}}]]));
+
+  const [Foo, setFoo, resetFoo] = componentThatReadsAndWritesAtom(fooAtom);
+  const [Bar, setBar, resetBar] = componentThatReadsAndWritesAtom(barAtom);
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Foo />
+      <Bar />
+    </>,
+  );
+
+  // Test initialize value from URL
+  expect(container.textContent).toBe('1');
+
+  // Test subscribe to URL updates
+  gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
+  expect(container.textContent).toBe('12');
+
+  // Test mutating atoms will update URL
+  act(() => setFoo(3));
+  expect(container.textContent).toBe('32');
+  expectURL([[loc, {compound: {foo: 3, bar: 2}}]]);
+  act(() => setBar(4));
+  expect(container.textContent).toBe('34');
+  expectURL([[loc, {compound: {foo: 3, bar: 4}}]]);
+
+  // Test reseting atoms will update URL
+  act(resetFoo);
+  expect(container.textContent).toBe('04');
+  expectURL([[loc, {compound: {bar: 4}}]]);
+  act(resetBar);
+  expect(container.textContent).toBe('0');
+  expectURL([[loc, {compound: {}}]]);
+});
+
+test('One item to atom family', async () => {
+  const loc = {part: 'queryParams'};
+  const input = assertion(dict(nullable(number())));
+
+  const oneToFamilyEffect = (prop: string) =>
+    syncEffect({
+      refine: nullable(number()),
+      read: ({read}) => read('compound')?.map(x => input(x)[prop]),
+      write: ({write, read}, loadable) =>
+        write(
+          'compound',
+          read('compound')?.map(compound => {
+            const x = {...input(compound)};
+            if (loadable == null) {
+              delete x[prop];
+              return x;
+            }
+            return loadable.map(newValue => ({...x, [prop]: newValue}));
+          }),
+        ),
+    });
+
+  const myAtoms = atomFamily({
+    key: 'recoil-rul-sync one-to-family',
+    default: undefined,
+    effects_UNSTABLE: prop => [oneToFamilyEffect(prop)],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {compound: {foo: 1}}]]));
+
+  const [Foo, setFoo, resetFoo] = componentThatReadsAndWritesAtom(
+    myAtoms('foo'),
+  );
+  const [Bar, setBar, resetBar] = componentThatReadsAndWritesAtom(
+    myAtoms('bar'),
+  );
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Foo />
+      <Bar />
+    </>,
+  );
+
+  // Test initialize value from URL
+  expect(container.textContent).toBe('1');
+
+  // Test subscribe to URL updates
+  gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
+  expect(container.textContent).toBe('12');
+
+  // Test mutating atoms will update URL
+  act(() => setFoo(3));
+  expect(container.textContent).toBe('32');
+  expectURL([[loc, {compound: {foo: 3, bar: 2}}]]);
+  act(() => setBar(4));
+  expect(container.textContent).toBe('34');
+  expectURL([[loc, {compound: {foo: 3, bar: 4}}]]);
+
+  // Test reseting atoms will update URL
+  act(resetFoo);
+  expect(container.textContent).toBe('4');
+  expectURL([[loc, {compound: {bar: 4}}]]);
+  act(resetBar);
+  expect(container.textContent).toBe('');
+  expectURL([[loc, {compound: {}}]]);
+});


### PR DESCRIPTION
Summary:
Add integration tests for some real-world scenarios using complex atom to item mappings:

* Upgrade an atom from a previous key to a new key.  (This is also acheivable by using two `syncEffect()`'s.)
* A single atom stores an object where each prop is synced with a different storage item saving a simple string.
* A single storage item contains multiple props that are each synched with their own atoms which each just store a simple string.

Differential Revision: D32612031

