### PR TITLE
Test multiple versions of React

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        react: ['17.0.2', '18.0.0-rc.0']
 
     steps:
     - uses: actions/checkout@v2
@@ -28,6 +29,15 @@ jobs:
     - run: npm i -g yarn
     - run: cd packages-ext/recoil-devtools && yarn install --frozen-lockfile
     - run: yarn install --frozen-lockfile
+    - name: Install React (Unix/Mac)
+      run: >
+       sed -i'' -e 's/\("react\(-dom\)\{0,1\}\(-test-renderer\)\{0,1\}": "\).*"/\1${{ matrix.react }}"/g' package.json
+      if: matrix.os != 'windows-latest'
+    - name: Install React (Windows)
+      run: >
+       sed -i 's/\(""react\(-dom\)\\{0,1\\}\(-test-renderer\)\\{0,1\\}"": ""\).*""/\1${{ matrix.react }}""/g' package.json
+      if: matrix.os == 'windows-latest'
+    - run: yarn install
     - run: yarn flow
     - run: yarn test
     - run: yarn test:typescript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - React 18
   - Leverage new React 18 APIs for improved safety and optimizations.
-  - Fixes for `<StrictMode>` (#1473, #1444).  There is a known issue with Strict Mode when using React 18's new createRoot().
+  - Fixes for `<StrictMode>` (#1473, #1444).
   - `useTransition()` is not yet supported for open source React.
 - Recoil updates now re-render earlier:
   - Recoil and React state changes from the same batch now stay in sync.
@@ -28,8 +28,12 @@
 - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
 - Fix transitive selector refresh for some cases (#1409)
 - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
+- Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up.
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
+
+### Breaking Changes
+- Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`.
 
 ## 0.5.2 (2021-11-07)
 

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -105,16 +105,6 @@ function initializeNode(store: Store, key: NodeKey): void {
   initializeNodeIfNewToStore(store, store.getState().currentTree, key, 'get');
 }
 
-function reinitializeNode(store: Store, key: NodeKey): void {
-  const storeState = store.getState();
-  // If this atom was previously initialized (set in knownAtoms), but was
-  // cleaned up (not set in nodeCleanupFunctions), then re-initialize it.
-  if (!storeState.nodeCleanupFunctions.has(key)) {
-    storeState.knownAtoms.delete(key); // Force atom to re-initialize
-  }
-  initializeNodeIfNewToStore(store, storeState.currentTree, key, 'get');
-}
-
 function cleanUpNode(store: Store, key: NodeKey) {
   const state = store.getState();
   state.nodeCleanupFunctions.get(key)?.();
@@ -223,7 +213,7 @@ function peekNodeInfo<T>(
     // Report current dependencies.  If the node hasn't been evaluated, then
     // dependencies may be missing based on the current state.
     deps: recoilValuesForKeys(graph.nodeDeps.get(key) ?? []),
-    // Reportsall "current" subscribers.  Evaluating other nodes or
+    // Reports all "current" subscribers.  Evaluating other nodes or
     // previous in-progress async evaluations may introduce new subscribers.
     subscribers: {
       nodes: recoilValuesForKeys(downstreamNodes),
@@ -262,7 +252,6 @@ module.exports = {
   peekNodeLoadable,
   setNodeValue,
   initializeNode,
-  reinitializeNode,
   cleanUpNode,
   setUnvalidatedAtomValue_DEPRECATED,
   peekNodeInfo,

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -46,6 +46,7 @@ const {isSSR} = require('recoil-shared/util/Recoil_Environment');
 const err = require('recoil-shared/util/Recoil_err');
 const filterIterable = require('recoil-shared/util/Recoil_filterIterable');
 const gkx = require('recoil-shared/util/Recoil_gkx');
+const mapIterable = require('recoil-shared/util/Recoil_mapIterable');
 const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
@@ -281,7 +282,15 @@ function cloneStoreState(
       nodesRetainedByZone: new Map(),
       retainablesToCheckForRelease: new Set(),
     },
-    nodeCleanupFunctions: new Map(),
+    // FIXME here's a copy
+    // Create blank cleanup handlers for atoms so snapshots don't re-run
+    // atom effects.
+    nodeCleanupFunctions: new Map(
+      mapIterable(storeState.nodeCleanupFunctions.entries(), ([key]) => [
+        key,
+        () => {},
+      ]),
+    ),
   };
 }
 
@@ -344,7 +353,6 @@ class MutableSnapshot extends Snapshot {
     // See note at `set` about batched updates.
     this._batch(() => {
       updateRetainCount(store, recoilState.key, 1);
-
       setRecoilValue(this.getStore_INTERNAL(), recoilState, DEFAULT_VALUE);
     });
   };

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -377,7 +377,7 @@ testRecoil('Consistent callback function', () => {
 
 testRecoil(
   'Atom effects are initialized twice if first seen on snapshot and then on root store',
-  ({strictMode}) => {
+  ({strictMode, concurrentMode}) => {
     const sm = strictMode ? 1 : 0;
     let numTimesEffectInit = 0;
 
@@ -400,11 +400,9 @@ testRecoil(
       });
 
       readAtomFromSnapshot(); // first initialization
-
       expect(numTimesEffectInit).toBe(1 + sm * renderCount);
 
       useRecoilValue(atomWithEffect); // second initialization
-
       expect(numTimesEffectInit).toBe(2);
 
       renderCount++;
@@ -413,14 +411,13 @@ testRecoil(
 
     const c = renderElements(<Component />);
     expect(c.textContent).toBe(''); // Confirm no failures from rendering
-
-    expect(numTimesEffectInit).toBe(2);
+    expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
   },
 );
 
 testRecoil(
   'Atom effects are initialized once if first seen on root store and then on snapshot',
-  () => {
+  ({strictMode, concurrentMode}) => {
     let numTimesEffectInit = 0;
 
     const atomWithEffect = atom({
@@ -439,7 +436,6 @@ testRecoil(
       });
 
       useRecoilValue(atomWithEffect); // first initialization
-
       expect(numTimesEffectInit).toBe(1);
 
       /**
@@ -447,7 +443,6 @@ testRecoil(
        * wherein atom was already initialized
        */
       readAtomFromSnapshot();
-
       expect(numTimesEffectInit).toBe(1);
 
       return null;
@@ -455,8 +450,7 @@ testRecoil(
 
     const c = renderElements(<Component />);
     expect(c.textContent).toBe(''); // Confirm no failures from rendering
-
-    expect(numTimesEffectInit).toBe(1);
+    expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 2 : 1);
   },
 );
 

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -350,19 +350,24 @@ const testGKs =
           setStrictMode,
           setConcurrentMode,
         } = require('./Recoil_ReactRenderModes');
+        // Setup test environment
         setStrictMode(strictMode);
         setConcurrentMode(concurrentMode);
-
+        // See: https://github.com/reactwg/react-18/discussions/102
+        const prevReactActEnvironment = global.IS_REACT_ACT_ENVIRONMENT;
+        global.IS_REACT_ACT_ENVIRONMENT = true;
         gksToTest.forEach(gkx.setPass);
-
         const after = reloadImports();
-        await assertionsFn({gks: gksToTest, strictMode, concurrentMode});
 
-        gksToTest.forEach(gkx.setFail);
-
-        after?.();
-        setStrictMode(false);
-        setConcurrentMode(false);
+        try {
+          await assertionsFn({gks: gksToTest, strictMode, concurrentMode});
+        } finally {
+          global.IS_REACT_ACT_ENVIRONMENT = prevReactActEnvironment;
+          gksToTest.forEach(gkx.setFail);
+          after?.();
+          setStrictMode(false);
+          setConcurrentMode(false);
+        }
       });
     }
 

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -375,7 +375,11 @@ const testGKs =
     runTests({strictMode: true, concurrentMode: false});
     if (isConcurrentModeAvailable()) {
       runTests({strictMode: false, concurrentMode: true});
-      runTests({strictMode: true, concurrentMode: true});
+      // 2020-12-20: The internal <StrictMode> isn't yet enabled to run effects
+      // multiple times.  So, rely on GitHub CI actions to test this for now.
+      if (!IS_INTERNAL) {
+        runTests({strictMode: true, concurrentMode: true});
+      }
     }
   };
 


### PR DESCRIPTION
Summary:
Update GitHub CI actions to do matrix testing with multiple versions of React in addition to OS and Node versions.

This allows us to test both React 17 and React 18 with new concurrent and strict modes.

how_to_regex_garabatokid

regex_train

iknowthis_regex

Differential Revision: D33196989

