### PR TITLE
Update atoms.mdx

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/atoms.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/atoms.mdx
@@ -40,7 +40,7 @@ function TodoList() {
 ```jsx
 function TodoItemCreator() {
   const [inputValue, setInputValue] = useState('');
-  const setTodoList = useSetRecoilState(todoListState);
+  const [todoList, setTodoList] = useSetRecoilState(todoListState);
 
   const addItem = () => {
     setTodoList((oldTodoList) => [


### PR DESCRIPTION
The API reference specifies that the `useRecoilState()` hook should return a tuple of the current value of the state and a setter function. Thus, assuming that `setTodoList` is intended to be used as a setter function, the variable should be declared as the second value of the return tuple, instead of it being the tuple itself.