### PR TITLE
Use DefaultValue vs undefined for reading missing item

### DIFF
--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -42,7 +42,6 @@ export type WriteItems = WriteInterface => void;
 export type ResetItem = ItemKey => void;
 
 export type ReadItem = ItemKey =>
-  | void
   | DefaultValue
   | Promise<DefaultValue | mixed>
   | Loadable<DefaultValue | mixed>
@@ -232,7 +231,7 @@ function readAtomItems<T>(
   } catch (error) {
     return RecoilLoadable.error(error);
   }
-  return value === undefined || value instanceof DefaultValue
+  return value instanceof DefaultValue
     ? null
     : validateLoadable(value, options);
 }
@@ -403,10 +402,15 @@ function useRecoilSync({
               if (loadable != null) {
                 switch (loadable.state) {
                   case 'hasValue':
-                    atomRegistration.pendingUpdate = {
-                      value: loadable.contents,
-                    };
-                    set(atomRegistration.atom, loadable.contents);
+                    if (loadable.contents instanceof DefaultValue) {
+                      atomRegistration.pendingUpdate = {value: DEFAULT_VALUE};
+                      reset(atomRegistration.atom);
+                    } else {
+                      atomRegistration.pendingUpdate = {
+                        value: loadable.contents,
+                      };
+                      set(atomRegistration.atom, loadable.contents);
+                    }
                     break;
                   case 'hasError':
                     if (options.actionOnFailure_UNSTABLE === 'errorState') {

--- a/packages/recoil-sync/RecoilSync_URL.js
+++ b/packages/recoil-sync/RecoilSync_URL.js
@@ -233,7 +233,9 @@ function useRecoilURLSync({
   );
 
   const read: ReadItem = useCallback(itemKey => {
-    return cachedState.current?.get(itemKey);
+    return cachedState.current?.has(itemKey)
+      ? cachedState.current?.get(itemKey)
+      : new DefaultValue();
   }, []);
 
   const listen = useCallback(

--- a/packages/recoil-sync/RecoilSync_index.js
+++ b/packages/recoil-sync/RecoilSync_index.js
@@ -17,6 +17,7 @@ import type {
   ReadAtomInterface,
   ReadItem,
   RecoilSyncOptions,
+  ResetItem,
   StoreKey,
   SyncEffectOptions,
   WriteAtom,
@@ -60,6 +61,7 @@ export type {
   ReadAtom,
   WriteAtomInterface,
   WriteAtom,
+  ResetItem,
   // URL Synchronization
   RecoilURLSyncOptions,
   RecoilURLSyncJSONOptions,

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -69,7 +69,14 @@ test('Many items to one atom', async () => {
   const manyToOneSyncEffct = () =>
     syncEffect({
       refine: dict(nullable(number())),
-      read: ({read}) => ({foo: read('foo'), bar: read('bar')}),
+      read: ({read}) => {
+        const foo = read('foo');
+        const bar = read('bar');
+        return {
+          foo: foo instanceof DefaultValue ? undefined : foo,
+          bar: bar instanceof DefaultValue ? undefined : bar,
+        };
+      },
       write: ({write, reset}, newValue) => {
         if (newValue instanceof DefaultValue) {
           reset('foo');
@@ -121,7 +128,10 @@ test('One item to multiple atoms', async () => {
   const oneToManySyncEffect = (prop: string) =>
     syncEffect({
       refine: nullable(number()),
-      read: ({read}) => input(read('compound'))[prop],
+      read: ({read}) => {
+        const compound = input(read('compound'));
+        return prop in compound ? compound[prop] : new DefaultValue();
+      },
       write: ({write, read}, newValue) => {
         const compound = {...input(read('compound'))};
         if (newValue instanceof DefaultValue) {
@@ -187,7 +197,10 @@ test('One item to atom family', async () => {
   const oneToFamilyEffect = (prop: string) =>
     syncEffect({
       refine: nullable(number()),
-      read: ({read}) => input(read('compound'))[prop],
+      read: ({read}) => {
+        const compound = input(read('compound'));
+        return prop in compound ? compound[prop] : new DefaultValue();
+      },
       write: ({write, read}, newValue) => {
         const compound = {...input(read('compound'))};
         if (newValue instanceof DefaultValue) {

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -221,7 +221,7 @@ describe('URL Transit Encode', () => {
       [atomWithFallback],
       '"FALLBACK"',
       '/path/page.html?foo=bar#anchor',
-      '/path/page.html?foo=bar&param=%5B%22%5E+%22%2C%22withFallback%22%2C%5B%22%7E%23__DV%22%2C0%5D%5D#anchor',
+      '/path/page.html?foo=bar&param=%5B%22%5E+%22%5D#anchor',
     ));
   test('Query Params - fallback', async () =>
     testTransit(
@@ -229,7 +229,7 @@ describe('URL Transit Encode', () => {
       [atomWithFallback],
       '"FALLBACK"',
       '/path/page.html#anchor',
-      '/path/page.html?withFallback=%5B%22%7E%23__DV%22%2C0%5D#anchor',
+      '/path/page.html#anchor',
     ));
 });
 


### PR DESCRIPTION
Summary:
Treat `undefined` as a literal value when reading an item instead of special semantic meaning that the item is missing.  This makes the API more consistent and easier to handle `undefined` as a value.  To specify that an item is missing and skip initialization a `new DefaultValue()` must be used, which could be a bit more cumbersome.  So, tradeoffs...

Review the changes in the tests for comparing the API tradeoffs.

Differential Revision: D33005716

