### PR TITLE
Lazily clone snapshots for callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `RecoilLoadable.all()` and `RecoilLoadable.of()` accept either literal values, async Promises, or Loadables.
 - Selector `getCallback()` callbacks can now mutate, refresh, and transact Recoil state in addition to reading it.
 - Re-renders from Recoil updates now occur 1) earlier, 2) in sync with React updates in the same batch, and 3) before transaction observers instead of after.
+- Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
 
 ### Pending
 - Memory management

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -93,8 +93,9 @@ class Snapshot {
         throw err('Cannot subscribe to Snapshots');
       },
     };
-    // Initialize any nodes that are live in the parent store (primarily so that this
-    // snapshot gets counted towards the node's live stores count).
+    // Initialize any nodes that are live in the parent store (primarily so that
+    // this snapshot gets counted towards the node's live stores count).
+    // TODO Optimize this when cloning snapshots for callbacks
     for (const nodeKey of this._store.getState().knownAtoms) {
       initializeNode(this._store, nodeKey);
       updateRetainCount(this._store, nodeKey, 1);

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -463,7 +463,6 @@ function useRecoilValueLoadable_LEGACY<T>(
 ): Loadable<T> {
   const storeRef = useStoreRef();
   const [, forceUpdate] = useState([]);
-
   const componentName = useComponentName();
 
   const getLoadable = useCallback(() => {
@@ -477,6 +476,12 @@ function useRecoilValueLoadable_LEGACY<T>(
       : storeState.currentTree;
     return getRecoilValueAsLoadable(store, recoilValue, treeState);
   }, [storeRef, recoilValue]);
+
+  const loadable = getLoadable();
+  const prevLoadableRef = useRef(loadable);
+  useEffect(() => {
+    prevLoadableRef.current = loadable;
+  });
 
   useEffect(() => {
     const store = storeRef.current;
@@ -532,11 +537,6 @@ function useRecoilValueLoadable_LEGACY<T>(
     return subscription.release;
   }, [componentName, getLoadable, recoilValue, storeRef]);
 
-  const loadable = getLoadable();
-  const prevLoadableRef = useRef(loadable);
-  useEffect(() => {
-    prevLoadableRef.current = loadable;
-  });
   return loadable;
 }
 

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -771,8 +771,12 @@ function selector<T>(
           );
         }
         invariant(recoilValue != null, 'Recoil Value can never be null');
-        // $FlowIssue[unclear-type]
-        return recoilCallback(store, fn, args, {node: (recoilValue: any)});
+        return recoilCallback<Args, Return, {node: RecoilState<T>}>(
+          store,
+          fn,
+          args,
+          {node: (recoilValue: any)}, // flowlint-line unclear-type:off
+        );
       };
     };
 

--- a/packages/shared/util/Recoil_lazyProxy.js
+++ b/packages/shared/util/Recoil_lazyProxy.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+/**
+ * Return a proxy object based on the provided base and factories objects.
+ * The proxy will include all properties of the base object as-is.
+ * The factories object contains callbacks to obtain the values of the properies
+ * for its keys.
+ *
+ * This is useful for providing users an object where some properties may be
+ * lazily computed only on first access.
+ */
+// $FlowIssue[unclear-type]
+function lazyProxy<Base, Factories: {[string]: () => any}>(
+  base: Base,
+  factories: Factories,
+): {...Base, ...$ObjMap<Factories, <F>(() => F) => F>} {
+  // $FlowIssue[incompatible-return]
+  return new Proxy(base, {
+    get: (target, prop) => {
+      if (prop in factories) {
+        // $FlowIssue[incompatible-use]
+        target[prop] = factories[prop]();
+      }
+      // $FlowIssue[incompatible-use]
+      return target[prop];
+    },
+  });
+}
+
+module.exports = lazyProxy;


### PR DESCRIPTION
Summary:
Performance optimization to lazily clone snapshots for callbacks only if the callback actually uses it.

Note this means that the snapshots for a callback may actually represent later state if they are first accessd later asynchronously.

Differential Revision: D33156967

