### PR TITLE
Ensure baseline GK state for OSS testing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        react: ['17.0.2', '18.0.0-rc.0']
 
     steps:
     - uses: actions/checkout@v2
@@ -28,6 +29,15 @@ jobs:
     - run: npm i -g yarn
     - run: cd packages-ext/recoil-devtools && yarn install --frozen-lockfile
     - run: yarn install --frozen-lockfile
+    - name: Install React (Unix/Mac)
+      run: >
+       sed -i'' -e 's/\("react\(-dom\)\{0,1\}\(-test-renderer\)\{0,1\}": "\).*"/\1${{ matrix.react }}"/g' package.json
+      if: matrix.os != 'windows-latest'
+    - name: Install React (Windows)
+      run: >
+       sed -i 's/\(""react\(-dom\)\\{0,1\\}\(-test-renderer\)\\{0,1\\}"": ""\).*""/\1${{ matrix.react }}""/g' package.json
+      if: matrix.os == 'windows-latest'
+    - run: yarn install
     - run: yarn flow
     - run: yarn test
     - run: yarn test:typescript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 ## 0.6 ()
 
 - React 18
-  - Leverage new React 18 APIs for improved safety and optimizations.
-  - Fixes for `<StrictMode>` (#1473, #1444).
+  - Leverage new React 18 APIs for improved safety and optimizations. (#1488)
+  - Fixes for `<StrictMode>` (#1473, #1444, #1509).
   - `useTransition()` is not yet supported for open source React.
 - Recoil updates now re-render earlier:
   - Recoil and React state changes from the same batch now stay in sync.
@@ -28,12 +28,12 @@
 - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
 - Fix transitive selector refresh for some cases (#1409)
 - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
-- Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up.
+- Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 
 ### Breaking Changes
-- Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`.
+- Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`. (#1509)
 
 ## 0.5.2 (2021-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - React 18
   - Leverage new React 18 APIs for improved safety and optimizations.
-  - Fixes for `<StrictMode>` (#1473, #1444).  There is a known issue with Strict Mode when using React 18's new createRoot().
+  - Fixes for `<StrictMode>` (#1473, #1444).
   - `useTransition()` is not yet supported for open source React.
 - Recoil updates now re-render earlier:
   - Recoil and React state changes from the same batch now stay in sync.
@@ -28,8 +28,12 @@
 - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
 - Fix transitive selector refresh for some cases (#1409)
 - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
+- Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up.
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
+
+### Breaking Changes
+- Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`.
 
 ## 0.5.2 (2021-11-07)
 

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -105,16 +105,6 @@ function initializeNode(store: Store, key: NodeKey): void {
   initializeNodeIfNewToStore(store, store.getState().currentTree, key, 'get');
 }
 
-function reinitializeNode(store: Store, key: NodeKey): void {
-  const storeState = store.getState();
-  // If this atom was previously initialized (set in knownAtoms), but was
-  // cleaned up (not set in nodeCleanupFunctions), then re-initialize it.
-  if (!storeState.nodeCleanupFunctions.has(key)) {
-    storeState.knownAtoms.delete(key); // Force atom to re-initialize
-  }
-  initializeNodeIfNewToStore(store, storeState.currentTree, key, 'get');
-}
-
 function cleanUpNode(store: Store, key: NodeKey) {
   const state = store.getState();
   state.nodeCleanupFunctions.get(key)?.();
@@ -223,7 +213,7 @@ function peekNodeInfo<T>(
     // Report current dependencies.  If the node hasn't been evaluated, then
     // dependencies may be missing based on the current state.
     deps: recoilValuesForKeys(graph.nodeDeps.get(key) ?? []),
-    // Reportsall "current" subscribers.  Evaluating other nodes or
+    // Reports all "current" subscribers.  Evaluating other nodes or
     // previous in-progress async evaluations may introduce new subscribers.
     subscribers: {
       nodes: recoilValuesForKeys(downstreamNodes),
@@ -262,7 +252,6 @@ module.exports = {
   peekNodeLoadable,
   setNodeValue,
   initializeNode,
-  reinitializeNode,
   cleanUpNode,
   setUnvalidatedAtomValue_DEPRECATED,
   peekNodeInfo,

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -46,6 +46,7 @@ const {isSSR} = require('recoil-shared/util/Recoil_Environment');
 const err = require('recoil-shared/util/Recoil_err');
 const filterIterable = require('recoil-shared/util/Recoil_filterIterable');
 const gkx = require('recoil-shared/util/Recoil_gkx');
+const mapIterable = require('recoil-shared/util/Recoil_mapIterable');
 const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
@@ -281,7 +282,15 @@ function cloneStoreState(
       nodesRetainedByZone: new Map(),
       retainablesToCheckForRelease: new Set(),
     },
-    nodeCleanupFunctions: new Map(),
+    // FIXME here's a copy
+    // Create blank cleanup handlers for atoms so snapshots don't re-run
+    // atom effects.
+    nodeCleanupFunctions: new Map(
+      mapIterable(storeState.nodeCleanupFunctions.entries(), ([key]) => [
+        key,
+        () => {},
+      ]),
+    ),
   };
 }
 
@@ -344,7 +353,6 @@ class MutableSnapshot extends Snapshot {
     // See note at `set` about batched updates.
     this._batch(() => {
       updateRetainCount(store, recoilState.key, 1);
-
       setRecoilValue(this.getStore_INTERNAL(), recoilState, DEFAULT_VALUE);
     });
   };

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -377,7 +377,7 @@ testRecoil('Consistent callback function', () => {
 
 testRecoil(
   'Atom effects are initialized twice if first seen on snapshot and then on root store',
-  ({strictMode}) => {
+  ({strictMode, concurrentMode}) => {
     const sm = strictMode ? 1 : 0;
     let numTimesEffectInit = 0;
 
@@ -400,11 +400,9 @@ testRecoil(
       });
 
       readAtomFromSnapshot(); // first initialization
-
       expect(numTimesEffectInit).toBe(1 + sm * renderCount);
 
       useRecoilValue(atomWithEffect); // second initialization
-
       expect(numTimesEffectInit).toBe(2);
 
       renderCount++;
@@ -413,14 +411,13 @@ testRecoil(
 
     const c = renderElements(<Component />);
     expect(c.textContent).toBe(''); // Confirm no failures from rendering
-
-    expect(numTimesEffectInit).toBe(2);
+    expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
   },
 );
 
 testRecoil(
   'Atom effects are initialized once if first seen on root store and then on snapshot',
-  () => {
+  ({strictMode, concurrentMode}) => {
     let numTimesEffectInit = 0;
 
     const atomWithEffect = atom({
@@ -439,7 +436,6 @@ testRecoil(
       });
 
       useRecoilValue(atomWithEffect); // first initialization
-
       expect(numTimesEffectInit).toBe(1);
 
       /**
@@ -447,7 +443,6 @@ testRecoil(
        * wherein atom was already initialized
        */
       readAtomFromSnapshot();
-
       expect(numTimesEffectInit).toBe(1);
 
       return null;
@@ -455,8 +450,7 @@ testRecoil(
 
     const c = renderElements(<Component />);
     expect(c.textContent).toBe(''); // Confirm no failures from rendering
-
-    expect(numTimesEffectInit).toBe(1);
+    expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 2 : 1);
   },
 );
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -657,7 +657,7 @@ describe('Effects', () => {
     expect(validated).toEqual(true);
   });
 
-  testRecoil('once per root', () => {
+  testRecoil('once per root', ({strictMode, concurrentMode}) => {
     let inited = 0;
     const myAtom = atom({
       key: 'atom effect once per root',
@@ -684,7 +684,7 @@ describe('Effects', () => {
     expect(c1.textContent).toEqual('"SET"');
     expect(c2.textContent).toEqual('"INIT"');
 
-    expect(inited).toEqual(2);
+    expect(inited).toEqual(strictMode && concurrentMode ? 4 : 2);
   });
 
   testRecoil('onSet', () => {
@@ -937,10 +937,70 @@ describe('Effects', () => {
     expect(refCountsB).toEqual([0, 0]);
   });
 
+  testRecoil('onSet unsubscribes', () => {
+    let onSetRan = 0;
+    const myAtom = atom({
+      key: 'atom effects onSet unsubscribe',
+      default: 'DEFAULT',
+      effects_UNSTABLE: [
+        ({onSet}) => {
+          onSet(() => {
+            onSetRan++;
+          });
+        },
+      ],
+    });
+
+    let setMount = _ => {
+      throw new Error('Test Error');
+    };
+    const [ReadWriteAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);
+    function Component() {
+      const [mount, setState] = useState(false);
+      setMount = setState;
+      return mount ? (
+        <RecoilRoot>
+          <ReadWriteAtom />
+        </RecoilRoot>
+      ) : (
+        'UNMOUNTED'
+      );
+    }
+
+    const c = renderElements(<Component />);
+    expect(c.textContent).toBe('UNMOUNTED');
+    expect(onSetRan).toBe(0);
+
+    act(() => setMount(true));
+    expect(c.textContent).toBe('"DEFAULT"');
+    expect(onSetRan).toBe(0);
+
+    act(() => setAtom('SET'));
+    expect(c.textContent).toBe('"SET"');
+    expect(onSetRan).toBe(1);
+
+    act(() => setMount(false));
+    expect(c.textContent).toBe('UNMOUNTED');
+    expect(onSetRan).toBe(1);
+
+    // onSet() handler not called after store is unmounted and effects cleanedup
+    act(() => setAtom('SET INVALID'));
+    expect(c.textContent).toBe('UNMOUNTED');
+    expect(onSetRan).toBe(1);
+
+    act(() => setMount(true));
+    expect(c.textContent).toBe('"DEFAULT"');
+    expect(onSetRan).toBe(1);
+
+    act(() => setAtom('SET2'));
+    expect(c.textContent).toBe('"SET2"');
+    expect(onSetRan).toBe(2);
+  });
+
   // Test that effects can initialize state when an atom is first used after an
   // action that also updated another atom's state.
   // This corner case was reported by multiple customers.
-  testRecoil('initialze concurrent with state update', () => {
+  testRecoil('initialize concurrent with state update', () => {
     const myAtom = atom({
       key: 'atom effect - concurrent update',
       default: 'DEFAULT',
@@ -989,7 +1049,7 @@ describe('Effects', () => {
    */
   testRecoil(
     'atom effect runs twice when selector that depends on that atom is read from a snapshot and the atom is read for first time in that snapshot',
-    () => {
+    ({strictMode, concurrentMode}) => {
       let numTimesEffectInit = 0;
       let latestSetSelf = a => a;
 
@@ -1019,20 +1079,20 @@ describe('Effects', () => {
 
         readSelFromSnapshot(); // first initialization;
 
-        const val = useRecoilValue(selThatDependsOnAtom); // second initialization;
-
-        return val;
+        return useRecoilValue(selThatDependsOnAtom); // second initialization;
       };
 
       const c = renderElements(<Component />);
-
       expect(c.textContent).toBe('1');
+      expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
 
       act(() => latestSetSelf(100));
-
       expect(c.textContent).toBe('100');
+      expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
 
-      expect(numTimesEffectInit).toBe(2);
+      act(() => latestSetSelf(200));
+      expect(c.textContent).toBe('200');
+      expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
     },
   );
 
@@ -1086,13 +1146,16 @@ describe('Effects', () => {
     });
 
     testRecoil('async get other atoms', async () => {
-      let initTest1 = Promise.reject('test error');
-      let initTest2 = Promise.reject('test error');
-      let initTest3 = Promise.reject('test error');
-      let initTest4 = Promise.reject('test error');
-      let initTest5 = Promise.reject('test error');
-      let initTest6 = Promise.reject('test error');
-      let setTest = Promise.reject('test error');
+      let initTest1 = null;
+      let initTest2 = null;
+      let initTest3 = null;
+      let initTest4 = null;
+      let initTest5 = null;
+      let initTest6 = null;
+      let setTest = null;
+
+      // StrictMode will render twice
+      let firstRender = true;
 
       const myAtom = atom({
         key: 'atom effect - async get',
@@ -1100,9 +1163,13 @@ describe('Effects', () => {
         effects_UNSTABLE: [
           // Test we can get default values
           ({node, getLoadable, getPromise, getInfo_UNSTABLE}) => {
-            expect(getLoadable(node).contents).toEqual('DEFAULT');
-            expect(getInfo_UNSTABLE(node).isSet).toBe(false);
-            expect(getInfo_UNSTABLE(node).loadable?.contents).toBe('DEFAULT');
+            expect(getLoadable(node).contents).toEqual(
+              firstRender ? 'DEFAULT' : 'INIT',
+            );
+            expect(getInfo_UNSTABLE(node).isSet).toBe(!firstRender);
+            expect(getInfo_UNSTABLE(node).loadable?.contents).toBe(
+              firstRender ? 'DEFAULT' : 'INIT',
+            );
             // eslint-disable-next-line jest/valid-expect
             initTest1 = expect(getPromise(asyncAtom)).resolves.toEqual('ASYNC');
           },
@@ -1130,6 +1197,9 @@ describe('Effects', () => {
                 'SET_OTHER',
               );
             });
+          },
+          () => {
+            firstRender = false;
           },
         ],
       });
@@ -1189,15 +1259,22 @@ describe('Effects', () => {
 
       await flushPromisesAndTimers();
       expect(c.textContent).toBe('"INIT""ASYNC"');
+      expect(initTest1).not.toBe(null);
       await initTest1;
+      expect(initTest2).not.toBe(null);
       await initTest2;
+      expect(initTest3).not.toBe(null);
       await initTest3;
+      expect(initTest4).not.toBe(null);
       await initTest4;
+      expect(initTest5).not.toBe(null);
       await initTest5;
+      expect(initTest6).not.toBe(null);
       await initTest6;
 
       act(() => setAsyncAtom('SET_OTHER'));
       act(() => setMyAtom('SET_ATOM'));
+      expect(setTest).not.toBe(null);
       await setTest;
     });
   });

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -344,8 +344,8 @@ const testGKs =
         ]),
       ])('%s', async (_title, gksToTest) => {
         jest.resetModules();
-
         const gkx = require('recoil-shared/util/Recoil_gkx');
+        gkx.clear(); // @oss-only
         const {
           setStrictMode,
           setConcurrentMode,

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -350,19 +350,24 @@ const testGKs =
           setStrictMode,
           setConcurrentMode,
         } = require('./Recoil_ReactRenderModes');
+        // Setup test environment
         setStrictMode(strictMode);
         setConcurrentMode(concurrentMode);
-
+        // See: https://github.com/reactwg/react-18/discussions/102
+        const prevReactActEnvironment = global.IS_REACT_ACT_ENVIRONMENT;
+        global.IS_REACT_ACT_ENVIRONMENT = true;
         gksToTest.forEach(gkx.setPass);
-
         const after = reloadImports();
-        await assertionsFn({gks: gksToTest, strictMode, concurrentMode});
 
-        gksToTest.forEach(gkx.setFail);
-
-        after?.();
-        setStrictMode(false);
-        setConcurrentMode(false);
+        try {
+          await assertionsFn({gks: gksToTest, strictMode, concurrentMode});
+        } finally {
+          global.IS_REACT_ACT_ENVIRONMENT = prevReactActEnvironment;
+          gksToTest.forEach(gkx.setFail);
+          after?.();
+          setStrictMode(false);
+          setConcurrentMode(false);
+        }
       });
     }
 

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -375,7 +375,11 @@ const testGKs =
     runTests({strictMode: true, concurrentMode: false});
     if (isConcurrentModeAvailable()) {
       runTests({strictMode: false, concurrentMode: true});
-      runTests({strictMode: true, concurrentMode: true});
+      // 2020-12-20: The internal <StrictMode> isn't yet enabled to run effects
+      // multiple times.  So, rely on GitHub CI actions to test this for now.
+      if (!IS_INTERNAL) {
+        runTests({strictMode: true, concurrentMode: true});
+      }
     }
   };
 

--- a/packages/shared/util/Recoil_gkx.js
+++ b/packages/shared/util/Recoil_gkx.js
@@ -28,6 +28,10 @@ Recoil_gkx_OSS.setFail = (gk: string): void => {
   gks.set(gk, false);
 };
 
+Recoil_gkx_OSS.clear = (): void => {
+  gks.clear();
+};
+
 module.exports = Recoil_gkx_OSS; // @oss-only
 
 // @fb-only: module.exports = require('gkx');


### PR DESCRIPTION
Summary: Ensure we have a clean baseline GK slate for OSS testing and not hitting the default OSS GK state for initial tests.

Differential Revision: D33270018

