### PR TITLE
Allow selector callbacks to mutate state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `storeID` added to atom effects interface (#1414)
 - `<RecoilRoot>` will only call `initializeState()` during initial render. (#1372)
 - `RecoilLoadable.all()` and `RecoilLoadable.of()` accept either literal values, async Promises, or Loadables.
+- Selector `getCallback()` callbacks can now mutate, refresh, and transact Recoil state in addition to reading it.
 
 ### Pending
 - Memory management

--- a/packages/recoil/Recoil_index.js
+++ b/packages/recoil/Recoil_index.js
@@ -62,7 +62,7 @@ const {
 } = require('./hooks/Recoil_SnapshotHooks');
 const useGetRecoilValueInfo = require('./hooks/Recoil_useGetRecoilValueInfo');
 const useRecoilBridgeAcrossReactRoots = require('./hooks/Recoil_useRecoilBridgeAcrossReactRoots');
-const useRecoilCallback = require('./hooks/Recoil_useRecoilCallback');
+const {useRecoilCallback} = require('./hooks/Recoil_useRecoilCallback');
 const useRecoilRefresher = require('./hooks/Recoil_useRecoilRefresher');
 const useRecoilTransaction = require('./hooks/Recoil_useRecoilTransaction');
 const useRetain = require('./hooks/Recoil_useRetain');

--- a/packages/recoil/core/__tests__/Recoil_Retention-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Retention-test.js
@@ -40,7 +40,7 @@ const testRecoil = getRecoilTestFn(() => {
     useRecoilValue,
     useRecoilValueLoadable,
   } = require('../../hooks/Recoil_Hooks'));
-  useRecoilCallback = require('../../hooks/Recoil_useRecoilCallback');
+  ({useRecoilCallback} = require('../../hooks/Recoil_useRecoilCallback'));
   useRetain = require('../../hooks/Recoil_useRetain');
   atom = require('../../recoil_values/Recoil_atom');
   selector = require('../../recoil_values/Recoil_selector');

--- a/packages/recoil/hooks/Recoil_useRecoilCallback.js
+++ b/packages/recoil/hooks/Recoil_useRecoilCallback.js
@@ -12,6 +12,7 @@
 
 import type {TransactionInterface} from '../core/Recoil_AtomicUpdates';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
+import type {Store} from '../core/Recoil_State';
 
 const {atomicUpdater} = require('../core/Recoil_AtomicUpdates');
 const {batchUpdates} = require('../core/Recoil_Batching');
@@ -22,7 +23,7 @@ const {
   setRecoilValue,
 } = require('../core/Recoil_RecoilValueInterface');
 const {Snapshot, cloneSnapshot} = require('../core/Recoil_Snapshot');
-const {useGotoRecoilSnapshot} = require('./Recoil_SnapshotHooks');
+const {gotoSnapshot} = require('./Recoil_SnapshotHooks');
 const {useCallback} = require('react');
 const err = require('recoil-shared/util/Recoil_err');
 const invariant = require('recoil-shared/util/Recoil_invariant');
@@ -39,69 +40,64 @@ export type RecoilCallbackInterface = $ReadOnly<{
 class Sentinel {}
 const SENTINEL = new Sentinel();
 
+function recoilCallback<
+  Args: $ReadOnlyArray<mixed>,
+  Return,
+  ExtraInterface: {...},
+>(
+  store: Store,
+  fn: ({...ExtraInterface, ...RecoilCallbackInterface}) => (...Args) => Return,
+  args: Args,
+  extraInterface?: ExtraInterface,
+): Return {
+  let ret = SENTINEL;
+  batchUpdates(() => {
+    const errMsg =
+      'useRecoilCallback expects a function that returns a function: ' +
+      'it accepts a function of the type (RecoilInterface) => T = R ' +
+      'and returns a callback function T => R, where RecoilInterface is an ' +
+      'object {snapshot, set, ...} and T and R are the argument and return ' +
+      'types of the callback you want to create.  Please see the docs ' +
+      'at recoiljs.org for details.';
+    if (typeof fn !== 'function') {
+      throw err(errMsg);
+    }
+    // flowlint-next-line unclear-type:off
+    const cb = (fn: any)({
+      ...(extraInterface ?? {}),
+      set: (node, newValue) => setRecoilValue(store, node, newValue),
+      reset: node => setRecoilValue(store, node, DEFAULT_VALUE),
+      refresh: node => refreshRecoilValue(store, node),
+      // TODO Good potential optimization to compute this lazily
+      snapshot: cloneSnapshot(store),
+      gotoSnapshot: snapshot => gotoSnapshot(store, snapshot),
+      transact_UNSTABLE: transaction => atomicUpdater(store)(transaction),
+    });
+    if (typeof cb !== 'function') {
+      throw err(errMsg);
+    }
+    ret = cb(...args);
+  });
+  invariant(
+    !(ret instanceof Sentinel),
+    'batchUpdates should return immediately',
+  );
+  return (ret: Return);
+}
+
 function useRecoilCallback<Args: $ReadOnlyArray<mixed>, Return>(
   fn: RecoilCallbackInterface => (...Args) => Return,
   deps?: $ReadOnlyArray<mixed>,
 ): (...Args) => Return {
   const storeRef = useStoreRef();
-  const gotoSnapshot = useGotoRecoilSnapshot();
 
   return useCallback(
-    (...args): Return => {
-      function set<T>(
-        recoilState: RecoilState<T>,
-        newValueOrUpdater: (T => T) | T,
-      ) {
-        setRecoilValue(storeRef.current, recoilState, newValueOrUpdater);
-      }
-
-      function reset<T>(recoilState: RecoilState<T>) {
-        setRecoilValue(storeRef.current, recoilState, DEFAULT_VALUE);
-      }
-
-      function refresh<T>(recoilValue: RecoilValue<T>) {
-        refreshRecoilValue(storeRef.current, recoilValue);
-      }
-
-      // Use currentTree for the snapshot to show the currently committed state
-      const snapshot = cloneSnapshot(storeRef.current); // FIXME massive gains from doing this lazily
-
-      const atomicUpdate = atomicUpdater(storeRef.current);
-
-      let ret = SENTINEL;
-      batchUpdates(() => {
-        const errMsg =
-          'useRecoilCallback expects a function that returns a function: ' +
-          'it accepts a function of the type (RecoilInterface) => T = R ' +
-          'and returns a callback function T => R, where RecoilInterface is an ' +
-          'object {snapshot, set, ...} and T and R are the argument and return ' +
-          'types of the callback you want to create.  Please see the docs ' +
-          'at recoiljs.org for details.';
-        if (typeof fn !== 'function') {
-          throw err(errMsg);
-        }
-        // flowlint-next-line unclear-type:off
-        const cb = (fn: any)({
-          set,
-          reset,
-          refresh,
-          snapshot,
-          gotoSnapshot,
-          transact_UNSTABLE: atomicUpdate,
-        });
-        if (typeof cb !== 'function') {
-          throw err(errMsg);
-        }
-        ret = cb(...args);
-      });
-      invariant(
-        !(ret instanceof Sentinel),
-        'batchUpdates should return immediately',
-      );
-      return (ret: Return);
+    // $FlowIssue[incompatible-call]
+    (...args: Args): Return => {
+      return recoilCallback(storeRef.current, fn, args);
     },
     deps != null ? [...deps, storeRef] : undefined, // eslint-disable-line fb-www/react-hooks-deps
   );
 }
 
-module.exports = useRecoilCallback;
+module.exports = {recoilCallback, useRecoilCallback};

--- a/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -38,7 +38,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({freshSnapshot} = require('../../core/Recoil_Snapshot'));
   ({useRecoilValue} = require('../../hooks/Recoil_Hooks'));
   ({useGotoRecoilSnapshot} = require('../../hooks/Recoil_SnapshotHooks'));
-  useRecoilCallback = require('../../hooks/Recoil_useRecoilCallback');
+  ({useRecoilCallback} = require('../../hooks/Recoil_useRecoilCallback'));
   atom = require('../../recoil_values/Recoil_atom');
   constSelector = require('../../recoil_values/Recoil_constSelector');
   selector = require('../../recoil_values/Recoil_selector');

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -60,7 +60,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     useRecoilTransactionObserver,
   } = require('../../hooks/Recoil_SnapshotHooks'));
-  useRecoilCallback = require('../../hooks/Recoil_useRecoilCallback');
+  ({useRecoilCallback} = require('../../hooks/Recoil_useRecoilCallback'));
   ({
     ReadsAtom,
     componentThatReadsAndWritesAtom,

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -63,7 +63,7 @@ const testRecoil = getRecoilTestFn(() => {
     useSetRecoilState,
     useResetRecoilState,
   } = require('../../hooks/Recoil_Hooks'));
-  useRecoilCallback = require('../../hooks/Recoil_useRecoilCallback');
+  ({useRecoilCallback} = require('../../hooks/Recoil_useRecoilCallback'));
   constSelector = require('../Recoil_constSelector');
   errorSelector = require('../Recoil_errorSelector');
   nullthrows = require('recoil-shared/util/Recoil_nullthrows');
@@ -1622,6 +1622,140 @@ testRecoil(
     expect(valLoadable.valueMaybe()).toBe(10);
   },
 );
+
+describe('getCallback', () => {
+  testRecoil('snapshot', async () => {
+    const otherSelector = constSelector('VALUE');
+    const mySelector = selector({
+      key: 'selector getCallback snapshot',
+      get: ({getCallback}) =>
+        getCallback(({snapshot}) => param => ({
+          param,
+          loadable: snapshot.getLoadable(otherSelector),
+          promise: snapshot.getPromise(otherSelector),
+        })),
+    });
+
+    expect(getValue(mySelector)(123).param).toBe(123);
+    expect(getValue(mySelector)(123).loadable.getValue()).toBe('VALUE');
+    await expect(getValue(mySelector)(123).promise).resolves.toBe('VALUE');
+  });
+
+  testRecoil('set', () => {
+    const myAtom = atom({
+      key: 'selector getCallback set atom',
+      default: 'DEFAULT',
+    });
+    const setSelector = selector({
+      key: 'selector getCallback set',
+      get: ({getCallback}) =>
+        getCallback(({set}) => param => {
+          set(myAtom, param);
+        }),
+    });
+    const resetSelector = selector({
+      key: 'selector getCallback reset',
+      get: ({getCallback}) =>
+        getCallback(({reset}) => () => {
+          reset(myAtom);
+        }),
+    });
+
+    expect(getValue(myAtom)).toBe('DEFAULT');
+    getValue(setSelector)('SET');
+    expect(getValue(myAtom)).toBe('SET');
+
+    getValue(resetSelector)();
+    expect(getValue(myAtom)).toBe('DEFAULT');
+  });
+
+  testRecoil('transaction', () => {
+    const myAtom = atom({
+      key: 'selector getCallback transact atom',
+      default: 'DEFAULT',
+    });
+    const setSelector = selector({
+      key: 'selector getCallback transact set',
+      get: ({getCallback}) =>
+        getCallback(({transact_UNSTABLE}) => param => {
+          transact_UNSTABLE(({set, get}) => {
+            expect(get(myAtom)).toBe('DEFAULT');
+            set(myAtom, 'TMP');
+            expect(get(myAtom)).toBe('TMP');
+            set(myAtom, param);
+          });
+        }),
+    });
+    const resetSelector = selector({
+      key: 'selector getCallback transact',
+      get: ({getCallback}) =>
+        getCallback(({transact_UNSTABLE}) => () => {
+          transact_UNSTABLE(({reset}) => reset(myAtom));
+        }),
+    });
+
+    expect(getValue(myAtom)).toBe('DEFAULT');
+    getValue(setSelector)('SET');
+    expect(getValue(myAtom)).toBe('SET');
+
+    getValue(resetSelector)();
+    expect(getValue(myAtom)).toBe('DEFAULT');
+  });
+
+  testRecoil('node', () => {
+    const mySelector = selector({
+      key: 'selector getCallback node',
+      get: ({getCallback}) =>
+        getCallback(({node, snapshot}) => param => ({
+          param,
+          loadable: snapshot.getLoadable(node),
+          promise: snapshot.getPromise(node),
+        })),
+    });
+
+    expect(getValue(mySelector)(123).param).toBe(123);
+    expect(getValue(mySelector)(123).loadable.getValue()(456).param).toBe(456);
+  });
+
+  testRecoil('refresh', async () => {
+    let externalValue = 0;
+    const mySelector = selector({
+      key: 'selector getCallback node refresh',
+      get: ({getCallback}) => {
+        const cachedExternalValue = externalValue;
+        return getCallback(({node, refresh}) => () => ({
+          cached: cachedExternalValue,
+          current: externalValue,
+          refresh: () => refresh(node),
+        }));
+      },
+    });
+
+    expect(getValue(mySelector)().current).toBe(0);
+    expect(getValue(mySelector)().cached).toBe(0);
+
+    externalValue = 1;
+    expect(getValue(mySelector)().current).toBe(1);
+    expect(getValue(mySelector)().cached).toBe(0);
+
+    getValue(mySelector)().refresh();
+    expect(getValue(mySelector)().current).toBe(1);
+    expect(getValue(mySelector)().cached).toBe(1);
+  });
+
+  testRecoil('guard against calling during selector evaluation', async () => {
+    const mySelector = selector({
+      key: 'selector getCallback guard',
+      get: ({getCallback}) => {
+        const callback = getCallback(() => () => {});
+        expect(() => callback()).toThrow();
+        return 'INVALID';
+      },
+    });
+
+    expect(getValue(mySelector)).toBe('INVALID');
+  });
+});
 
 testRecoil('Selector values are frozen', async () => {
   const devStatus = window.__DEV__;

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -114,12 +114,31 @@
  /**
   * Creates an atom, which represents a piece of writeable state
   */
-export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
+ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
+
+ export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
+ export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
+ export type Resetter = () => void;
+ export interface TransactionInterface_UNSTABLE {
+  get<T>(a: RecoilValue<T>): T;
+  set<T>(s: RecoilState<T>, u: ((currVal: T) => T) | T): void;
+  reset(s: RecoilState<any>): void;
+ }
+ export interface CallbackInterface {
+  set: <T>(recoilVal: RecoilState<T>, valOrUpdater: ((currVal: T) => T) | T) => void;
+  reset: (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  refresh: (recoilValue: RecoilValue<any>) => void;
+  snapshot: Snapshot;
+  gotoSnapshot: (snapshot: Snapshot) => void;
+  transact_UNSTABLE: (cb: (i: TransactionInterface_UNSTABLE) => void) => void;
+ }
 
  // selector.d.ts
- export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
+ export interface SelectorCallbackInterface extends CallbackInterface {
+   node: RecoilState<unknown>; // TODO This isn't properly typed
+ }
  export type GetCallback = <Args extends ReadonlyArray<unknown>, Return>(
-  fn: (interface: Readonly<{snapshot: Snapshot}>) => (...args: Args) => Return,
+  fn: (interface: SelectorCallbackInterface) => (...args: Args) => Return,
  ) => (...args: Args) => Return;
 
  export type SetRecoilState = <T>(
@@ -174,21 +193,6 @@ export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
  export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
 
  // hooks.d.ts
- export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
- export type Resetter = () => void;
- export interface TransactionInterface_UNSTABLE {
-  get<T>(a: RecoilValue<T>): T;
-  set<T>(s: RecoilState<T>, u: ((currVal: T) => T) | T): void;
-  reset(s: RecoilState<any>): void;
- }
- export type CallbackInterface = Readonly<{
-  set: <T>(recoilVal: RecoilState<T>, valOrUpdater: ((currVal: T) => T) | T) => void;
-  reset: (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
-  refresh: (recoilValue: RecoilValue<any>) => void;
-  snapshot: Snapshot,
-  gotoSnapshot: (snapshot: Snapshot) => void,
-  transact_UNSTABLE: (cb: (i: TransactionInterface_UNSTABLE) => void) => void;
- }>;
 
  /**
   * Returns the value of an atom or selector (readonly or writeable) and

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -31,6 +31,7 @@
   useRecoilRefresher_UNSTABLE,
   useRecoilStoreID,
 } from 'recoil';
+import { string } from 'refine';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -90,7 +91,17 @@ const writeableSelector = selector({
 const callbackSelector = selector({
   key: 'CallbackSelector',
   get: ({ getCallback }) => {
-    return getCallback(({snapshot}) => () => {
+    return getCallback(({snapshot, set, reset, refresh, transact_UNSTABLE}) => () => {
+      set(myAtom, 5);
+      reset(myAtom);
+      refresh(myAtom);
+
+      transact_UNSTABLE(({get, set, reset}) => {
+        get(myAtom); // $ExpectType number
+        set(myAtom, 5);
+        reset(myAtom);
+      });
+
       const ret = snapshot.getPromise(mySelector1); // $ExpectType Promise<number>
       return ret;
     });
@@ -574,7 +585,7 @@ isRecoilValue(mySelector1);
       ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
         node; // $ExpectType RecoilState<number>
         storeID; // $ExpectType StoreID
-        trigger; // $ExpectType "get" | "set"
+        trigger; // $ExpectType "set" | "get"
 
         setSelf(1);
         setSelf('a'); // $ExpectError
@@ -616,7 +627,7 @@ isRecoilValue(mySelector1);
 
         node; // $ExpectType RecoilState<number>
         storeID; // $ExpectType StoreID
-        trigger; // $ExpectType "get" | "set"
+        trigger; // $ExpectType "set" | "get"
 
         setSelf(1);
         setSelf('a'); // $ExpectError


### PR DESCRIPTION
Allow callbacks generated from selectors to mutate, refresh, and transact Recoil state in addition to reading snapshots.  The creates feature parity between callbacks generated from `useRecoilCallback()` and `getCallback()` from a selector.

This feature allows a selector to return an object or function which contains a callback that can mutate state.

# Example
```jsx
const menuItemState = selector({
  key: 'MenuItem',
  get: ({get, getCallback}) => {
    const onReadClick = getCallback(({snapshot}) => async () => {
      const itemDetails = await snapshot.getPromise(myItemDetailsState);
      alert(itemDetails);
    });
    const onWriteClick = getCallback(({set}) => () => {
      set(myItemState, x => ({...x, do something...});
    });
    return {
      label: get(myItemState).label,
      onReadClick,
      onWriteClick,
    };
  },
});
```

# Example with query refresh
```jsx
const myQuery = selector({
  key: 'MyQuery',
  get: ({getCallback}) => {
    try {
      return fetch(url);
    } catch (error) {
      error.retry = getCallback(({refresh, node}) => () => refresh(node));
      throw error;
    }
  },
});
```

Update TypeScript, though it's not fully parameterized the `node` option which was leading to strange TypeScript gaps.

Differential Revision: D33055888

