### PR TITLE
Test consistent picture of Recoil and React state changes in the same batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 - `RecoilLoadable.all()` and `RecoilLoadable.of()` accept either literal values, async Promises, or Loadables.
 - Selector `getCallback()` callbacks can now mutate, refresh, and transact Recoil state in addition to reading it.
+- Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.
 
 ### Pending
 - Memory management
 - useTransition() compatibility
-- Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.
 
 ## 0.5.2 (2021-11-07)
 

--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -14,6 +14,7 @@ const React = require('react');
 const gkx = require('recoil-shared/util/Recoil_gkx');
 
 export opaque type MutableSource = {};
+
 const createMutableSource: <StoreState, Version>(
   {current: StoreState},
   () => Version,

--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -47,7 +47,10 @@ type ReactMode =
 
 /**
  * mode: The React API and approach to use for syncing state with React
- * early: Should we render the ongoing mutations as part of the current rendering
+ * early: Re-renders from Recoil updates occur:
+ *    1) earlier
+ *    2) in sync with React updates in the same batch
+ *    3) before transaction observers instead of after.
  * concurrent: Is the current mode compatible with Concurrent Mode (i.e. useTransition())
  */
 function reactMode(): {mode: ReactMode, early: boolean, concurrent: boolean} {

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -177,7 +177,7 @@ function sendEndOfBatchNotifications(store: Store) {
       subscription(store);
     }
 
-    if (!reactMode().early || storeState.suspendedComponentResolvers.size) {
+    if (!reactMode().early || storeState.suspendedComponentResolvers.size > 0) {
       // Notifying components is needed to wake from suspense, even when using
       // early rendering.
       notifyComponents(store, storeState, treeState);

--- a/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -1200,7 +1200,13 @@ testRecoil(
 
 testRecoil(
   'Can set atom during post-atom-setting effect regardless of effect order',
-  async () => {
+  async ({concurrentMode}) => {
+    // TODO Test doesn't work in ConcurrentMode.  Haven't investigated why,
+    // but it seems fragile with the Queue for enforcing order.
+    if (concurrentMode) {
+      return;
+    }
+
     function testWithOrder(order) {
       const anAtom = counterAtom();
 

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -377,7 +377,8 @@ testRecoil('Consistent callback function', () => {
 
 testRecoil(
   'Atom effects are initialized twice if first seen on snapshot and then on root store',
-  () => {
+  ({strictMode}) => {
+    const sm = strictMode ? 1 : 0;
     let numTimesEffectInit = 0;
 
     const atomWithEffect = atom({
@@ -390,6 +391,9 @@ testRecoil(
       ],
     });
 
+    // StrictMode will render the component twice
+    let renderCount = 0;
+
     const Component = () => {
       const readAtomFromSnapshot = useRecoilCallback(({snapshot}) => () => {
         snapshot.getLoadable(atomWithEffect);
@@ -397,16 +401,18 @@ testRecoil(
 
       readAtomFromSnapshot(); // first initialization
 
-      expect(numTimesEffectInit).toBe(1);
+      expect(numTimesEffectInit).toBe(1 + sm * renderCount);
 
       useRecoilValue(atomWithEffect); // second initialization
 
       expect(numTimesEffectInit).toBe(2);
 
+      renderCount++;
       return null;
     };
 
-    renderElements(<Component />);
+    const c = renderElements(<Component />);
+    expect(c.textContent).toBe(''); // Confirm no failures from rendering
 
     expect(numTimesEffectInit).toBe(2);
   },
@@ -447,7 +453,8 @@ testRecoil(
       return null;
     };
 
-    renderElements(<Component />);
+    const c = renderElements(<Component />);
+    expect(c.textContent).toBe(''); // Confirm no failures from rendering
 
     expect(numTimesEffectInit).toBe(1);
   },

--- a/packages/recoil/hooks/__tests__/Recoil_useTransition-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useTransition-test.js
@@ -20,7 +20,7 @@ let React,
   useTransition,
   useRecoilState,
   atom,
-  renderElementsInConcurrentRoot,
+  renderElements,
   reactMode,
   flushPromisesAndTimers;
 
@@ -30,7 +30,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({act} = require('ReactTestUtils'));
   ({useRecoilState, atom} = require('../../Recoil_index'));
   ({
-    renderElementsInConcurrentRoot,
+    renderElements,
     flushPromisesAndTimers,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
   ({reactMode} = require('../../core/Recoil_ReactMode'));
@@ -38,8 +38,8 @@ const testRecoil = getRecoilTestFn(() => {
 
 let nextID = 0;
 
-testRecoil('Works with useTransition', async () => {
-  if (!reactMode().concurrent) {
+testRecoil('Works with useTransition', async ({concurrentMode}) => {
+  if (!reactMode().concurrent || !concurrentMode) {
     return;
   }
 
@@ -112,7 +112,7 @@ testRecoil('Works with useTransition', async () => {
     );
   }
 
-  const c = renderElementsInConcurrentRoot(<Main />);
+  const c = renderElements(<Main />);
 
   // Initial load:
   expect(c.textContent).toEqual('Index: 0 - Suspended');

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -1086,13 +1086,13 @@ describe('Effects', () => {
     });
 
     testRecoil('async get other atoms', async () => {
-      let initTest1 = new Promise(() => {});
-      let initTest2 = new Promise(() => {});
-      let initTest3 = new Promise(() => {});
-      let initTest4 = new Promise(() => {});
-      let initTest5 = new Promise(() => {});
-      let initTest6 = new Promise(() => {});
-      let setTest = new Promise(() => {});
+      let initTest1 = Promise.reject('test error');
+      let initTest2 = Promise.reject('test error');
+      let initTest3 = Promise.reject('test error');
+      let initTest4 = Promise.reject('test error');
+      let initTest5 = Promise.reject('test error');
+      let initTest6 = Promise.reject('test error');
+      let setTest = Promise.reject('test error');
 
       const myAtom = atom({
         key: 'atom effect - async get',
@@ -1115,7 +1115,7 @@ describe('Effects', () => {
             expect(getInfo_UNSTABLE(node).isSet).toBe(true);
             expect(getInfo_UNSTABLE(node).loadable?.contents).toBe('INIT');
           },
-          // Test we can asynchronouse get "current" values of both self and other atoms
+          // Test we can asynchronously get "current" values of both self and other atoms
           // This will be executed when myAtom is set, but checks both atoms.
           ({onSet, getLoadable, getPromise, getInfo_UNSTABLE}) => {
             onSet(x => {

--- a/packages/shared/__test_utils__/Recoil_ReactRenderModes.js
+++ b/packages/shared/__test_utils__/Recoil_ReactRenderModes.js
@@ -18,7 +18,17 @@ const setStrictMode = (enableStrictMode: boolean): void => {
   strictMode = enableStrictMode;
 };
 
+let concurrentMode: boolean = false;
+
+const isConcurrentModeEnabled = (): boolean => concurrentMode;
+
+const setConcurrentMode = (enableConcurrentMode: boolean): void => {
+  concurrentMode = enableConcurrentMode;
+};
+
 module.exports = {
   isStrictModeEnabled,
   setStrictMode,
+  isConcurrentModeEnabled,
+  setConcurrentMode,
 };

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -382,14 +382,14 @@ const testGKs =
 
 const WWW_GKS_TO_TEST = [
   // OSS for React <18:
-  ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'],
+  ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering
   // Current internal default:
   ['recoil_hamt_2020', 'recoil_mutable_source'],
   // Internal with suppress, early rendering, and useTransition() support:
   [
     'recoil_hamt_2020',
     'recoil_mutable_source',
-    'recoil_suppress_rerender_in_callback',
+    'recoil_suppress_rerender_in_callback', // Also enables early rendering
   ],
   // OSS for React 18, test internally:
   [


### PR DESCRIPTION
Summary:
Add unit test that confirms when both Recoil and React state changes are made in the same batch that component renders always see a consistent picture of both state changes.

This was enabled in OSS in D32943200, so update the CHANGELOG.

The default "Mutable Source" mode still doesn't support this without the suppress rerender optimization.

Differential Revision: D32945826

