### PR TITLE
Couple recoil_early_rendering_2021 and recoil_suppress_rerender_in_callback GKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Recoil with React strict mode that re-executes effects multiple times.
 - Add `refresh` to Recoil callback interface (#1413)
 - Fix transitive selector refresh for some cases (#1409)
+- Run atom effects when set from `useRecoilTransaction_UNSTABLE()` (#1466)
 - `useRecoilStoreID()` hook to get an ID for the current <RecoilRoot> store. (#1417)
 - `storeID` added to atom effects interface (#1414)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -49,6 +49,7 @@ const {
 const err = require('recoil-shared/util/Recoil_err');
 const expectationViolation = require('recoil-shared/util/Recoil_expectationViolation');
 const gkx = require('recoil-shared/util/Recoil_gkx');
+const gkx_early_rendering = require('recoil-shared/util/Recoil_gkx_early_rendering');
 const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 const unionSets = require('recoil-shared/util/Recoil_unionSets');
@@ -174,10 +175,7 @@ function sendEndOfBatchNotifications(store: Store) {
       subscription(store);
     }
 
-    if (
-      !gkx('recoil_early_rendering_2021') ||
-      storeState.suspendedComponentResolvers.size
-    ) {
+    if (!gkx_early_rendering() || storeState.suspendedComponentResolvers.size) {
       // Notifying components is needed to wake from suspense, even when using
       // early rendering.
       notifyComponents(store, storeState, treeState);
@@ -426,7 +424,7 @@ function RecoilRoot_INTERNAL({
 
     // Save changes to nextTree and schedule a React update:
     storeStateRef.current.nextTree = replaced;
-    if (gkx('recoil_early_rendering_2021')) {
+    if (gkx_early_rendering()) {
       notifyComponents(storeRef.current, storeStateRef.current, replaced);
     }
     nullthrows(notifyBatcherOfChange.current)();

--- a/packages/recoil/core/Recoil_RecoilValueInterface.js
+++ b/packages/recoil/core/Recoil_RecoilValueInterface.js
@@ -34,7 +34,7 @@ const {
   RecoilValueReadOnly,
   isRecoilValue,
 } = require('./Recoil_RecoilValue');
-const gkx = require('recoil-shared/util/Recoil_gkx');
+const gkx_early_rendering = require('recoil-shared/util/Recoil_gkx_early_rendering');
 const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
@@ -313,7 +313,7 @@ function subscribeToRecoilValue<T>(
 
   // Handle the case that, during the same tick that we are subscribing, an atom
   // has been updated by some effect handler. Otherwise we will miss the update.
-  if (gkx('recoil_early_rendering_2021')) {
+  if (gkx_early_rendering()) {
     const nextTree = store.getState().nextTree;
     if (nextTree && nextTree.dirtyAtoms.has(key)) {
       callback(nextTree);

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -69,7 +69,7 @@ function handleLoadable<T>(
   }
 }
 
-function validateRecoilValue(recoilValue, hookName) {
+function validateRecoilValue<T>(recoilValue: RecoilValue<T>, hookName) {
   if (!isRecoilValue(recoilValue)) {
     throw err(
       `Invalid argument to ${hookName}: expected an atom or selector but got ${String(
@@ -194,7 +194,6 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
       recoilState: RecoilState<T>,
     ): SetterOrUpdater<T> {
       if (__DEV__) {
-        // $FlowFixMe[escaped-generic]
         validateRecoilValue(recoilState, 'useSetRecoilState');
       }
       return (
@@ -207,7 +206,6 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
     // eslint-disable-next-line no-shadow
     function useResetRecoilState<T>(recoilState: RecoilState<T>): Resetter {
       if (__DEV__) {
-        // $FlowFixMe[escaped-generic]
         validateRecoilValue(recoilState, 'useResetRecoilState');
       }
       return () => setRecoilValue(storeRef.current, recoilState, DEFAULT_VALUE);
@@ -218,7 +216,6 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
       recoilValue: RecoilValue<T>,
     ): Loadable<T> {
       if (__DEV__) {
-        // $FlowFixMe[escaped-generic]
         validateRecoilValue(recoilValue, 'useRecoilValueLoadable');
       }
       if (!recoilValuesUsed.current.has(recoilValue.key)) {
@@ -241,7 +238,6 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
     // eslint-disable-next-line no-shadow
     function useRecoilValue<T>(recoilValue: RecoilValue<T>): T {
       if (__DEV__) {
-        // $FlowFixMe[escaped-generic]
         validateRecoilValue(recoilValue, 'useRecoilValue');
       }
       const loadable = useRecoilValueLoadable(recoilValue);
@@ -253,7 +249,6 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
       recoilState: RecoilState<T>,
     ): [T, SetterOrUpdater<T>] {
       if (__DEV__) {
-        // $FlowFixMe[escaped-generic]
         validateRecoilValue(recoilState, 'useRecoilState');
       }
       return [useRecoilValue(recoilState), useSetRecoilState(recoilState)];
@@ -264,7 +259,6 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
       recoilState: RecoilState<T>,
     ): [Loadable<T>, SetterOrUpdater<T>] {
       if (__DEV__) {
-        // $FlowFixMe[escaped-generic]
         validateRecoilValue(recoilState, 'useRecoilStateLoadable');
       }
       return [
@@ -289,10 +283,6 @@ const recoilComponentGetRecoilValueCount_FOR_TESTING = {current: 0};
 function useRecoilValueLoadable_MUTABLESOURCE<T>(
   recoilValue: RecoilValue<T>,
 ): Loadable<T> {
-  if (__DEV__) {
-    // $FlowFixMe[escaped-generic]
-    validateRecoilValue(recoilValue, 'useRecoilValueLoadable');
-  }
   const storeRef = useStoreRef();
 
   const getLoadable = useCallback(() => {
@@ -355,10 +345,6 @@ function useRecoilValueLoadable_MUTABLESOURCE<T>(
 function useRecoilValueLoadable_LEGACY<T>(
   recoilValue: RecoilValue<T>,
 ): Loadable<T> {
-  if (__DEV__) {
-    // $FlowFixMe[escaped-generic]
-    validateRecoilValue(recoilValue, 'useRecoilValueLoadable');
-  }
   const storeRef = useStoreRef();
   const [_, forceUpdate] = useState([]);
 
@@ -439,6 +425,9 @@ function useRecoilValueLoadable_LEGACY<T>(
   just undefined if not available for any reason, such as pending or error.
 */
 function useRecoilValueLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
+  if (__DEV__) {
+    validateRecoilValue(recoilValue, 'useRecoilValueLoadable');
+  }
   if (gkx('recoil_memory_managament_2020')) {
     // eslint-disable-next-line fb-www/react-hooks
     useRetain(recoilValue);
@@ -460,7 +449,6 @@ function useRecoilValueLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
   */
 function useRecoilValue<T>(recoilValue: RecoilValue<T>): T {
   if (__DEV__) {
-    // $FlowFixMe[escaped-generic]
     validateRecoilValue(recoilValue, 'useRecoilValue');
   }
   const storeRef = useStoreRef();
@@ -474,7 +462,6 @@ function useRecoilValue<T>(recoilValue: RecoilValue<T>): T {
 */
 function useSetRecoilState<T>(recoilState: RecoilState<T>): SetterOrUpdater<T> {
   if (__DEV__) {
-    // $FlowFixMe[escaped-generic]
     validateRecoilValue(recoilState, 'useSetRecoilState');
   }
   const storeRef = useStoreRef();
@@ -491,7 +478,6 @@ function useSetRecoilState<T>(recoilState: RecoilState<T>): SetterOrUpdater<T> {
 */
 function useResetRecoilState<T>(recoilState: RecoilState<T>): Resetter {
   if (__DEV__) {
-    // $FlowFixMe[escaped-generic]
     validateRecoilValue(recoilState, 'useResetRecoilState');
   }
   const storeRef = useStoreRef();
@@ -511,7 +497,6 @@ function useRecoilState<T>(
   recoilState: RecoilState<T>,
 ): [T, SetterOrUpdater<T>] {
   if (__DEV__) {
-    // $FlowFixMe[escaped-generic]
     validateRecoilValue(recoilState, 'useRecoilState');
   }
   return [useRecoilValue(recoilState), useSetRecoilState(recoilState)];
@@ -526,7 +511,6 @@ function useRecoilStateLoadable<T>(
   recoilState: RecoilState<T>,
 ): [Loadable<T>, SetterOrUpdater<T>] {
   if (__DEV__) {
-    // $FlowFixMe[escaped-generic]
     validateRecoilValue(recoilState, 'useRecoilStateLoadable');
   }
   return [useRecoilValueLoadable(recoilState), useSetRecoilState(recoilState)];

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -37,6 +37,7 @@ const differenceSets = require('recoil-shared/util/Recoil_differenceSets');
 const err = require('recoil-shared/util/Recoil_err');
 const expectationViolation = require('recoil-shared/util/Recoil_expectationViolation');
 const gkx = require('recoil-shared/util/Recoil_gkx');
+const gkx_early_rendering = require('recoil-shared/util/Recoil_gkx_early_rendering');
 const {
   mutableSourceExists,
   useMutableSource,
@@ -229,7 +230,7 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
       return getRecoilValueAsLoadable(
         storeRef.current,
         recoilValue,
-        gkx('recoil_early_rendering_2021')
+        gkx_early_rendering()
           ? storeState.nextTree ?? storeState.currentTree
           : storeState.currentTree,
       );
@@ -288,7 +289,7 @@ function useRecoilValueLoadable_MUTABLESOURCE<T>(
   const getLoadable = useCallback(() => {
     const store = storeRef.current;
     const storeState = store.getState();
-    const treeState = gkx('recoil_early_rendering_2021')
+    const treeState = gkx_early_rendering()
       ? storeState.nextTree ?? storeState.currentTree
       : storeState.currentTree;
     return getRecoilValueAsLoadable(store, recoilValue, treeState);

--- a/packages/recoil/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useTransaction-test.js
@@ -91,6 +91,72 @@ describe('Atoms', () => {
 });
 
 describe('Atom Effects', () => {
+  testRecoil(
+    'Atom effects are run when first get from a transaction',
+    async () => {
+      let numTimesEffectInit = 0;
+
+      const atomWithEffect = atom({
+        key: 'atom effect first get transaction',
+        default: 'DEFAULT',
+        effects_UNSTABLE: [
+          ({trigger}) => {
+            expect(trigger).toEqual('get');
+            numTimesEffectInit++;
+          },
+        ],
+      });
+
+      let getAtomWithTransaction;
+      const Component = () => {
+        getAtomWithTransaction = useRecoilTransaction(({get}) => () => {
+          expect(get(atomWithEffect)).toEqual('DEFAULT');
+        });
+        return null;
+      };
+
+      renderElements(<Component />);
+
+      act(() => getAtomWithTransaction());
+
+      expect(numTimesEffectInit).toBe(1);
+    },
+  );
+
+  // TODO Unable to test setting from a transaction as Jest complains about
+  // updates not wrapped in act(...)...
+  // testRecoil(
+  //   'Atom effects are run when first set with a transaction',
+  //   async () => {
+  //     let numTimesEffectInit = 0;
+
+  //     const atomWithEffect = atom({
+  //       key: 'atom effect first set transaction',
+  //       default: 'DEFAULT',
+  //       effects_UNSTABLE: [
+  //         ({trigger}) => {
+  //           expect(trigger).toEqual('set');
+  //           numTimesEffectInit++;
+  //         },
+  //       ],
+  //     });
+
+  //     let setAtomWithTransaction;
+  //     const Component = () => {
+  //       setAtomWithTransaction = useRecoilTransaction(({set}) => () => {
+  //         set(atomWithEffect, 'SET');
+  //       });
+  //       return null;
+  //     };
+
+  //     renderElements(<Component />);
+
+  //     act(() => setAtomWithTransaction());
+
+  //     expect(numTimesEffectInit).toBe(1);
+  //   },
+  // );
+
   testRecoil('Atom effects can initialize for a transaction', async () => {
     let numTimesEffectInit = 0;
     const atomWithEffect = atom({

--- a/packages/recoil/hooks/__tests__/Recoil_useTransition-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useTransition-test.js
@@ -12,13 +12,14 @@
 'use strict';
 
 const {
-  IS_INTERNAL,
   getRecoilTestFn,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
+const {
+  mutableSourceExists,
+} = require('recoil-shared/util/Recoil_mutableSource');
 
 let React,
   act,
-  gkx,
   useTransition,
   useRecoilState,
   atom,
@@ -29,25 +30,22 @@ const testRecoil = getRecoilTestFn(() => {
   React = require('react');
   ({useTransition} = React);
   ({act} = require('ReactTestUtils'));
-  gkx = require('recoil-shared/util/Recoil_gkx');
   ({useRecoilState, atom} = require('../../Recoil_index'));
   ({
     renderElementsInConcurrentRoot,
     flushPromisesAndTimers,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
-
-  const initialGKValue = gkx('recoil_early_rendering_2021');
-  gkx.setPass('recoil_early_rendering_2021');
-  return () => {
-    initialGKValue || gkx.setFail('recoil_early_rendering_2021');
-  };
 });
 
 let nextID = 0;
 
-testRecoil('Works with useTransition', async () => {
-  if (!IS_INTERNAL) {
-    return; // FIXME: these tests do not work in OSS, possibly due to differing ReactDOM in OSS and internal
+testRecoil('Works with useTransition', async ({gks}) => {
+  // recoil_early_rendering_2021 is currently coupled with recoil_suppress_rerender_in_callback
+  if (!gks.includes('recoil_early_rendering_2021')) {
+    return;
+  }
+  if (!mutableSourceExists()) {
+    return;
   }
 
   const indexAtom = atom({

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -111,7 +111,7 @@ function createLegacyReactRoot(container, contents) {
 
 function createConcurrentReactRoot(container, contents) {
   // @fb-only: ReactDOMComet.createRoot(container).render(contents);
-  // @oss-only ReactDOMComet.unstable_createRoot(container).render(contents);
+  ReactDOM.unstable_createRoot(container).render(contents); // @oss-only
 }
 
 function renderElementsInternal(
@@ -333,14 +333,15 @@ const testGKs =
 
 // TODO Remove the recoil_suppress_rerender_in_callback GK checks
 const WWW_GKS_TO_TEST = [
+  ['recoil_hamt_2020'],
   [
     'recoil_suppress_rerender_in_callback',
-    'recoil_early_rendering_2021',
+    'recoil_early_rendering_2021', // coupled with recoil_suppress_rerender_in_callback in Recoil_gkx_early_rendering.js
     'recoil_hamt_2020',
   ],
   [
     'recoil_suppress_rerender_in_callback',
-    'recoil_early_rendering_2021',
+    'recoil_early_rendering_2021', // coupled with recoil_suppress_rerender_in_callback in Recoil_gkx_early_rendering.js
     'recoil_hamt_2020',
     'recoil_memory_managament_2020',
     'recoil_release_on_cascading_update_killswitch_2021',
@@ -351,13 +352,15 @@ const WWW_GKS_TO_TEST = [
  * GK combinations to exclude in OSS, presumably because these combinations pass
  * in FB internally but not in OSS. Ideally this array would be empty.
  */
-const OSS_GK_COMBINATION_EXCLUSIONS = [];
+const OSS_GK_COMBINATION_EXCLUSIONS = [['recoil_hamt_2020']];
 
 // eslint-disable-next-line no-unused-vars
 const OSS_GKS_TO_TEST = WWW_GKS_TO_TEST.filter(
   gkCombination =>
-    !OSS_GK_COMBINATION_EXCLUSIONS.some(exclusion =>
-      exclusion.every(gk => gkCombination.includes(gk)),
+    !OSS_GK_COMBINATION_EXCLUSIONS.some(
+      exclusion =>
+        exclusion.every(gk => gkCombination.includes(gk)) &&
+        gkCombination.every(gk => exclusion.includes(gk)),
     ),
 );
 

--- a/packages/shared/util/Recoil_gkx.js
+++ b/packages/shared/util/Recoil_gkx.js
@@ -10,28 +10,24 @@
  */
 'use strict';
 
-const {mutableSourceExists} = require('./Recoil_mutableSource');
-
 const gks = new Map()
   .set('recoil_hamt_2020', true)
   .set('recoil_memory_managament_2020', true)
   .set('recoil_suppress_rerender_in_callback', true);
 
-function Recoil_gkx(gk: string): boolean {
-  if (gk === 'recoil_early_rendering_2021' && !mutableSourceExists()) {
-    return false;
-  }
+// NOTE: use gkx_early_rendering() instead for that GK!
+function Recoil_gkx_OSS(gk: string): boolean {
   return gks.get(gk) ?? false;
 }
 
-Recoil_gkx.setPass = (gk: string): void => {
+Recoil_gkx_OSS.setPass = (gk: string): void => {
   gks.set(gk, true);
 };
 
-Recoil_gkx.setFail = (gk: string): void => {
+Recoil_gkx_OSS.setFail = (gk: string): void => {
   gks.set(gk, false);
 };
 
-module.exports = Recoil_gkx; // @oss-only
+module.exports = Recoil_gkx_OSS; // @oss-only
 
 // @fb-only: module.exports = require('gkx');

--- a/packages/shared/util/Recoil_gkx_early_rendering.js
+++ b/packages/shared/util/Recoil_gkx_early_rendering.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict
+ * @format
+ */
+'use strict';
+
+const gkx = require('./Recoil_gkx');
+const {mutableSourceExists} = require('./Recoil_mutableSource');
+
+/**
+ * recoil_early_rendering_2021 only works with useMutableSource()
+ * Also couple it with recoil_suppress_rerender_in_callback as it resolves
+ * some corner cases with that feature.
+ */
+function gkx_early_rendering(): boolean {
+  // recoil_early_rendering_2021 only works with useMutableSource()
+  if (!mutableSourceExists()) {
+    return false;
+  }
+
+  return (
+    gkx('recoil_suppress_rerender_in_callback') ||
+    gkx('recoil_early_rendering_2021')
+  );
+}
+
+module.exports = gkx_early_rendering;


### PR DESCRIPTION
Summary: Couple the `recoil_early_rendering_2021` GK to always follow the value of the `recoil_suppress_rerender_in_callback` GK.  This is because we found them each to resolve corner cases for the other.

Differential Revision: D32826772

