### PR TITLE
Simplify browser abstraction and don't encode empty query params in URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
 - `storeID` added to atom effects interface (#1414)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
+- `RecoilLoadable.all()` accepts literal values and async Promises in addition to Loadables.
 
 ### Pending
 - Memory management

--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -137,10 +137,9 @@ function writeAtomItems<T>(
   readFromStorage?: ReadItem,
   loadable: ?Loadable<T>,
 ) {
-  const write = <S>(k, l: ?Loadable<S>) => void diff.set(k, l);
-  const read =
+  const readFromStorageRequired =
     readFromStorage ??
-    (() =>
+    (_ =>
       RecoilLoadable.error(
         `Read functionality not provided for ${
           options.storeKey != null ? `"${options.storeKey}" ` : ''
@@ -148,6 +147,9 @@ function writeAtomItems<T>(
           options.itemKey
         }".`,
       ));
+  const read = itemKey =>
+    diff.has(itemKey) ? diff.get(itemKey) : readFromStorageRequired(itemKey);
+  const write = <S>(k, l: ?Loadable<S>) => void diff.set(k, l);
   options.write({write, read}, loadable);
   return diff;
 }

--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -33,27 +33,27 @@ export type StoreKey = string | void;
 export type ItemDiff = Map<ItemKey, ?Loadable<any>>; // null means reset
 export type ItemSnapshot = Map<ItemKey, ?Loadable<mixed>>; // null means default
 export type ReadItem = ItemKey => ?Loadable<mixed>;
-type WriteInterface = {diff: ItemDiff, allItems: ItemSnapshot};
+export type WriteInterface = {diff: ItemDiff, allItems: ItemSnapshot};
 export type WriteItems = WriteInterface => void;
+export type UpdateItem = (ItemKey, ?Loadable<mixed>) => void;
+export type UpdateAllKnownItems = ItemSnapshot => void;
 export type ListenInterface = {
-  updateItem: (ItemKey, ?Loadable<mixed>) => void,
-  updateAllKnownItems: ItemSnapshot => void,
+  updateItem: UpdateItem,
+  updateAllKnownItems: UpdateAllKnownItems,
 };
 export type ListenToItems = ListenInterface => void | (() => void);
 type ActionOnFailure = 'errorState' | 'defaultValue';
 
 const DEFAULT_VALUE = new DefaultValue();
 
+type AtomSyncOptions<T> = {
+  ...SyncEffectOptions<T>,
+  // Mark some items as required
+  itemKey: ItemKey,
+};
 type AtomRegistration<T> = {
   atom: RecoilState<T>,
-  itemKeys: Map<
-    ItemKey,
-    {
-      refine: Checker<T>,
-      syncDefault?: boolean,
-      actionOnFailure: ActionOnFailure,
-    },
-  >,
+  itemKeys: Map<ItemKey, AtomSyncOptions<T>>,
   // In-flight updates to avoid feedback loops
   pendingUpdate?: {value: mixed | DefaultValue},
 };
@@ -115,21 +115,32 @@ const registries: Registries = new Registries();
 
 const validateLoadable = <T>(
   loadable: Loadable<mixed>,
-  {
-    refine,
-    actionOnFailure,
-  }: {refine: Checker<T>, actionOnFailure: ActionOnFailure, ...},
+  {refine, actionOnFailure_UNSTABLE}: AtomSyncOptions<T>,
 ): Loadable<T | DefaultValue> =>
   loadable.map<T | DefaultValue>(x => {
     const result = refine(x);
     if (result.type === 'success') {
       return result.value;
     }
-    if (actionOnFailure === 'defaultValue') {
+    if (actionOnFailure_UNSTABLE === 'defaultValue') {
       return new DefaultValue();
     }
     throw err(`[${result.path.toString()}]: ${result.message}`);
   });
+
+function writeAtomItems<T>(
+  diff: ItemDiff,
+  options: AtomSyncOptions<T>,
+  loadable: ?Loadable<T>,
+) {
+  if (options.write != null) {
+    const write = (k, l) => void diff.set(k, l);
+    options.write({write}, loadable);
+  } else {
+    diff.set(options.itemKey, loadable);
+  }
+  return diff;
+}
 
 const itemsFromSnapshot = (
   recoilStoreID: StoreID,
@@ -141,17 +152,37 @@ const itemsFromSnapshot = (
     recoilStoreID,
     storeKey,
   )) {
-    // TODO syncEffect()'s write()
-    for (const [itemKey, {syncDefault}] of itemKeys) {
+    for (const [, opt] of itemKeys) {
       const atomInfo = getInfo(atom);
-      items.set(
-        itemKey,
-        atomInfo.isSet || syncDefault === true ? atomInfo.loadable : null,
+      writeAtomItems(
+        items,
+        opt,
+        atomInfo.isSet || opt.syncDefault === true ? atomInfo.loadable : null,
       );
     }
   }
   return items;
 };
+
+function writeInterfaceItems(
+  recoilStoreID: StoreID,
+  storeKey: StoreKey,
+  diff: ItemDiff,
+  getInfo,
+): WriteInterface {
+  // Use a Proxy so we only generate `allItems` if it's actually used
+  return new Proxy(
+    ({diff, allItems: (null: any)}: WriteInterface), // flowlint-line unclear-type:off
+    {
+      get: (target, prop) => {
+        if (prop === 'allItems' && target.allItems == null) {
+          target.allItems = itemsFromSnapshot(recoilStoreID, storeKey, getInfo);
+        }
+        return target[prop];
+      },
+    },
+  );
+}
 
 ///////////////////////
 // useRecoilSync()
@@ -190,19 +221,17 @@ function useRecoilSync({
           // Avoid feedback loops:
           // Don't write to storage updates that came from listening to storage
           if (
-            !(
-              (atomInfo.isSet &&
-                atomInfo.loadable?.contents ===
-                  registration.pendingUpdate?.value) ||
-              (!atomInfo.isSet &&
-                registration.pendingUpdate?.value instanceof DefaultValue)
-            )
+            (atomInfo.isSet &&
+              atomInfo.loadable?.contents !==
+                registration.pendingUpdate?.value) ||
+            (!atomInfo.isSet &&
+              !(registration.pendingUpdate?.value instanceof DefaultValue))
           ) {
-            // TODO syncEffect()'s write()
-            for (const [itemKey, {syncDefault}] of registration.itemKeys) {
-              diff.set(
-                itemKey,
-                atomInfo.isSet || syncDefault === true
+            for (const [, options] of registration.itemKeys) {
+              writeAtomItems(
+                diff,
+                options,
+                atomInfo.isSet || options.syncDefault === true
                   ? atomInfo.loadable
                   : null,
               );
@@ -211,24 +240,15 @@ function useRecoilSync({
           delete registration.pendingUpdate;
         }
       }
-      // Lazy load "allItems" only if needed.
-      const writeInterface = new Proxy(
-        ({diff, allItems: (null: any)}: WriteInterface), // flowlint-line unclear-type:off
-        {
-          get: (target, prop) => {
-            if (prop === 'allItems' && target.allItems == null) {
-              target.allItems = itemsFromSnapshot(
-                recoilStoreID,
-                storeKey,
-                snapshot.getInfo_UNSTABLE,
-              );
-            }
-            return target[prop];
-          },
-        },
-      );
       if (diff.size) {
-        write(writeInterface);
+        write(
+          writeInterfaceItems(
+            recoilStoreID,
+            storeKey,
+            diff,
+            snapshot.getInfo_UNSTABLE,
+          ),
+        );
       }
     }
   }, [recoilStoreID, snapshot, storeKey, write]);
@@ -241,11 +261,12 @@ function useRecoilSync({
           recoilStoreID,
           storeKey,
         );
+        // TODO syncEffect() read
         for (const [, registration] of atomRegistry) {
           let resetAtom = false;
           // Go through registered item keys in reverse order so later syncEffects
           // take priority if multiple keys are specified for the same storage
-          for (const [itemKey, entry] of Array.from(
+          for (const [itemKey, options] of Array.from(
             registration.itemKeys,
           ).reverse()) {
             if (diff.has(itemKey)) {
@@ -257,7 +278,7 @@ function useRecoilSync({
             const loadable = diff.get(itemKey);
             if (loadable != null) {
               resetAtom = false;
-              const validated = validateLoadable(loadable, entry);
+              const validated = validateLoadable(loadable, options);
               switch (validated.state) {
                 case 'hasValue':
                   registration.pendingUpdate = {
@@ -266,7 +287,7 @@ function useRecoilSync({
                   set(registration.atom, validated.contents);
                   break;
                 case 'hasError':
-                  if (entry.actionOnFailure === 'errorState') {
+                  if (options.actionOnFailure_UNSTABLE === 'errorState') {
                     // TODO Async atom support to allow setting atom to error state
                     // in the meantime we can just reset it to default value...
                     registration.pendingUpdate = {value: DEFAULT_VALUE};
@@ -291,7 +312,7 @@ function useRecoilSync({
     [recoilStoreID, storeKey],
   );
   const updateItem = useCallback(
-    (itemKey: ItemKey, loadable: ?Loadable<mixed>) => {
+    <T>(itemKey: ItemKey, loadable: ?Loadable<T>) => {
       updateItems(new Map([[itemKey, loadable]]));
     },
     [updateItems],
@@ -336,6 +357,12 @@ function RecoilSync(props: RecoilSyncOptions): React.Node {
 ///////////////////////
 // syncEffect()
 ///////////////////////
+export type WriteItem = (ItemKey, ?Loadable<mixed>) => void;
+export type WriteAtomInterface = {
+  write: WriteItem,
+  // read: ReadItem, // TODO
+};
+type WriteAtom<T> = (WriteAtomInterface, ?Loadable<T>) => void;
 export type SyncEffectOptions<T> = {
   storeKey?: StoreKey,
   itemKey?: ItemKey,
@@ -343,7 +370,7 @@ export type SyncEffectOptions<T> = {
   refine: Checker<T>,
 
   read?: ({read: ReadItem}) => mixed,
-  write?: (Loadable<T>, {read: ReadItem}) => ItemDiff,
+  write?: WriteAtom<T>,
 
   // Sync actual default value instead of empty when atom is in default state
   syncDefault?: boolean,
@@ -353,42 +380,40 @@ export type SyncEffectOptions<T> = {
   actionOnFailure_UNSTABLE?: ActionOnFailure,
 };
 
-function syncEffect<T>({
-  storeKey,
-  itemKey,
-  refine,
-  syncDefault,
-  actionOnFailure_UNSTABLE: actionOnFailure = 'errorState',
-}: SyncEffectOptions<T>): AtomEffect<T> {
+function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
   return ({node, trigger, storeID, setSelf, getLoadable, getInfo_UNSTABLE}) => {
-    const key = itemKey ?? node.key;
+    const options: AtomSyncOptions<T> = {
+      itemKey: node.key,
+      syncDefault: false,
+      actionOnFailure_UNSTABLE: 'errorState',
+      ...opt,
+    };
+    const {storeKey, itemKey} = options;
+    const storage = registries.getStorage(storeID, storeKey);
 
     // Register Atom
     const atomRegistry = registries.getAtomRegistry(storeID, storeKey);
     const registration = atomRegistry.get(node.key);
-    const entry = {refine, syncDefault, actionOnFailure};
     registration != null
-      ? registration.itemKeys.set(key, entry)
+      ? registration.itemKeys.set(itemKey, options)
       : atomRegistry.set(node.key, {
           atom: node,
-          itemKeys: new Map([[key, entry]]),
+          itemKeys: new Map([[itemKey, options]]),
         });
 
     if (trigger === 'get') {
       // Initialize Atom value
-      const readFromStorage = registries.getStorage(storeID, storeKey)?.read;
+      const readFromStorage = storage?.read;
       if (readFromStorage != null) {
         try {
-          const loadable = readFromStorage(key);
+          // TODO syncEffect() read
+          const loadable = readFromStorage(itemKey);
           if (loadable != null) {
             if (!RecoilLoadable.isLoadable(loadable)) {
               throw err('Sync read must provide a Loadable');
             }
 
-            const validated = validateLoadable<T>(loadable, {
-              refine,
-              actionOnFailure,
-            });
+            const validated = validateLoadable<T>(loadable, options);
             switch (validated.state) {
               case 'hasValue':
                 if (!(validated.contents instanceof DefaultValue)) {
@@ -396,7 +421,7 @@ function syncEffect<T>({
                 }
                 break;
               case 'hasError':
-                if (actionOnFailure === 'errorState') {
+                if (options.actionOnFailure_UNSTABLE === 'errorState') {
                   throw validated.contents;
                 }
                 break;
@@ -406,43 +431,24 @@ function syncEffect<T>({
             }
           }
         } catch (error) {
-          if (actionOnFailure === 'errorState') {
+          if (options.actionOnFailure_UNSTABLE === 'errorState') {
             throw error;
           }
         }
       }
 
       // Persist on Initial Read
-      const writeToStorage = registries.getStorage(storeID, storeKey)?.write;
-      if (syncDefault === true && writeToStorage != null) {
-        setTimeout(() => {
+      const writeToStorage = storage?.write;
+      if (options.syncDefault === true && writeToStorage != null) {
+        setImmediate(() => {
           const loadable = getLoadable(node);
           if (loadable.state === 'hasValue') {
-            // TODO Atom syncEffect() Write
-
-            // Lazy load "allItems" only if needed.
-            const writeInterface = new Proxy(
-              ({
-                diff: new Map([[key, loadable]]),
-                allItems: (null: any), // flowlint-line unclear-type:off
-              }: WriteInterface),
-              {
-                get: (target, prop) => {
-                  if (prop === 'allItems' && target.allItems == null) {
-                    target.allItems = itemsFromSnapshot(
-                      storeID,
-                      storeKey,
-                      getInfo_UNSTABLE,
-                    );
-                  }
-                  return target[prop];
-                },
-              },
+            const diff = writeAtomItems(new Map(), options, loadable);
+            writeToStorage(
+              writeInterfaceItems(storeID, storeKey, diff, getInfo_UNSTABLE),
             );
-
-            writeToStorage(writeInterface);
           }
-        }, 0);
+        });
       }
     }
 

--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -113,17 +113,22 @@ class Registries {
     externalStoreKey: StoreKey,
     node: RecoilState<T>,
     options: AtomSyncOptions<T>,
-  ): () => void {
+  ): {effectRegistration: EffectRegistration<T>, unregisterEffect: () => void} {
     const atomRegistry = this.getAtomRegistry(recoilStoreID, externalStoreKey);
     if (!atomRegistry.has(node.key)) {
       atomRegistry.set(node.key, {atom: node, effects: new Map()});
     }
     const effectKey = this.nextEffectKey++;
-    atomRegistry.get(node.key)?.effects.set(effectKey, {
+    const effectRegistration = {
       options,
       subscribedItemKeys: new Set([options.itemKey]),
-    });
-    return () => void atomRegistry.get(node.key)?.effects.delete(effectKey);
+    };
+    atomRegistry.get(node.key)?.effects.set(effectKey, effectRegistration);
+    return {
+      effectRegistration,
+      unregisterEffect: () =>
+        void atomRegistry.get(node.key)?.effects.delete(effectKey),
+    };
   }
 
   storageRegistries: Map<StoreID, Map<StoreKey, Storage>> = new Map();
@@ -166,7 +171,34 @@ function validateLoadable<T>(
   });
 }
 
-function writeAtomItems<T>(
+function readAtomItems<T>(
+  effectRegistration: EffectRegistration<T>,
+  readFromStorage?: ReadItem,
+  diff?: ItemDiff,
+): ?Loadable<T | DefaultValue> {
+  const {options} = effectRegistration;
+  const readFromStorageRequired =
+    readFromStorage ??
+    (itemKey =>
+      RecoilLoadable.error(
+        `Read functionality not provided for ${
+          options.storeKey != null ? `"${options.storeKey}" ` : ''
+        }store in useRecoilSync() hook while updating item "${itemKey}".`,
+      ));
+
+  effectRegistration.subscribedItemKeys = new Set();
+  const read = itemKey => {
+    effectRegistration.subscribedItemKeys.add(itemKey);
+    return diff != null && diff.has(itemKey)
+      ? diff.get(itemKey)
+      : readFromStorageRequired(itemKey);
+  };
+
+  const loadable = options.read({read});
+  return loadable && validateLoadable(loadable, options);
+}
+
+function writeAtomItemsToDiff<T>(
   diff: ItemDiff,
   options: AtomSyncOptions<T>,
   readFromStorage?: ReadItem,
@@ -201,7 +233,7 @@ const itemsFromSnapshot = (
   )) {
     for (const [, {options}] of effects) {
       const atomInfo = getInfo(atom);
-      writeAtomItems(
+      writeAtomItemsToDiff(
         items,
         options,
         registries.getStorage(recoilStoreID, storeKey)?.read,
@@ -214,7 +246,7 @@ const itemsFromSnapshot = (
   return items;
 };
 
-function writeInterfaceItems(
+function getWriteInterface(
   recoilStoreID: StoreID,
   storeKey: StoreKey,
   diff: ItemDiff,
@@ -278,7 +310,7 @@ function useRecoilSync({
               !(registration.pendingUpdate?.value instanceof DefaultValue))
           ) {
             for (const [, {options}] of registration.effects) {
-              writeAtomItems(
+              writeAtomItemsToDiff(
                 diff,
                 options,
                 read,
@@ -293,7 +325,7 @@ function useRecoilSync({
       }
       if (diff.size) {
         write(
-          writeInterfaceItems(
+          getWriteInterface(
             recoilStoreID,
             storeKey,
             diff,
@@ -311,45 +343,33 @@ function useRecoilSync({
           recoilStoreID,
           storeKey,
         );
-        const readFromStorageRequired =
-          read ??
-          (itemKey =>
-            RecoilLoadable.error(
-              `Read functionality not provided for ${
-                storeKey != null ? `"${storeKey}" ` : ''
-              }store in useRecoilSync() hook while updating item "${itemKey}".`,
-            ));
-        const readFromDiff = itemKey =>
-          diff.has(itemKey)
-            ? diff.get(itemKey)
-            : readFromStorageRequired(itemKey);
         // TODO iterating over all atoms registered with the store could be
         // optimized if we maintain a reverse look-up map of subscriptions.
-        for (const [, registration] of atomRegistry) {
+        for (const [, atomRegistration] of atomRegistry) {
           // Iterate through the effects for this storage in reverse order as
           // the last effect takes priority.
-          for (const [, {options, subscribedItemKeys}] of Array.from(
-            registration.effects,
+          for (const [, effectRegistration] of Array.from(
+            atomRegistration.effects,
           ).reverse()) {
+            const {options, subscribedItemKeys} = effectRegistration;
             // Only consider updating this atom if it subscribes to any items
             // specified in the diff.
             if (hasIntersection(subscribedItemKeys, diff)) {
-              const loadable = options.read({read: readFromDiff});
+              const loadable = readAtomItems(effectRegistration, read, diff);
               if (loadable != null) {
-                const validated = validateLoadable(loadable, options);
-                switch (validated.state) {
+                switch (loadable.state) {
                   case 'hasValue':
-                    registration.pendingUpdate = {
-                      value: validated.contents,
+                    atomRegistration.pendingUpdate = {
+                      value: loadable.contents,
                     };
-                    set(registration.atom, validated.contents);
+                    set(atomRegistration.atom, loadable.contents);
                     break;
                   case 'hasError':
                     if (options.actionOnFailure_UNSTABLE === 'errorState') {
                       // TODO Async atom support to allow setting atom to error state
                       // in the meantime we can just reset it to default value...
-                      registration.pendingUpdate = {value: DEFAULT_VALUE};
-                      reset(registration.atom);
+                      atomRegistration.pendingUpdate = {value: DEFAULT_VALUE};
+                      reset(atomRegistration.atom);
                     }
                     break;
                   case 'loading':
@@ -366,8 +386,8 @@ function useRecoilSync({
                 // older key as a fallback.
                 break;
               } else {
-                registration.pendingUpdate = {value: DEFAULT_VALUE};
-                reset(registration.atom);
+                atomRegistration.pendingUpdate = {value: DEFAULT_VALUE};
+                reset(atomRegistration.atom);
               }
             }
           }
@@ -461,27 +481,34 @@ function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
     const {storeKey} = options;
     const storage = registries.getStorage(storeID, storeKey);
 
+    // Register Atom
+    const {effectRegistration, unregisterEffect} = registries.setAtomEffect(
+      storeID,
+      storeKey,
+      node,
+      options,
+    );
+
     if (trigger === 'get') {
       // Initialize Atom value
       const readFromStorage = storage?.read;
       if (readFromStorage != null) {
         try {
-          const loadable = options.read({read: readFromStorage});
+          const loadable = readAtomItems(effectRegistration, readFromStorage);
           if (loadable != null) {
-            const validated = validateLoadable<T>(loadable, options);
-            switch (validated.state) {
+            switch (loadable.state) {
               case 'hasValue':
-                if (!(validated.contents instanceof DefaultValue)) {
-                  setSelf(validated.contents);
+                if (!(loadable.contents instanceof DefaultValue)) {
+                  setSelf(loadable.contents);
                 }
                 break;
               case 'hasError':
                 if (options.actionOnFailure_UNSTABLE === 'errorState') {
-                  throw validated.contents;
+                  throw loadable.contents;
                 }
                 break;
               case 'loading':
-                setSelf(validated.toPromise());
+                setSelf(loadable.toPromise());
                 break;
             }
           }
@@ -498,22 +525,22 @@ function syncEffect<T>(opt: SyncEffectOptions<T>): AtomEffect<T> {
         setImmediate(() => {
           const loadable = getLoadable(node);
           if (loadable.state === 'hasValue') {
-            const diff = writeAtomItems(
+            const diff = writeAtomItemsToDiff(
               new Map(),
               options,
               storage?.read,
               loadable,
             );
             writeToStorage(
-              writeInterfaceItems(storeID, storeKey, diff, getInfo_UNSTABLE),
+              getWriteInterface(storeID, storeKey, diff, getInfo_UNSTABLE),
             );
           }
         });
       }
     }
 
-    // Register Atom
-    return registries.setAtomEffect(storeID, storeKey, node, options);
+    // Cleanup atom effect registration
+    return unregisterEffect;
   };
 }
 

--- a/packages/recoil-sync/RecoilSync_URLTransit.js
+++ b/packages/recoil-sync/RecoilSync_URLTransit.js
@@ -20,18 +20,18 @@ const React = require('react');
 const {useCallback, useMemo} = require('react');
 const transit = require('transit-js');
 
-type Handler<T, S> = {
+export type TransitHandler<T, S> = {
   tag: string,
   class: Class<T>,
   write: T => S,
   read: S => T,
 };
 
-type RecoilURLSyncTrnsitOptions = $Rest<
+export type RecoilURLSyncTransitOptions = $Rest<
   {
     ...RecoilURLSyncOptions,
     // $FlowIssue[unclear-type]
-    handlers?: $ReadOnlyArray<Handler<any, any>>,
+    handlers?: $ReadOnlyArray<TransitHandler<any, any>>,
   },
   {
     serialize: mixed => string,
@@ -69,7 +69,7 @@ const BUILTIN_HANDLERS = [
 function useRecoilURLSyncTransit({
   handlers: handlersProp = [],
   ...options
-}: RecoilURLSyncTrnsitOptions): void {
+}: RecoilURLSyncTransitOptions): void {
   if (options.location.part === 'href') {
     throw err('"href" location is not supported for Transit encoding');
   }
@@ -121,7 +121,7 @@ function useRecoilURLSyncTransit({
   useRecoilURLSync({...options, serialize, deserialize});
 }
 
-function RecoilURLSyncTransit(props: RecoilURLSyncTrnsitOptions): React.Node {
+function RecoilURLSyncTransit(props: RecoilURLSyncTransitOptions): React.Node {
   useRecoilURLSyncTransit(props);
   return null;
 }

--- a/packages/recoil-sync/RecoilSync_index.js
+++ b/packages/recoil-sync/RecoilSync_index.js
@@ -10,8 +10,25 @@
  */
 'use strict';
 
+import type {
+  ItemKey,
+  ListenToItems,
+  ReadAtom,
+  ReadAtomInterface,
+  ReadItem,
+  RecoilSyncOptions,
+  StoreKey,
+  SyncEffectOptions,
+  WriteAtom,
+  WriteAtomInterface,
+  WriteItems,
+} from './RecoilSync';
 import type {RecoilURLSyncOptions} from './RecoilSync_URL';
 import type {RecoilURLSyncJSONOptions} from './RecoilSync_URLJSON';
+import type {
+  RecoilURLSyncTransitOptions,
+  TransitHandler,
+} from './RecoilSync_URLTransit';
 
 const {RecoilSync, syncEffect, useRecoilSync} = require('./RecoilSync');
 const {
@@ -24,8 +41,27 @@ const {
   useRecoilURLSyncJSON,
 } = require('./RecoilSync_URLJSON');
 
-export type {RecoilURLSyncOptions};
-export type {RecoilURLSyncJSONOptions};
+export type {
+  // Keys
+  ItemKey,
+  StoreKey,
+  // Core useRecoilSync() options
+  RecoilSyncOptions,
+  ReadItem,
+  WriteItems,
+  ListenToItems,
+  // Core syncEffect() options
+  SyncEffectOptions,
+  ReadAtomInterface,
+  ReadAtom,
+  WriteAtomInterface,
+  WriteAtom,
+  // URL Synchronization
+  RecoilURLSyncOptions,
+  RecoilURLSyncJSONOptions,
+  RecoilURLSyncTransitOptions,
+  TransitHandler,
+};
 
 module.exports = {
   // Core Recoil Sync

--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -91,7 +91,7 @@ function encodeURLPart(href: string, loc: LocationOption, obj): string {
           searchParams.set(key, JSON.stringify(value) ?? '');
         }
       }
-      url.search = searchParams.toString() || '?';
+      url.search = searchParams.toString();
       break;
     }
   }

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -33,7 +33,7 @@ const {
   flushPromisesAndTimers,
   renderElements,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
-const {asType, match, number, string} = require('refine');
+const {asType, dict, match, number, string} = require('refine');
 
 ////////////////////////////
 // Mock Storage
@@ -1048,6 +1048,32 @@ describe('Complex Mappings', () => {
 
     expect(storage.size).toEqual(2);
     expect(storage.get('self')?.contents).toEqual('OTHER_SELF');
+  });
+
+  test('read from multiple items', () => {
+    const myAtom = atom({
+      key: 'recoil-sync read from multiple',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        syncEffect({
+          refine: dict(string()),
+          read: ({read}) => RecoilLoadable.all({a: read('a'), b: read('b')}),
+        }),
+      ],
+    });
+
+    const storage = new Map([
+      ['a', RecoilLoadable.of('A')],
+      ['b', RecoilLoadable.of('B')],
+    ]);
+    const container = renderElements(
+      <>
+        <TestRecoilSync storage={storage} />
+        <ReadsAtom atom={myAtom} />
+      </>,
+    );
+
+    expect(container.textContent).toBe('{"a":"A","b":"B"}');
   });
 });
 

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -1024,6 +1024,8 @@ describe('Complex Mappings', () => {
         syncEffect({
           refine: string(),
           write: ({write, read}, loadable) => {
+            write('self', RecoilLoadable.of('TMP'));
+            expect(read('self')?.getValue()).toEqual('TMP');
             write(
               'self',
               read('other')?.map(x => loadable?.map(y => `${String(x)}_${y}`)),

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -1091,10 +1091,16 @@ describe('Complex Mappings', () => {
     // Test mapping while initializing values
     expect(container.textContent).toBe('{"a":1,"b":2}');
 
-    // TODO
     // Test subscribing to multiple items
     act(() => updateItem('a', RecoilLoadable.of(10)));
-    // expect(container.textContent).toBe('{"a":10,"b":2}');
+    expect(container.textContent).toBe('{"a":10,"b":2}');
+
+    // Avoid feedback loops
+    expect(storage.get('a')?.contents).toEqual(1);
+    storage.set('a', RecoilLoadable.of(10)); // Keep storage in sync
+
+    act(() => updateItem('b', RecoilLoadable.of(20)));
+    expect(container.textContent).toBe('{"a":10,"b":20}');
   });
 });
 

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {act} = require('ReactTestUtils');
+const {RecoilLoadable, atom, atomFamily} = require('Recoil');
+
+const {
+  encodeURL,
+  expectURL,
+  gotoURL,
+} = require('../__test_utils__/RecoilSync_MockURLSerialization');
+const {syncEffect} = require('../RecoilSync');
+const {RecoilURLSyncJSON} = require('../RecoilSync_URLJSON');
+const React = require('react');
+const {
+  componentThatReadsAndWritesAtom,
+  renderElements,
+} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
+const {assertion, dict, nullable, number, string} = require('refine');
+
+test('Upgrade item ID', async () => {
+  const loc = {part: 'queryParams'};
+
+  const myAtom = atom({
+    key: 'recoil-url-sync upgrade itemID',
+    default: 'DEFAULT',
+    effects_UNSTABLE: [
+      syncEffect({
+        refine: string(),
+        itemKey: 'new_key',
+        read: ({read}) => read('old_key') ?? read('new_key'),
+      }),
+    ],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {old_key: 'OLD'}]]));
+
+  const [Atom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(myAtom);
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Atom />
+    </>,
+  );
+
+  // Test that we can load based on old key
+  expect(container.textContent).toEqual('"OLD"');
+
+  // Test that we can save to the new key
+  act(() => setAtom('NEW'));
+  expect(container.textContent).toEqual('"NEW"');
+  expectURL([[loc, {new_key: 'NEW'}]]);
+
+  // Test that we can reset the atom and get the default instead of the old key's value
+  act(resetAtom);
+  expect(container.textContent).toEqual('"DEFAULT"');
+  expectURL([[loc, {}]]);
+});
+
+test('Many items to one atom', async () => {
+  const loc = {part: 'queryParams'};
+
+  const manyToOneSyncEffct = () =>
+    syncEffect({
+      refine: dict(nullable(number())),
+      read: ({read}) =>
+        RecoilLoadable.all({foo: read('foo'), bar: read('bar')}),
+      write: ({write}, loadable) => {
+        if (loadable == null) {
+          write('foo');
+          write('bar');
+        }
+        if (loadable?.state === 'hasValue') {
+          for (const key of Object.keys(loadable.contents)) {
+            write(key, RecoilLoadable.of(loadable.contents[key]));
+          }
+        }
+      },
+    });
+
+  const myAtom = atom({
+    key: 'recoil-url-sync many-to-one',
+    default: {},
+    effects_UNSTABLE: [manyToOneSyncEffct()],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {foo: 1}]]));
+
+  const [Atom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(myAtom);
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Atom />
+    </>,
+  );
+
+  // Test initialize value from URL
+  expect(container.textContent).toBe('{"foo":1}');
+
+  // Test subscribe to URL updates
+  gotoURL([[loc, {foo: 1, bar: 2}]]);
+  expect(container.textContent).toBe('{"bar":2,"foo":1}');
+
+  // Test mutating atoms will update URL
+  act(() => setAtom({foo: 3, bar: 4}));
+  expectURL([[loc, {foo: 3, bar: 4}]]);
+
+  // Test reseting atoms will update URL
+  act(resetAtom);
+  expectURL([[loc, {}]]);
+});
+
+test('One item to multiple atoms', async () => {
+  const loc = {part: 'queryParams'};
+  const input = assertion(dict(nullable(number())));
+
+  const oneToManySyncEffect = (prop: string) =>
+    syncEffect({
+      refine: nullable(number()),
+      read: ({read}) => read('compound')?.map(x => input(x)[prop]),
+      write: ({write, read}, loadable) =>
+        write(
+          'compound',
+          read('compound')?.map(compound => {
+            const x = {...input(compound)};
+            if (loadable == null) {
+              delete x[prop];
+              return x;
+            }
+            return loadable.map(newValue => ({...x, [prop]: newValue}));
+          }),
+        ),
+    });
+
+  const fooAtom = atom({
+    key: 'recoil-url-sync one-to-many foo',
+    default: 0,
+    effects_UNSTABLE: [oneToManySyncEffect('foo')],
+  });
+
+  const barAtom = atom({
+    key: 'recoil-url-sync one-to-many bar',
+    default: undefined,
+    effects_UNSTABLE: [oneToManySyncEffect('bar')],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {compound: {foo: 1}}]]));
+
+  const [Foo, setFoo, resetFoo] = componentThatReadsAndWritesAtom(fooAtom);
+  const [Bar, setBar, resetBar] = componentThatReadsAndWritesAtom(barAtom);
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Foo />
+      <Bar />
+    </>,
+  );
+
+  // Test initialize value from URL
+  expect(container.textContent).toBe('1');
+
+  // Test subscribe to URL updates
+  gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
+  expect(container.textContent).toBe('12');
+
+  // Test mutating atoms will update URL
+  act(() => setFoo(3));
+  expect(container.textContent).toBe('32');
+  expectURL([[loc, {compound: {foo: 3, bar: 2}}]]);
+  act(() => setBar(4));
+  expect(container.textContent).toBe('34');
+  expectURL([[loc, {compound: {foo: 3, bar: 4}}]]);
+
+  // Test reseting atoms will update URL
+  act(resetFoo);
+  expect(container.textContent).toBe('04');
+  expectURL([[loc, {compound: {bar: 4}}]]);
+  act(resetBar);
+  expect(container.textContent).toBe('0');
+  expectURL([[loc, {compound: {}}]]);
+});
+
+test('One item to atom family', async () => {
+  const loc = {part: 'queryParams'};
+  const input = assertion(dict(nullable(number())));
+
+  const oneToFamilyEffect = (prop: string) =>
+    syncEffect({
+      refine: nullable(number()),
+      read: ({read}) => read('compound')?.map(x => input(x)[prop]),
+      write: ({write, read}, loadable) =>
+        write(
+          'compound',
+          read('compound')?.map(compound => {
+            const x = {...input(compound)};
+            if (loadable == null) {
+              delete x[prop];
+              return x;
+            }
+            return loadable.map(newValue => ({...x, [prop]: newValue}));
+          }),
+        ),
+    });
+
+  const myAtoms = atomFamily({
+    key: 'recoil-rul-sync one-to-family',
+    default: undefined,
+    effects_UNSTABLE: prop => [oneToFamilyEffect(prop)],
+  });
+
+  history.replaceState(null, '', encodeURL([[loc, {compound: {foo: 1}}]]));
+
+  const [Foo, setFoo, resetFoo] = componentThatReadsAndWritesAtom(
+    myAtoms('foo'),
+  );
+  const [Bar, setBar, resetBar] = componentThatReadsAndWritesAtom(
+    myAtoms('bar'),
+  );
+  const container = renderElements(
+    <>
+      <RecoilURLSyncJSON location={loc} />
+      <Foo />
+      <Bar />
+    </>,
+  );
+
+  // Test initialize value from URL
+  expect(container.textContent).toBe('1');
+
+  // Test subscribe to URL updates
+  gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
+  expect(container.textContent).toBe('12');
+
+  // Test mutating atoms will update URL
+  act(() => setFoo(3));
+  expect(container.textContent).toBe('32');
+  expectURL([[loc, {compound: {foo: 3, bar: 2}}]]);
+  act(() => setBar(4));
+  expect(container.textContent).toBe('34');
+  expectURL([[loc, {compound: {foo: 3, bar: 4}}]]);
+
+  // Test reseting atoms will update URL
+  act(resetFoo);
+  expect(container.textContent).toBe('4');
+  expectURL([[loc, {compound: {bar: 4}}]]);
+  act(resetBar);
+  expect(container.textContent).toBe('');
+  expectURL([[loc, {compound: {}}]]);
+});

--- a/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
@@ -36,7 +36,7 @@ const mockBrowserURL = {
     urls[urls.length - 1] = absoluteURL(url);
   },
   pushURL: url => void urls.push(absoluteURL(url)),
-  getURL: () => new URL(absoluteURL(currentURL())),
+  getURL: () => absoluteURL(currentURL()),
   listenChangeURL: handler => {
     subscriptions.add(handler);
     return () => void subscriptions.delete(handler);

--- a/packages/recoil/adt/__tests__/Recoil_Loadable-test.js
+++ b/packages/recoil/adt/__tests__/Recoil_Loadable-test.js
@@ -177,57 +177,84 @@ test('Loadable Factory Interface', async () => {
   expect(errorLoadable.contents).toBe('ERROR');
 });
 
-test('Load All Array', async () => {
-  expect(
-    RecoilLoadable.all([RecoilLoadable.of('x'), RecoilLoadable.of(123)])
-      .contents,
-  ).toEqual(['x', 123]);
-  await expect(
-    RecoilLoadable.all([
-      RecoilLoadable.of(Promise.resolve('x')),
-      RecoilLoadable.of(123),
-    ]).contents,
-  ).resolves.toEqual(['x', 123]);
-  expect(
-    RecoilLoadable.all([
-      RecoilLoadable.of('x'),
-      RecoilLoadable.of(123),
-      RecoilLoadable.error('ERROR'),
-    ]).contents,
-  ).toEqual('ERROR');
+describe('Loadable All', () => {
+  test('Array', async () => {
+    expect(
+      RecoilLoadable.all([RecoilLoadable.of('x'), RecoilLoadable.of(123)])
+        .contents,
+    ).toEqual(['x', 123]);
+    await expect(
+      RecoilLoadable.all([
+        RecoilLoadable.of(Promise.resolve('x')),
+        RecoilLoadable.of(123),
+      ]).contents,
+    ).resolves.toEqual(['x', 123]);
+    expect(
+      RecoilLoadable.all([
+        RecoilLoadable.of('x'),
+        RecoilLoadable.of(123),
+        RecoilLoadable.error('ERROR'),
+      ]).contents,
+    ).toEqual('ERROR');
 
-  expect(
-    RecoilLoadable.all([
-      RecoilLoadable.of('x'),
-      RecoilLoadable.all([RecoilLoadable.of(1), RecoilLoadable.of(2)]),
-    ]).contents,
-  ).toEqual(['x', [1, 2]]);
-});
+    expect(
+      RecoilLoadable.all([
+        RecoilLoadable.of('x'),
+        RecoilLoadable.all([RecoilLoadable.of(1), RecoilLoadable.of(2)]),
+      ]).contents,
+    ).toEqual(['x', [1, 2]]);
+  });
 
-test('Load All Object', async () => {
-  expect(
-    RecoilLoadable.all({
-      str: RecoilLoadable.of('x'),
-      num: RecoilLoadable.of(123),
-    }).contents,
-  ).toEqual({
-    str: 'x',
-    num: 123,
+  test('Object', async () => {
+    expect(
+      RecoilLoadable.all({
+        str: RecoilLoadable.of('x'),
+        num: RecoilLoadable.of(123),
+      }).contents,
+    ).toEqual({
+      str: 'x',
+      num: 123,
+    });
+    await expect(
+      RecoilLoadable.all({
+        str: RecoilLoadable.of(Promise.resolve('x')),
+        num: RecoilLoadable.of(123),
+      }).contents,
+    ).resolves.toEqual({
+      str: 'x',
+      num: 123,
+    });
+    expect(
+      RecoilLoadable.all({
+        str: RecoilLoadable.of('x'),
+        num: RecoilLoadable.of(123),
+        err: RecoilLoadable.error('ERROR'),
+      }).contents,
+    ).toEqual('ERROR');
   });
-  await expect(
-    RecoilLoadable.all({
-      str: RecoilLoadable.of(Promise.resolve('x')),
-      num: RecoilLoadable.of(123),
-    }).contents,
-  ).resolves.toEqual({
-    str: 'x',
-    num: 123,
+
+  test('mixed values', async () => {
+    expect(RecoilLoadable.all([RecoilLoadable.of('A'), 'B']).contents).toEqual([
+      'A',
+      'B',
+    ]);
+
+    await expect(
+      RecoilLoadable.all([RecoilLoadable.of('A'), Promise.resolve('B')])
+        .contents,
+    ).resolves.toEqual(['A', 'B']);
+
+    await expect(
+      RecoilLoadable.all([RecoilLoadable.of('A'), Promise.reject('B')])
+        .contents,
+    ).rejects.toEqual('B');
+
+    await expect(
+      RecoilLoadable.all({
+        a: 'A',
+        b: RecoilLoadable.of('B'),
+        c: Promise.resolve('C'),
+      }).contents,
+    ).resolves.toEqual({a: 'A', b: 'B', c: 'C'});
   });
-  expect(
-    RecoilLoadable.all({
-      str: RecoilLoadable.of('x'),
-      num: RecoilLoadable.of(123),
-      err: RecoilLoadable.error('ERROR'),
-    }).contents,
-  ).toEqual('ERROR');
 });

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -492,8 +492,8 @@ export function noWait<T>(state: RecoilValue<T>): RecoilValueReadOnly<Loadable<T
   param: RecoilValues,
  ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
-  export type UnwrapLoadable<T> = T extends Loadable<infer R> ? R : never;
-  export type UnwrapLoadables<T extends Array<Loadable<any>> | { [key: string]: Loadable<any> }> = {
+  export type UnwrapLoadable<T> = T extends Loadable<infer R> ? R : T extends Promise<infer P> ? P : T;
+  export type UnwrapLoadables<T extends any[] | { [key: string]: any }> = {
     [P in keyof T]: UnwrapLoadable<T[P]>;
   };
 
@@ -512,9 +512,10 @@ export function noWait<T>(state: RecoilValue<T>): RecoilValueReadOnly<Loadable<T
      * Factory to make a Loadable which is resolved when all of the Loadables provided
      * to it are resolved or any one has an error.  The value is an array of the values
      * of all of the provided Loadables.  This is comparable to Promise.all() for Loadables.
+     * Similar to Promise.all(), inputs may be Loadables, Promises, or literal values.
      */
-    function all<Inputs extends Array<Loadable<any>> | [Loadable<any>]>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
-    function all<Inputs extends {[key: string]: Loadable<any>}>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
+    function all<Inputs extends any[] | [Loadable<any>]>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
+    function all<Inputs extends {[key: string]: any}>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
     /**
      * Returns true if the provided parameter is a Loadable type.
      */

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -759,6 +759,16 @@ isRecoilValue(mySelector1);
     x.void; // $ExpectError
   });
 
+  const mixedAllLoadableArray = RecoilLoadable.all([
+    RecoilLoadable.of('str'),
+    'str',
+    Promise.resolve('str'),
+  ]).map(x => {
+    x[0]; // $ExpectType string
+    x[1]; // $ExpectType string
+    x[2]; // $ExpectType string
+  });
+
   RecoilLoadable.isLoadable(false); // $ExpectType boolean
   RecoilLoadable.isLoadable(RecoilLoadable.of('x')); // $ExpectType boolean
 }


### PR DESCRIPTION
Summary:
Simplify the browser abstraction interface by having `getURL()` return a `string` instead of a `URL` object.

When encoding a URL with no query params don't include an ampty `?` character.

Differential Revision: D32626000

