### PR TITLE
Run atom effect when first used by setting from a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Recoil with React strict mode that re-executes effects multiple times.
 - Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
+- Run atom effects when set from `useRecoilTransaction_UNSTABLE()` (#1466)
 - `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
 - `storeID` added to atom effects interface (#1414)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)

--- a/packages/recoil/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useTransaction-test.js
@@ -91,6 +91,72 @@ describe('Atoms', () => {
 });
 
 describe('Atom Effects', () => {
+  testRecoil(
+    'Atom effects are run when first get from a transaction',
+    async () => {
+      let numTimesEffectInit = 0;
+
+      const atomWithEffect = atom({
+        key: 'atom effect first get transaction',
+        default: 'DEFAULT',
+        effects_UNSTABLE: [
+          ({trigger}) => {
+            expect(trigger).toEqual('get');
+            numTimesEffectInit++;
+          },
+        ],
+      });
+
+      let getAtomWithTransaction;
+      const Component = () => {
+        getAtomWithTransaction = useRecoilTransaction(({get}) => () => {
+          expect(get(atomWithEffect)).toEqual('DEFAULT');
+        });
+        return null;
+      };
+
+      renderElements(<Component />);
+
+      act(() => getAtomWithTransaction());
+
+      expect(numTimesEffectInit).toBe(1);
+    },
+  );
+
+  // TODO Unable to test setting from a transaction as Jest complains about
+  // updates not wrapped in act(...)...
+  // testRecoil(
+  //   'Atom effects are run when first set with a transaction',
+  //   async () => {
+  //     let numTimesEffectInit = 0;
+
+  //     const atomWithEffect = atom({
+  //       key: 'atom effect first set transaction',
+  //       default: 'DEFAULT',
+  //       effects_UNSTABLE: [
+  //         ({trigger}) => {
+  //           expect(trigger).toEqual('set');
+  //           numTimesEffectInit++;
+  //         },
+  //       ],
+  //     });
+
+  //     let setAtomWithTransaction;
+  //     const Component = () => {
+  //       setAtomWithTransaction = useRecoilTransaction(({set}) => () => {
+  //         set(atomWithEffect, 'SET');
+  //       });
+  //       return null;
+  //     };
+
+  //     renderElements(<Component />);
+
+  //     act(() => setAtomWithTransaction());
+
+  //     expect(numTimesEffectInit).toBe(1);
+  //   },
+  // );
+
   testRecoil('Atom effects can initialize for a transaction', async () => {
     let numTimesEffectInit = 0;
     const atomWithEffect = atom({


### PR DESCRIPTION
Summary:
Run atom effects when they are first used by being set from a transaction from `useRecoilTransaction_UNSTABLE()`.

Resolves #1466

Differential Revision: D32777543

