### PR TITLE
Test onSet() is called when atom initialized via snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@
 ### Other Fixes and Optimizations
 - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
 - Fix transitive selector refresh for some cases (#1409)
-- Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
-- Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
-- Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
+- Atom Effects
+  - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
+  - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
+  - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
+  - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix transitive selector refresh for some cases (#1409)
 - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
 - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
+- Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -88,13 +88,13 @@ function initializeNodeIfNewToStore(
   if (storeState.nodeCleanupFunctions.has(key)) {
     return;
   }
-  const config = getNode(key);
+  const node = getNode(key);
   const retentionCleanup = initializeRetentionForNode(
     store,
     key,
-    config.retainedBy,
+    node.retainedBy,
   );
-  const nodeCleanup = config.init(store, treeState, trigger);
+  const nodeCleanup = node.init(store, treeState, trigger);
   storeState.nodeCleanupFunctions.set(key, () => {
     nodeCleanup();
     retentionCleanup();

--- a/packages/recoil/hooks/Recoil_useRecoilBridgeAcrossReactRoots.js
+++ b/packages/recoil/hooks/Recoil_useRecoilBridgeAcrossReactRoots.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+const {reactMode} = require('../core/Recoil_ReactMode');
 const {RecoilRoot, useStoreRef} = require('../core/Recoil_RecoilRoot');
 const React = require('react');
 const {useMemo} = require('react');
@@ -17,6 +18,14 @@ const {useMemo} = require('react');
 export type RecoilBridge = React.AbstractComponent<{children: React.Node}>;
 
 function useRecoilBridgeAcrossReactRoots(): RecoilBridge {
+  // The test fails when using useMutableSource(), but only if act() is used
+  // for the nested root.  So, this may only be a testing environment issue.
+  if (reactMode().mode === 'MUTABLE_SOURCE') {
+    // eslint-disable-next-line fb-www/no-console
+    console.warn(
+      'Warning: There are known issues using useRecoilBridgeAcrossReactRoots() in recoil_mutable_source rendering mode.  Please consider upgrading to recoil_sync_external_store mode.',
+    );
+  }
   const store = useStoreRef().current;
   return useMemo(() => {
     // eslint-disable-next-line no-shadow

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -308,12 +308,11 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       const setSelf =
         (effect: AtomEffect<T>) => (valueOrUpdater: NewValueOrUpdater<T>) => {
           if (duringInit) {
+            const currentLoadable = getLoadable(node);
             const currentValue: T | DefaultValue =
-              initValue instanceof DefaultValue || isPromise(initValue)
-                ? defaultLoadable.state === 'hasValue'
-                  ? defaultLoadable.contents
-                  : DEFAULT_VALUE
-                : initValue;
+              currentLoadable.state === 'hasValue'
+                ? currentLoadable.contents
+                : DEFAULT_VALUE;
             initValue =
               typeof valueOrUpdater === 'function'
                 ? // cast to any because we can't restrict T from being a function without losing support for opaque types

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -229,17 +229,14 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     initState: TreeState,
     trigger: Trigger,
   ): () => void {
+    liveStoresCount++;
     const cleanupAtom = () => {
       liveStoresCount--;
       cleanupEffectsByStore.get(store)?.forEach(cleanup => cleanup());
       cleanupEffectsByStore.delete(store);
     };
 
-    if (store.getState().nodeCleanupFunctions.has(key)) {
-      return cleanupAtom;
-    }
     store.getState().knownAtoms.add(key);
-    liveStoresCount++;
 
     // Setup async defaults to notify subscribers when they resolve
     if (defaultLoadable.state === 'loading') {

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -279,11 +279,9 @@ function selector<T>(
 
   function selectorInit(store: Store): () => void {
     liveStoresCount++;
-    store.getState().knownSelectors.add(key); // FIXME remove knownSelectors?
+    store.getState().knownSelectors.add(key);
     return () => {
       liveStoresCount--;
-      store.getState().knownSelectors.delete(key);
-      executionInfoMap.delete(store);
     };
   }
 
@@ -1142,15 +1140,13 @@ function selector<T>(
   }
 
   function selectorPeek(store: Store, state: TreeState): ?Loadable<T> {
-    const cacheVal = cache.get(nodeKey => {
+    return cache.get(nodeKey => {
       invariant(typeof nodeKey === 'string', 'Cache nodeKey is type string');
 
       const peek = peekNodeLoadable(store, state, nodeKey);
 
       return peek?.contents;
     });
-
-    return cacheVal;
   }
 
   function selectorGet(store: Store, state: TreeState): Loadable<T> {

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -396,6 +396,7 @@ describe('Effects', () => {
 
   testRecoil('async set', () => {
     let setAtom, resetAtom;
+    let effectRan = false;
 
     const myAtom = atom({
       key: 'atom effect init set',
@@ -405,7 +406,8 @@ describe('Effects', () => {
           setAtom = setSelf;
           resetAtom = resetSelf;
           setSelf(x => {
-            expect(x).toEqual('DEFAULT');
+            expect(x).toEqual(effectRan ? 'INIT' : 'DEFAULT');
+            effectRan = true;
             return 'INIT';
           });
         },

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -49,6 +49,8 @@ const err = require('recoil-shared/util/Recoil_err');
 const ReactDOM = require('react-dom'); // @oss-only
 const StrictMode = React.StrictMode; // @oss-only
 
+const QUICK_TEST = false;
+
 // @fb-only: const IS_INTERNAL = true;
 const IS_INTERNAL = false; // @oss-only
 
@@ -363,46 +365,52 @@ const testGKs =
       });
     }
 
-    runTests({strictMode: false, concurrentMode: false});
-    runTests({strictMode: true, concurrentMode: false});
-    if (isConcurrentModeAvailable()) {
+    if (QUICK_TEST) {
       runTests({strictMode: false, concurrentMode: true});
-      // 2020-12-20: The internal <StrictMode> isn't yet enabled to run effects
-      // multiple times.  So, rely on GitHub CI actions to test this for now.
-      if (!IS_INTERNAL) {
-        runTests({strictMode: true, concurrentMode: true});
+    } else {
+      runTests({strictMode: false, concurrentMode: false});
+      runTests({strictMode: true, concurrentMode: false});
+      if (isConcurrentModeAvailable()) {
+        runTests({strictMode: false, concurrentMode: true});
+        // 2020-12-20: The internal <StrictMode> isn't yet enabled to run effects
+        // multiple times.  So, rely on GitHub CI actions to test this for now.
+        if (!IS_INTERNAL) {
+          runTests({strictMode: true, concurrentMode: true});
+        }
       }
     }
   };
 
-const WWW_GKS_TO_TEST = [
-  // OSS for React <18:
-  ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering
-  // Current internal default:
-  ['recoil_hamt_2020', 'recoil_mutable_source'],
-  // Internal with suppress, early rendering, and useTransition() support:
-  [
-    'recoil_hamt_2020',
-    'recoil_mutable_source',
-    'recoil_suppress_rerender_in_callback', // Also enables early rendering
-  ],
-  // OSS for React 18, test internally:
-  [
-    'recoil_hamt_2020',
-    'recoil_sync_external_store',
-    'recoil_suppress_rerender_in_callback', // Only used for fallback if no useSyncExternalStore()
-  ],
-  // Latest with GC:
-  [
-    'recoil_hamt_2020',
-    'recoil_sync_external_store',
-    'recoil_suppress_rerender_in_callback',
-    'recoil_memory_managament_2020',
-    'recoil_release_on_cascading_update_killswitch_2021',
-  ],
-  // Experimental mode for useTransition() support:
-  // ['recoil_hamt_2020', 'recoil_concurrent_legacy'],
-];
+const WWW_GKS_TO_TEST = QUICK_TEST
+  ? [['recoil_hamt_2020', 'recoil_sync_external_store']]
+  : [
+      // OSS for React <18:
+      ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering
+      // Current internal default:
+      ['recoil_hamt_2020', 'recoil_mutable_source'],
+      // Internal with suppress, early rendering, and useTransition() support:
+      [
+        'recoil_hamt_2020',
+        'recoil_mutable_source',
+        'recoil_suppress_rerender_in_callback', // Also enables early rendering
+      ],
+      // OSS for React 18, test internally:
+      [
+        'recoil_hamt_2020',
+        'recoil_sync_external_store',
+        'recoil_suppress_rerender_in_callback', // Only used for fallback if no useSyncExternalStore()
+      ],
+      // Latest with GC:
+      [
+        'recoil_hamt_2020',
+        'recoil_sync_external_store',
+        'recoil_suppress_rerender_in_callback',
+        'recoil_memory_managament_2020',
+        'recoil_release_on_cascading_update_killswitch_2021',
+      ],
+      // Experimental mode for useTransition() support:
+      // ['recoil_hamt_2020', 'recoil_concurrent_legacy'],
+    ];
 
 /**
  * GK combinations to exclude in OSS, presumably because these combinations pass

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -140,14 +140,17 @@ function renderConcurrentReactRoot<Props>(
   createRoot(container).render(contents);
 }
 
-function renderUnwrappedElements(elements: ?React.Node): HTMLDivElement {
-  const container = document.createElement('div');
+function renderUnwrappedElements(
+  elements: ?React.Node,
+  container?: ?HTMLDivElement,
+): HTMLDivElement {
+  const div = container ?? document.createElement('div');
   const renderReactRoot = isConcurrentModeEnabled()
     ? renderConcurrentReactRoot
     : renderLegacyReactRoot;
   act(() => {
     renderReactRoot(
-      container,
+      div,
       isStrictModeEnabled() ? (
         <StrictMode>{elements}</StrictMode>
       ) : (
@@ -155,10 +158,13 @@ function renderUnwrappedElements(elements: ?React.Node): HTMLDivElement {
       ),
     );
   });
-  return container;
+  return div;
 }
 
-function renderElements(elements: ?React.Node): HTMLDivElement {
+function renderElements(
+  elements: ?React.Node,
+  container?: ?HTMLDivElement,
+): HTMLDivElement {
   return renderUnwrappedElements(
     <RecoilRoot>
       {/* eslint-disable-next-line fb-www/no-null-fallback-for-error-boundary */}
@@ -166,11 +172,12 @@ function renderElements(elements: ?React.Node): HTMLDivElement {
         <React.Suspense fallback="loading">{elements}</React.Suspense>
       </ErrorBoundary>
     </RecoilRoot>,
+    container,
   );
 }
 
 function renderElementsWithSuspenseCount(
-  elements: ?React.Node,
+  elements: React.Node,
 ): [HTMLDivElement, JestMockFn<[], void>] {
   const suspenseCommit = jest.fn(() => {});
   function Fallback() {


### PR DESCRIPTION
Summary: Test that `onSet()` is called and `setSelf()` works when atoms are initialized first via Snapshot and then used from hooks in a `<RecoilRoot>`.  This includes when initializing atoms via `initializeState` prop in `<RecoilRoot>` which uses a Snapshot.  Also make sure the "current" value provided in the updater form of `setSelf()` reflects the current initialized value.

Differential Revision: D33372676

