### PR TITLE
Suppress React 18 act() warning with tests

### DIFF
--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -350,19 +350,24 @@ const testGKs =
           setStrictMode,
           setConcurrentMode,
         } = require('./Recoil_ReactRenderModes');
+        // Setup test environment
         setStrictMode(strictMode);
         setConcurrentMode(concurrentMode);
-
+        // See: https://github.com/reactwg/react-18/discussions/102
+        const prevReactActEnvironment = global.IS_REACT_ACT_ENVIRONMENT;
+        global.IS_REACT_ACT_ENVIRONMENT = true;
         gksToTest.forEach(gkx.setPass);
-
         const after = reloadImports();
-        await assertionsFn({gks: gksToTest, strictMode, concurrentMode});
 
-        gksToTest.forEach(gkx.setFail);
-
-        after?.();
-        setStrictMode(false);
-        setConcurrentMode(false);
+        try {
+          await assertionsFn({gks: gksToTest, strictMode, concurrentMode});
+        } finally {
+          global.IS_REACT_ACT_ENVIRONMENT = prevReactActEnvironment;
+          gksToTest.forEach(gkx.setFail);
+          after?.();
+          setStrictMode(false);
+          setConcurrentMode(false);
+        }
       });
     }
 


### PR DESCRIPTION
Summary:
Suppress the following warning when testing with React 18:
```
Warning: The current testing environment is not configured to support act(...)
```

See https://github.com/reactwg/react-18/discussions/102 for context

Differential Revision: D33174422

