### PR TITLE
Simplify API by removing Loadables

### DIFF
--- a/packages/recoil-sync/RecoilSync_index.js
+++ b/packages/recoil-sync/RecoilSync_index.js
@@ -17,6 +17,7 @@ import type {
   ReadAtomInterface,
   ReadItem,
   RecoilSyncOptions,
+  ResetItem,
   StoreKey,
   SyncEffectOptions,
   WriteAtom,
@@ -60,6 +61,7 @@ export type {
   ReadAtom,
   WriteAtomInterface,
   WriteAtom,
+  ResetItem,
   // URL Synchronization
   RecoilURLSyncOptions,
   RecoilURLSyncJSONOptions,

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -221,7 +221,7 @@ describe('URL Transit Encode', () => {
       [atomWithFallback],
       '"FALLBACK"',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22withFallback%22%2C%5B%22%7E%23__DV%22%2C0%5D%5D#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%5D#anchor',
     ));
   test('Query Params - fallback', async () =>
     testTransit(
@@ -229,7 +229,7 @@ describe('URL Transit Encode', () => {
       [atomWithFallback],
       '"FALLBACK"',
       '/path/page.html#anchor',
-      '/path/page.html?withFallback=%5B%22%7E%23__DV%22%2C0%5D#anchor',
+      '/path/page.html#anchor',
     ));
 });
 


### PR DESCRIPTION
Summary:
Simplify the API by removing `Loadable`'s and making it more consistent with the selector interface.  Loadables can still be used to capture some corner cases such as setting a synchronous error, but in general can be avoided for simplicity.

The drawback to this approach is more complex handling for reading async items during a write or a compound read, which shouldn't be as common.

Differential Revision: D32614322

