### PR TITLE
Cleanup atom effects when initialized with a snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix transitive selector refresh for some cases (#1409)
 - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
 - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
+- Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -88,13 +88,13 @@ function initializeNodeIfNewToStore(
   if (storeState.nodeCleanupFunctions.has(key)) {
     return;
   }
-  const config = getNode(key);
+  const node = getNode(key);
   const retentionCleanup = initializeRetentionForNode(
     store,
     key,
-    config.retainedBy,
+    node.retainedBy,
   );
-  const nodeCleanup = config.init(store, treeState, trigger);
+  const nodeCleanup = node.init(store, treeState, trigger);
   storeState.nodeCleanupFunctions.set(key, () => {
     nodeCleanup();
     retentionCleanup();

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -229,17 +229,14 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     initState: TreeState,
     trigger: Trigger,
   ): () => void {
+    liveStoresCount++;
     const cleanupAtom = () => {
       liveStoresCount--;
       cleanupEffectsByStore.get(store)?.forEach(cleanup => cleanup());
       cleanupEffectsByStore.delete(store);
     };
 
-    if (store.getState().nodeCleanupFunctions.has(key)) {
-      return cleanupAtom;
-    }
     store.getState().knownAtoms.add(key);
-    liveStoresCount++;
 
     // Setup async defaults to notify subscribers when they resolve
     if (defaultLoadable.state === 'loading') {

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -279,11 +279,9 @@ function selector<T>(
 
   function selectorInit(store: Store): () => void {
     liveStoresCount++;
-    store.getState().knownSelectors.add(key); // FIXME remove knownSelectors?
+    store.getState().knownSelectors.add(key);
     return () => {
       liveStoresCount--;
-      store.getState().knownSelectors.delete(key);
-      executionInfoMap.delete(store);
     };
   }
 
@@ -1142,15 +1140,13 @@ function selector<T>(
   }
 
   function selectorPeek(store: Store, state: TreeState): ?Loadable<T> {
-    const cacheVal = cache.get(nodeKey => {
+    return cache.get(nodeKey => {
       invariant(typeof nodeKey === 'string', 'Cache nodeKey is type string');
 
       const peek = peekNodeLoadable(store, state, nodeKey);
 
       return peek?.contents;
     });
-
-    return cacheVal;
   }
 
   function selectorGet(store: Store, state: TreeState): Loadable<T> {


### PR DESCRIPTION
Summary: When an atom is used with a snapshot that has not already seen it, then it needs to initialize and run the atom effects.  Make sure those atom effects are cleaned up when that snapshot is released.

Differential Revision: D33270037

