### PR TITLE
fix selectorGetter performance issue

### DIFF
--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -683,18 +683,6 @@ function selector<T>(
     }
   }
 
-  function setNewDepInStore(
-    store: Store,
-    state: TreeState,
-    deps: Set<NodeKey>,
-    newDepKey: NodeKey,
-    executionId: ?ExecutionId,
-  ): void {
-    deps.add(newDepKey);
-
-    setDepsInStore(store, state, deps, executionId);
-  }
-
   function evaluateSelectorGetter(
     store: Store,
     state: TreeState,
@@ -729,12 +717,10 @@ function selector<T>(
      */
     const deps = new Set();
 
-    setDepsInStore(store, state, deps, executionId);
-
     function getRecoilValue<S>(dep: RecoilValue<S>): S {
       const {key: depKey} = dep;
 
-      setNewDepInStore(store, state, deps, depKey, executionId);
+      deps.add(depKey);
 
       const depLoadable = getCachedNodeLoadable(store, state, depKey);
 
@@ -818,6 +804,7 @@ function selector<T>(
       maybeFreezeValue(loadable.contents);
     }
 
+    setDepsInStore(store, state, deps, executionId);
     return [loadable, depValues];
   }
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -181,15 +181,6 @@ testRecoil('selector reset', () => {
   expect(getValue(selectorRW)).toEqual('DEFAULT');
 });
 
-testRecoil('useRecoilState - resolved async selector', async () => {
-  const resolvingSel = resolvingAsyncSelector('HELLO');
-  const c = renderElements(<ReadsAtom atom={resolvingSel} />);
-  expect(c.textContent).toEqual('loading');
-  act(() => jest.runAllTimers());
-  await flushPromisesAndTimers();
-  expect(c.textContent).toEqual('"HELLO"');
-});
-
 testRecoil('selector - evaluate to RecoilValue', () => {
   const atomA = atom({key: 'selector/const atom A', default: 'A'});
   const atomB = atom({key: 'selector/const atom B', default: 'B'});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,11 +1,7 @@
 {
   "name": "recoil-shared",
   "description": "This is the internal package.json enabling CommonJS module",
-  "main": "Recoil_Shared.js",
   "haste_commonjs": true,
-  "files": [
-    "Recoil_Shared.js"
-  ],
   "directories": {
     "": "./"
   },


### PR DESCRIPTION
- motivation: the getter is call `setDepsInStore` every time, harm the performance when multiple call the getter
- notes: this pr just a demo, I don't known is this feasible. please give me a confirm, and I will make some further change with testcases

#914 Please refer this issue for detail