### PR TITLE
Rename effects_UNSTABLE to effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
 - Fix transitive selector refresh for some cases (#1409)
 - Atom Effects
+  - Rename option from `effects_UNSTABLE` to just `effects` as the interface is mostly stabilizing (#1520)
   - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
   - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
   - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@
 ### Other Fixes and Optimizations
 - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
 - Fix transitive selector refresh for some cases (#1409)
-- Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
-- Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
-- Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
+- Atom Effects
+  - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
+  - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
+  - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
+  - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix transitive selector refresh for some cases (#1409)
 - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
 - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
+- Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -85,12 +85,12 @@ test('Write to storage', async () => {
   const atomA = atom({
     key: 'recoil-sync write A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync write B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
   const ignoreAtom = atom({
     key: 'recoil-sync write ignore',
@@ -134,12 +134,12 @@ test('Write to multiple storages', async () => {
   const atomA = atom({
     key: 'recoil-sync multiple storage A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({storeKey: 'A', refine: string()})],
+    effects: [syncEffect({storeKey: 'A', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync multiple storage B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({storeKey: 'B', refine: string()})],
+    effects: [syncEffect({storeKey: 'B', refine: string()})],
   });
 
   const storageA = new Map();
@@ -171,17 +171,17 @@ test('Read from storage', async () => {
   const atomA = atom({
     key: 'recoil-sync read A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync read B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
   const atomC = atom({
     key: 'recoil-sync read C',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
 
   const storage = new Map([
@@ -205,7 +205,7 @@ test('Read from storage async', async () => {
   const atomA = atom({
     key: 'recoil-sync read async',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
 
   const storage = new Map([['recoil-sync read async', Promise.resolve('A')]]);
@@ -226,12 +226,12 @@ test('Read from storage error', async () => {
   const atomA = atom({
     key: 'recoil-sync read error A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync read error B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({refine: string(), actionOnFailure_UNSTABLE: 'defaultValue'}),
     ],
   });
@@ -239,13 +239,13 @@ test('Read from storage error', async () => {
     key: 'recoil-sync read error C',
     default: 'DEFAULT',
     // <TestRecoilSync> will throw error if the key is "error"
-    effects_UNSTABLE: [syncEffect({itemKey: 'error', refine: string()})],
+    effects: [syncEffect({itemKey: 'error', refine: string()})],
   });
   const atomD = atom({
     key: 'recoil-sync read error D',
     default: 'DEFAULT',
     // <TestRecoilSync> will throw error if the key is "error"
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         itemKey: 'error',
         refine: string(),
@@ -256,7 +256,7 @@ test('Read from storage error', async () => {
   const atomE = atom({
     key: 'recoil-sync read error E',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: string(),
       }),
@@ -265,7 +265,7 @@ test('Read from storage error', async () => {
   const atomF = atom({
     key: 'recoil-sync read error F',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: string(),
         actionOnFailure_UNSTABLE: 'defaultValue',
@@ -314,32 +314,32 @@ test('Read nullable', async () => {
   const atomUndefinedA = atom({
     key: 'recoil-sync read undefined A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: literal(undefined)})],
+    effects: [syncEffect({refine: literal(undefined)})],
   });
   const atomUndefinedB = atom({
     key: 'recoil-sync read undefined B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: literal(undefined)})],
+    effects: [syncEffect({refine: literal(undefined)})],
   });
   const atomUndefinedC = atom({
     key: 'recoil-sync read undefined C',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: literal(undefined)})],
+    effects: [syncEffect({refine: literal(undefined)})],
   });
   const atomNullA = atom({
     key: 'recoil-sync read null A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: literal(null)})],
+    effects: [syncEffect({refine: literal(null)})],
   });
   const atomNullB = atom({
     key: 'recoil-sync read null B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: literal(null)})],
+    effects: [syncEffect({refine: literal(null)})],
   });
   const atomNullC = atom({
     key: 'recoil-sync read null C',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: literal(null)})],
+    effects: [syncEffect({refine: literal(null)})],
   });
 
   const storage = new Map([
@@ -372,17 +372,17 @@ test('Abort read', async () => {
   const atomA = atom({
     key: 'recoil-sync abort read A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync abort read B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
   const atomC = atom({
     key: 'recoil-sync abort read C',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string()})],
+    effects: [syncEffect({refine: string()})],
   });
 
   const storage = new Map([
@@ -410,34 +410,22 @@ test('Abort vs reset', async () => {
   const atomA = atom({
     key: 'recoil-sync abort vs reset A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
-      ({setSelf}) => setSelf('INIT'),
-      syncEffect({refine: string()}),
-    ],
+    effects: [({setSelf}) => setSelf('INIT'), syncEffect({refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync abort vs reset B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
-      ({setSelf}) => setSelf('INIT'),
-      syncEffect({refine: string()}),
-    ],
+    effects: [({setSelf}) => setSelf('INIT'), syncEffect({refine: string()})],
   });
   const atomC = atom({
     key: 'recoil-sync abort vs reset C',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
-      ({setSelf}) => setSelf('INIT'),
-      syncEffect({refine: string()}),
-    ],
+    effects: [({setSelf}) => setSelf('INIT'), syncEffect({refine: string()})],
   });
   const atomD = atom({
     key: 'recoil-sync abort vs reset D',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
-      ({setSelf}) => setSelf('INIT'),
-      syncEffect({refine: string()}),
-    ],
+    effects: [({setSelf}) => setSelf('INIT'), syncEffect({refine: string()})],
   });
 
   const storage = new Map([
@@ -470,7 +458,7 @@ test('Read from storage upgrade - multiple effects', async () => {
   const atomA = atom<string>({
     key: 'recoil-sync fail validation - multi',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       // No matching sync effect
       syncEffect({refine: string(), actionOnFailure_UNSTABLE: 'defaultValue'}),
     ],
@@ -480,7 +468,7 @@ test('Read from storage upgrade - multiple effects', async () => {
   const atomB = atom<string>({
     key: 'recoil-sync upgrade number - multi',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       // This sync effect is ignored
       syncEffect({
         refine: asType(string(), () => 'IGNORE'),
@@ -502,7 +490,7 @@ test('Read from storage upgrade - multiple effects', async () => {
   const atomC = atom<number>({
     key: 'recoil-sync upgrade string - multi',
     default: 0,
-    effects_UNSTABLE: [
+    effects: [
       // This sync effect is ignored
       syncEffect({
         refine: asType(number(), () => 999),
@@ -524,7 +512,7 @@ test('Read from storage upgrade - multiple effects', async () => {
   const atomD = atom<string>({
     key: 'recoil-sync upgrade async - multi',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: asType(number(), num => `${num}`),
         actionOnFailure_UNSTABLE: 'defaultValue',
@@ -559,7 +547,7 @@ test('Read from storage upgrade', async () => {
   const atomA = atom<string>({
     key: 'recoil-sync fail validation',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       // No matching sync effect
       syncEffect({refine: string(), actionOnFailure_UNSTABLE: 'defaultValue'}),
     ],
@@ -569,7 +557,7 @@ test('Read from storage upgrade', async () => {
   const atomB = atom<string>({
     key: 'recoil-sync upgrade number',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: match(
           asType(string(), () => 'IGNORE'), // This rule is ignored
@@ -584,7 +572,7 @@ test('Read from storage upgrade', async () => {
   const atomC = atom<number>({
     key: 'recoil-sync upgrade string',
     default: 0,
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: match(
           asType(number(), () => 999), // This rule is ignored
@@ -599,7 +587,7 @@ test('Read from storage upgrade', async () => {
   const atomD = atom<string>({
     key: 'recoil-sync upgrade async',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: match(
           string(),
@@ -635,7 +623,7 @@ test('Read/Write from storage upgrade', async () => {
   const atomA = atom<string>({
     key: 'recoil-sync read/write upgrade type',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: match(
           string(),
@@ -647,7 +635,7 @@ test('Read/Write from storage upgrade', async () => {
   const atomB = atom({
     key: 'recoil-sync read/write upgrade key',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({itemKey: 'OLD KEY', refine: string()}),
       syncEffect({itemKey: 'NEW KEY', refine: string()}),
     ],
@@ -655,7 +643,7 @@ test('Read/Write from storage upgrade', async () => {
   const atomC = atom({
     key: 'recoil-sync read/write upgrade storage',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({refine: string()}),
       syncEffect({storeKey: 'OTHER_SYNC', refine: string()}),
     ],
@@ -710,12 +698,12 @@ test('Listen to storage', async () => {
   const atomA = atom({
     key: 'recoil-sync listen',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({storeKey: 'SYNC_1', refine: string()})],
+    effects: [syncEffect({storeKey: 'SYNC_1', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync listen to multiple keys',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({storeKey: 'SYNC_1', itemKey: 'KEY A', refine: string()}),
       syncEffect({storeKey: 'SYNC_1', itemKey: 'KEY B', refine: string()}),
     ],
@@ -723,7 +711,7 @@ test('Listen to storage', async () => {
   const atomC = atom({
     key: 'recoil-sync listen to multiple storage',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({storeKey: 'SYNC_1', refine: string()}),
       syncEffect({storeKey: 'SYNC_2', refine: string()}),
     ],
@@ -887,12 +875,12 @@ test('Persist on read', async () => {
   const atomA = atom({
     key: 'recoil-sync persist on read default',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({refine: string(), syncDefault: true})],
+    effects: [syncEffect({refine: string(), syncDefault: true})],
   });
   const atomB = atom({
     key: 'recoil-sync persist on read init',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) => setSelf('INIT_BEFORE'),
       syncEffect({refine: string(), syncDefault: true}),
       ({setSelf}) => setSelf('INIT_AFTER'),
@@ -927,12 +915,12 @@ test('Persist on read - async', async () => {
     default: new Promise(resolve => {
       resolveA = resolve;
     }),
-    effects_UNSTABLE: [syncEffect({refine: string(), syncDefault: true})],
+    effects: [syncEffect({refine: string(), syncDefault: true})],
   });
   const atomB = atom({
     key: 'recoil-sync persist on read init async',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) =>
         setSelf(
           new Promise(resolve => {
@@ -1000,17 +988,17 @@ test('Sync based on component props', async () => {
   const atomA = atom({
     key: 'recoil-sync from props spam',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({itemKey: 'spam', refine: string()})],
+    effects: [syncEffect({itemKey: 'spam', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-sync from props eggs',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({itemKey: 'eggs', refine: string()})],
+    effects: [syncEffect({itemKey: 'eggs', refine: string()})],
   });
   const atomC = atom({
     key: 'recoil-sync from props default',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({itemKey: 'default', refine: string()})],
+    effects: [syncEffect({itemKey: 'default', refine: string()})],
   });
 
   const container = renderElements(
@@ -1029,7 +1017,7 @@ test('Sync Atom Family', async () => {
   const atoms = atomFamily({
     key: 'recoil-sync atom family',
     default: 'DEFAULT',
-    effects_UNSTABLE: param => [syncEffect({itemKey: param, refine: string()})],
+    effects: param => [syncEffect({itemKey: param, refine: string()})],
   });
 
   const storage = new Map([
@@ -1054,7 +1042,7 @@ describe('Complex Mappings', () => {
     const atomA = atom({
       key: 'recoil-sync write multiple A',
       default: 'A',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({
           itemKey: 'a', // UNUSED
           refine: string(),
@@ -1076,7 +1064,7 @@ describe('Complex Mappings', () => {
     const atomB = atom({
       key: 'recoil-sync write multiple B',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({
           itemKey: 'b', // UNUSED
           refine: string(),
@@ -1147,7 +1135,7 @@ describe('Complex Mappings', () => {
     const myAtom = atom({
       key: 'recoil-sync read while writing',
       default: 'SELF',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({
           refine: string(),
           write: ({write, read}, newValue) => {
@@ -1184,7 +1172,7 @@ describe('Complex Mappings', () => {
     const myAtom = atom({
       key: 'recoil-sync read from multiple',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({
           refine: dict(number()),
           read: ({read}) => ({a: read('a'), b: read('b')}),
@@ -1231,7 +1219,7 @@ test('Reading before sync hook', async () => {
   const atoms = atomFamily({
     key: 'recoil-sync order',
     default: 'DEFAULT',
-    effects_UNSTABLE: param => [syncEffect({itemKey: param, refine: string()})],
+    effects: param => [syncEffect({itemKey: param, refine: string()})],
   });
 
   function SyncOrder() {
@@ -1268,23 +1256,19 @@ test('Sibling <RecoilRoot>', async () => {
   const atomA = atom({
     key: 'recoil-sync sibling root A',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
-      syncEffect({itemKey: 'a', refine: string(), syncDefault: true}),
-    ],
+    effects: [syncEffect({itemKey: 'a', refine: string(), syncDefault: true})],
   });
 
   const atomB = atom({
     key: 'recoil-sync sibling root B',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
-      syncEffect({itemKey: 'b', refine: string(), syncDefault: true}),
-    ],
+    effects: [syncEffect({itemKey: 'b', refine: string(), syncDefault: true})],
   });
 
   const atomShared = atom({
     key: 'recoil-sync sibling root shared',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({itemKey: 'shared', refine: string(), syncDefault: true}),
     ],
   });
@@ -1361,7 +1345,7 @@ test('Unregister store and atoms', () => {
   const myAtom = atom({
     key,
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       ({storeID}) => {
         expect(registries_FOR_TESTING.getAtomRegistry(storeID).has(key)).toBe(
           false,

--- a/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
@@ -38,12 +38,12 @@ describe('Test URL Persistence', () => {
     const atomA = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [urlSyncEffect({itemKey: 'a', refine: string()})],
+      effects: [urlSyncEffect({itemKey: 'a', refine: string()})],
     });
     const atomB = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [urlSyncEffect({itemKey: 'b', refine: string()})],
+      effects: [urlSyncEffect({itemKey: 'b', refine: string()})],
     });
     const ignoreAtom = atom({
       key: nextKey(),
@@ -110,16 +110,12 @@ describe('Test URL Persistence', () => {
     const atomA = atom({
       key: 'recoil-url-sync multiple param A',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
-        syncEffect({storeKey: 'A', itemKey: 'x', refine: string()}),
-      ],
+      effects: [syncEffect({storeKey: 'A', itemKey: 'x', refine: string()})],
     });
     const atomB = atom({
       key: 'recoil-url-sync multiple param B',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
-        syncEffect({storeKey: 'B', itemKey: 'x', refine: string()}),
-      ],
+      effects: [syncEffect({storeKey: 'B', itemKey: 'x', refine: string()})],
     });
 
     const [AtomA, setA] = componentThatReadsAndWritesAtom(atomA);
@@ -145,17 +141,17 @@ describe('Test URL Persistence', () => {
     const atomA = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({itemKey: 'a', refine: string()})],
+      effects: [syncEffect({itemKey: 'a', refine: string()})],
     });
     const atomB = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({itemKey: 'b', refine: string()})],
+      effects: [syncEffect({itemKey: 'b', refine: string()})],
     });
     const atomC = atom({
       key: nextKey(),
       default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({itemKey: 'c', refine: string()})],
+      effects: [syncEffect({itemKey: 'c', refine: string()})],
     });
 
     history.replaceState(
@@ -201,7 +197,7 @@ describe('Test URL Persistence', () => {
     const atomA = atom<string>({
       key: 'recoil-url-sync fail validation',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         // No matching sync effect
         syncEffect({
           refine: string(),
@@ -214,7 +210,7 @@ describe('Test URL Persistence', () => {
     const atomB = atom<string>({
       key: 'recoil-url-sync upgrade number',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({
           refine: match(
             string(),
@@ -229,7 +225,7 @@ describe('Test URL Persistence', () => {
     const atomC = atom<number>({
       key: 'recoil-url-sync upgrade string',
       default: 0,
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({
           refine: match(
             number(),
@@ -274,7 +270,7 @@ describe('Test URL Persistence', () => {
     const atomA = atom<string>({
       key: 'recoil-url-sync read/write upgrade type',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({
           refine: match(
             string(),
@@ -286,7 +282,7 @@ describe('Test URL Persistence', () => {
     const atomB = atom({
       key: 'recoil-url-sync read/write upgrade key',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({itemKey: 'OLD KEY', refine: string()}),
         syncEffect({itemKey: 'NEW KEY', refine: string()}),
       ],
@@ -294,7 +290,7 @@ describe('Test URL Persistence', () => {
     const atomC = atom({
       key: 'recoil-url-sync read/write upgrade storage',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         syncEffect({refine: string()}),
         syncEffect({storeKey: 'SYNC_2', refine: string()}),
       ],
@@ -374,12 +370,12 @@ describe('Test URL Persistence', () => {
     const atomA = atom({
       key: 'recoil-url-sync persist on read default',
       default: 'DEFAULT',
-      effects_UNSTABLE: [syncEffect({refine: string(), syncDefault: true})],
+      effects: [syncEffect({refine: string(), syncDefault: true})],
     });
     const atomB = atom({
       key: 'recoil-url-sync persist on read init',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) => setSelf('INIT_BEFORE'),
         syncEffect({refine: string(), syncDefault: true}),
         ({setSelf}) => setSelf('INIT_AFTER'),

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -30,7 +30,7 @@ test('Upgrade item ID', async () => {
   const myAtom = atom({
     key: 'recoil-url-sync upgrade itemID',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({
         refine: string(),
         itemKey: 'new_key',
@@ -92,7 +92,7 @@ test('Many items to one atom', async () => {
   const myAtom = atom({
     key: 'recoil-url-sync many-to-one',
     default: {},
-    effects_UNSTABLE: [manyToOneSyncEffct()],
+    effects: [manyToOneSyncEffct()],
   });
 
   history.replaceState(null, '', encodeURL([[loc, {foo: 1}]]));
@@ -145,13 +145,13 @@ test('One item to multiple atoms', async () => {
   const fooAtom = atom({
     key: 'recoil-url-sync one-to-many foo',
     default: 0,
-    effects_UNSTABLE: [oneToManySyncEffect('foo')],
+    effects: [oneToManySyncEffect('foo')],
   });
 
   const barAtom = atom({
     key: 'recoil-url-sync one-to-many bar',
     default: null,
-    effects_UNSTABLE: [oneToManySyncEffect('bar')],
+    effects: [oneToManySyncEffect('bar')],
   });
 
   history.replaceState(null, '', encodeURL([[loc, {compound: {foo: 1}}]]));
@@ -214,7 +214,7 @@ test('One item to atom family', async () => {
   const myAtoms = atomFamily({
     key: 'recoil-rul-sync one-to-family',
     default: null,
-    effects_UNSTABLE: prop => [oneToFamilyEffect(prop)],
+    effects: prop => [oneToFamilyEffect(prop)],
   });
 
   history.replaceState(null, '', encodeURL([[loc, {compound: {foo: 1}}]]));

--- a/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
@@ -53,17 +53,17 @@ test('Push URLs in mock history', async () => {
   const atomA = atom({
     key: 'recoil-url-sync replace',
     default: 'DEFAULT',
-    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'replace'})],
+    effects: [urlSyncEffect({refine: string(), history: 'replace'})],
   });
   const atomB = atom({
     key: 'recoil-url-sync push',
     default: 'DEFAULT',
-    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'push'})],
+    effects: [urlSyncEffect({refine: string(), history: 'push'})],
   });
   const atomC = atom({
     key: 'recoil-url-sync push 2',
     default: 'DEFAULT',
-    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'push'})],
+    effects: [urlSyncEffect({refine: string(), history: 'push'})],
   });
 
   const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);

--- a/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
@@ -31,48 +31,44 @@ const {
 const atomUndefined = atom({
   key: 'void',
   default: undefined,
-  effects_UNSTABLE: [
-    syncEffect({refine: literal(undefined), syncDefault: true}),
-  ],
+  effects: [syncEffect({refine: literal(undefined), syncDefault: true})],
 });
 const atomNull = atom({
   key: 'null',
   default: null,
-  effects_UNSTABLE: [syncEffect({refine: literal(null), syncDefault: true})],
+  effects: [syncEffect({refine: literal(null), syncDefault: true})],
 });
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
-  effects_UNSTABLE: [syncEffect({refine: boolean(), syncDefault: true})],
+  effects: [syncEffect({refine: boolean(), syncDefault: true})],
 });
 const atomNumber = atom({
   key: 'number',
   default: 123,
-  effects_UNSTABLE: [syncEffect({refine: number(), syncDefault: true})],
+  effects: [syncEffect({refine: number(), syncDefault: true})],
 });
 const atomString = atom({
   key: 'string',
   default: 'STRING',
-  effects_UNSTABLE: [syncEffect({refine: string(), syncDefault: true})],
+  effects: [syncEffect({refine: string(), syncDefault: true})],
 });
 const atomArray = atom({
   key: 'array',
   default: [1, 'a'],
-  effects_UNSTABLE: [
-    syncEffect({refine: tuple(number(), string()), syncDefault: true}),
-  ],
+  effects: [syncEffect({refine: tuple(number(), string()), syncDefault: true})],
 });
 const atomObject = atom({
   key: 'object',
   default: {foo: [1, 2]},
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({refine: object({foo: array(number())}), syncDefault: true}),
   ],
 });
 const atomDate = atom({
   key: 'date',
   default: new Date('October 26, 1985'),
-  effects_UNSTABLE: [syncEffect({refine: jsonDate(), syncDefault: true})],
+  effects: [syncEffect({refine: jsonDate(), syncDefault: true})],
 });
 
 async function testJSON(loc, contents, beforeURL, afterURL) {

--- a/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
@@ -31,12 +31,12 @@ test('Listen to URL changes', async () => {
   const atomA = atom({
     key: 'recoil-url-sync listen',
     default: 'DEFAULT',
-    effects_UNSTABLE: [syncEffect({storeKey: 'foo', refine: string()})],
+    effects: [syncEffect({storeKey: 'foo', refine: string()})],
   });
   const atomB = atom({
     key: 'recoil-url-sync listen to multiple keys',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({storeKey: 'foo', itemKey: 'KEY A', refine: string()}),
       syncEffect({storeKey: 'foo', itemKey: 'KEY B', refine: string()}),
     ],
@@ -44,7 +44,7 @@ test('Listen to URL changes', async () => {
   const atomC = atom({
     key: 'recoil-url-sync listen to multiple storage',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       syncEffect({storeKey: 'foo', refine: string()}),
       syncEffect({storeKey: 'bar', refine: string()}),
     ],

--- a/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
@@ -29,17 +29,17 @@ test('Push URLs in browser history', async () => {
   const atomA = atom({
     key: 'recoil-url-sync replace',
     default: 'DEFAULT',
-    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'replace'})],
+    effects: [urlSyncEffect({refine: string(), history: 'replace'})],
   });
   const atomB = atom({
     key: 'recoil-url-sync push',
     default: 'DEFAULT',
-    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'push'})],
+    effects: [urlSyncEffect({refine: string(), history: 'push'})],
   });
   const atomC = atom({
     key: 'recoil-url-sync push 2',
     default: 'DEFAULT',
-    effects_UNSTABLE: [urlSyncEffect({refine: string(), history: 'push'})],
+    effects: [urlSyncEffect({refine: string(), history: 'push'})],
   });
 
   const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -41,58 +41,54 @@ class MyClass {
 const atomNull = atom({
   key: 'null',
   default: null,
-  effects_UNSTABLE: [syncEffect({refine: literal(null), syncDefault: true})],
+  effects: [syncEffect({refine: literal(null), syncDefault: true})],
 });
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
-  effects_UNSTABLE: [syncEffect({refine: boolean(), syncDefault: true})],
+  effects: [syncEffect({refine: boolean(), syncDefault: true})],
 });
 const atomNumber = atom({
   key: 'number',
   default: 123,
-  effects_UNSTABLE: [syncEffect({refine: number(), syncDefault: true})],
+  effects: [syncEffect({refine: number(), syncDefault: true})],
 });
 const atomString = atom({
   key: 'string',
   default: 'STRING',
-  effects_UNSTABLE: [syncEffect({refine: string(), syncDefault: true})],
+  effects: [syncEffect({refine: string(), syncDefault: true})],
 });
 const atomArray = atom({
   key: 'array',
   default: [1, 'a'],
-  effects_UNSTABLE: [
-    syncEffect({refine: tuple(number(), string()), syncDefault: true}),
-  ],
+  effects: [syncEffect({refine: tuple(number(), string()), syncDefault: true})],
 });
 const atomObject = atom({
   key: 'object',
   default: {foo: [1, 2]},
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({refine: object({foo: array(number())}), syncDefault: true}),
   ],
 });
 const atomSet = atom({
   key: 'set',
   default: new Set([1, 2]),
-  effects_UNSTABLE: [syncEffect({refine: set(number()), syncDefault: true})],
+  effects: [syncEffect({refine: set(number()), syncDefault: true})],
 });
 const atomMap = atom({
   key: 'map',
   default: new Map([[1, 'a']]),
-  effects_UNSTABLE: [
-    syncEffect({refine: map(number(), string()), syncDefault: true}),
-  ],
+  effects: [syncEffect({refine: map(number(), string()), syncDefault: true})],
 });
 const atomDate = atom({
   key: 'date',
   default: new Date('October 26, 1985'),
-  effects_UNSTABLE: [syncEffect({refine: date(), syncDefault: true})],
+  effects: [syncEffect({refine: date(), syncDefault: true})],
 });
 const atomUser = atom({
   key: 'user',
   default: new MyClass('CUSTOM'),
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({
       refine: custom(x => (x instanceof MyClass ? x : null)),
       syncDefault: true,
@@ -102,7 +98,7 @@ const atomUser = atom({
 const atomWithFallback = atom({
   key: 'withFallback',
   default: selector({key: 'fallback selector', get: () => 'FALLBACK'}),
-  effects_UNSTABLE: [syncEffect({refine: string(), syncDefault: true})],
+  effects: [syncEffect({refine: string(), syncDefault: true})],
 });
 
 const HANDLERS = [

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransitJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransitJSON-test.js
@@ -23,28 +23,28 @@ const {array, boolean, number, object, string, tuple} = require('refine');
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({storeKey: 'json', refine: boolean(), syncDefault: true}),
   ],
 });
 const atomNumber = atom({
   key: 'number',
   default: 123,
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({storeKey: 'json', refine: number(), syncDefault: true}),
   ],
 });
 const atomString = atom({
   key: 'string',
   default: 'STRING',
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({storeKey: 'json', refine: string(), syncDefault: true}),
   ],
 });
 const atomArray = atom({
   key: 'array',
   default: [1, 'a'],
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({
       storeKey: 'transit',
       refine: tuple(number(), string()),
@@ -55,7 +55,7 @@ const atomArray = atom({
 const atomObject = atom({
   key: 'object',
   default: {foo: [1, 2]},
-  effects_UNSTABLE: [
+  effects: [
     syncEffect({
       storeKey: 'transit',
       refine: object({foo: array(number())}),

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -88,13 +88,13 @@ function initializeNodeIfNewToStore(
   if (storeState.nodeCleanupFunctions.has(key)) {
     return;
   }
-  const config = getNode(key);
+  const node = getNode(key);
   const retentionCleanup = initializeRetentionForNode(
     store,
     key,
-    config.retainedBy,
+    node.retainedBy,
   );
-  const nodeCleanup = config.init(store, treeState, trigger);
+  const nodeCleanup = node.init(store, treeState, trigger);
   storeState.nodeCleanupFunctions.set(key, () => {
     nodeCleanup();
     retentionCleanup();

--- a/packages/recoil/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_RecoilRoot-test.js
@@ -106,7 +106,7 @@ describe('initializeState', () => {
       const myAtom = atom<string>({
         key: 'RecoilRoot - initializeState - atom effects',
         default: 'DEFAULT',
-        effects_UNSTABLE: [
+        effects: [
           ({setSelf}) => {
             effectRan++;
             setSelf('EFFECT');
@@ -152,7 +152,7 @@ describe('initializeState', () => {
       const myAtom = atom({
         key: 'RecoilRoot - initializeState - onSet',
         default: 0,
-        effects_UNSTABLE: [
+        effects: [
           ({onSet, setSelf}) => {
             onSet(value => {
               setValues.push(value);

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -501,7 +501,7 @@ describe('Atom effects', () => {
     const myAtom = atom({
       key: 'snapshot effects',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) => {
           effectsRefCount++;
           setSelf('INIT');
@@ -532,7 +532,7 @@ describe('Atom effects', () => {
     const myAtom = atom({
       key: 'snapshot effects',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) => {
           effectsRefCount++;
           setSelf('INIT');

--- a/packages/recoil/hooks/Recoil_useRecoilBridgeAcrossReactRoots.js
+++ b/packages/recoil/hooks/Recoil_useRecoilBridgeAcrossReactRoots.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+const {reactMode} = require('../core/Recoil_ReactMode');
 const {RecoilRoot, useStoreRef} = require('../core/Recoil_RecoilRoot');
 const React = require('react');
 const {useMemo} = require('react');
@@ -17,6 +18,14 @@ const {useMemo} = require('react');
 export type RecoilBridge = React.AbstractComponent<{children: React.Node}>;
 
 function useRecoilBridgeAcrossReactRoots(): RecoilBridge {
+  // The test fails when using useMutableSource(), but only if act() is used
+  // for the nested root.  So, this may only be a testing environment issue.
+  if (reactMode().mode === 'MUTABLE_SOURCE') {
+    // eslint-disable-next-line fb-www/no-console
+    console.warn(
+      'Warning: There are known issues using useRecoilBridgeAcrossReactRoots() in recoil_mutable_source rendering mode.  Please consider upgrading to recoil_sync_external_store mode.',
+    );
+  }
   const store = useStoreRef().current;
   return useMemo(() => {
     // eslint-disable-next-line no-shadow

--- a/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -237,7 +237,7 @@ testRecoil(
     const myAtom = atom({
       key: 'gotoSnapshot effect',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         () => {
           init++;
         },

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -387,7 +387,7 @@ describe('Atom Effects', () => {
       const atomWithEffect = atom({
         key: 'atomWithEffect',
         default: 0,
-        effects_UNSTABLE: [
+        effects: [
           () => {
             numTimesEffectInit++;
           },
@@ -426,7 +426,7 @@ describe('Atom Effects', () => {
       const atomWithEffect = atom({
         key: 'atomWithEffect2',
         default: 0,
-        effects_UNSTABLE: [
+        effects: [
           () => {
             numTimesEffectInit++;
           },
@@ -462,7 +462,7 @@ describe('Atom Effects', () => {
     const myAtom = atom({
       key: 'useRecoilCallback - atom effect - onSet',
       default: 0,
-      effects_UNSTABLE: [
+      effects: [
         ({onSet, setSelf}) => {
           onSet(value => {
             setValues.push(value);

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -261,7 +261,7 @@ testRecoil('Snapshot auto-release', async ({gks}) => {
   const rootFirstAtom = atom({
     key: 'useRecoilSnapshot auto-release root-first',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) => {
         rootFirstCnt++;
         setSelf('ROOT');
@@ -276,7 +276,7 @@ testRecoil('Snapshot auto-release', async ({gks}) => {
   const snapshotFirstAtom = atom({
     key: 'useRecoilSnapshot auto-release snapshot-first',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) => {
         snapshotFirstCnt++;
         setSelf('SNAPSHOT FIRST');
@@ -291,7 +291,7 @@ testRecoil('Snapshot auto-release', async ({gks}) => {
   const snapshotOnlyAtom = atom({
     key: 'useRecoilSnapshot auto-release snapshot-only',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) => {
         snapshotOnlyCnt++;
         setSelf('SNAPSHOT ONLY');
@@ -306,7 +306,7 @@ testRecoil('Snapshot auto-release', async ({gks}) => {
   const rootOnlyAtom = atom({
     key: 'useRecoilSnapshot auto-release root-only',
     default: 'DEFAULT',
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) => {
         rootOnlyCnt++;
         setSelf('RETAIN');

--- a/packages/recoil/hooks/__tests__/Recoil_useTransaction-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useTransaction-test.js
@@ -99,7 +99,7 @@ describe('Atom Effects', () => {
       const atomWithEffect = atom({
         key: 'atom effect first get transaction',
         default: 'DEFAULT',
-        effects_UNSTABLE: [
+        effects: [
           ({trigger}) => {
             expect(trigger).toEqual('get');
             numTimesEffectInit++;
@@ -135,7 +135,7 @@ describe('Atom Effects', () => {
   //     const atomWithEffect = atom({
   //       key: 'atom effect first set transaction',
   //       default: 'DEFAULT',
-  //       effects_UNSTABLE: [
+  //       effects: [
   //         ({trigger}) => {
   //           expect(trigger).toEqual('set');
   //           numTimesEffectInit++;
@@ -163,7 +163,7 @@ describe('Atom Effects', () => {
     const atomWithEffect = atom({
       key: 'atom effect init transaction',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) => {
           setSelf('INIT');
           numTimesEffectInit++;
@@ -197,7 +197,7 @@ describe('Atom Effects', () => {
       const atomWithEffect = atom({
         key: 'useTransaction effect first get transaction',
         default: 0,
-        effects_UNSTABLE: [
+        effects: [
           () => {
             numTimesEffectInit++;
           },
@@ -238,7 +238,7 @@ describe('Atom Effects', () => {
       const atomWithEffect = atom({
         key: 'atom effect first get root',
         default: 0,
-        effects_UNSTABLE: [
+        effects: [
           () => {
             numTimesEffectInit++;
           },

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -308,12 +308,11 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       const setSelf =
         (effect: AtomEffect<T>) => (valueOrUpdater: NewValueOrUpdater<T>) => {
           if (duringInit) {
+            const currentLoadable = getLoadable(node);
             const currentValue: T | DefaultValue =
-              initValue instanceof DefaultValue || isPromise(initValue)
-                ? defaultLoadable.state === 'hasValue'
-                  ? defaultLoadable.contents
-                  : DEFAULT_VALUE
-                : initValue;
+              currentLoadable.state === 'hasValue'
+                ? currentLoadable.contents
+                : DEFAULT_VALUE;
             initValue =
               typeof valueOrUpdater === 'function'
                 ? // cast to any because we can't restrict T from being a function without losing support for opaque types

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -229,17 +229,14 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
     initState: TreeState,
     trigger: Trigger,
   ): () => void {
+    liveStoresCount++;
     const cleanupAtom = () => {
       liveStoresCount--;
       cleanupEffectsByStore.get(store)?.forEach(cleanup => cleanup());
       cleanupEffectsByStore.delete(store);
     };
 
-    if (store.getState().nodeCleanupFunctions.has(key)) {
-      return cleanupAtom;
-    }
     store.getState().knownAtoms.add(key);
-    liveStoresCount++;
 
     // Setup async defaults to notify subscribers when they resolve
     if (defaultLoadable.state === 'loading') {

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -45,9 +45,12 @@ export type AtomFamilyOptions<T, P: Parameter> = $ReadOnly<{
     | Promise<T>
     | T
     | (P => T | RecoilValue<T> | Promise<T>),
-  effects_UNSTABLE?:
+  effects?:
     | $ReadOnlyArray<AtomEffect<T>>
     | (P => $ReadOnlyArray<AtomEffect<T>>),
+  //   effects_UNSTABLE?:
+  // | $ReadOnlyArray<AtomEffect<T>>
+  // | (P => $ReadOnlyArray<AtomEffect<T>>),
   retainedBy_UNSTABLE?: RetainedBy | (P => RetainedBy),
   cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction,
 
@@ -116,10 +119,12 @@ function atomFamily<T, P: Parameter>(
           ? options.retainedBy_UNSTABLE(params)
           : options.retainedBy_UNSTABLE,
 
-      effects_UNSTABLE:
-        typeof options.effects_UNSTABLE === 'function'
+      effects:
+        typeof options.effects === 'function'
+          ? options.effects(params)
+          : typeof options.effects_UNSTABLE === 'function'
           ? options.effects_UNSTABLE(params)
-          : options.effects_UNSTABLE,
+          : options.effects ?? options.effects_UNSTABLE,
 
       // prettier-ignore
       // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS: mapScopeRules(

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -279,11 +279,9 @@ function selector<T>(
 
   function selectorInit(store: Store): () => void {
     liveStoresCount++;
-    store.getState().knownSelectors.add(key); // FIXME remove knownSelectors?
+    store.getState().knownSelectors.add(key);
     return () => {
       liveStoresCount--;
-      store.getState().knownSelectors.delete(key);
-      executionInfoMap.delete(store);
     };
   }
 
@@ -1142,15 +1140,13 @@ function selector<T>(
   }
 
   function selectorPeek(store: Store, state: TreeState): ?Loadable<T> {
-    const cacheVal = cache.get(nodeKey => {
+    return cache.get(nodeKey => {
       invariant(typeof nodeKey === 'string', 'Cache nodeKey is type string');
 
       const peek = peekNodeLoadable(store, state, nodeKey);
 
       return peek?.contents;
     });
-
-    return cacheVal;
   }
 
   function selectorGet(store: Store, state: TreeState): Loadable<T> {

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -254,7 +254,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect error',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         () => {
           throw ERROR;
         },
@@ -279,7 +279,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({node, trigger, setSelf}) => {
           inited = true;
           expect(trigger).toEqual('get');
@@ -297,7 +297,7 @@ describe('Effects', () => {
     const myAtom = atom<string>({
       key: 'atom effect async default',
       default: Promise.resolve('RESOLVE'),
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf, onSet}) => {
           inited = true;
           setSelf('INIT');
@@ -326,7 +326,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect order',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) => {
           setSelf(x => {
             expect(x).toEqual('DEFAULT');
@@ -353,10 +353,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect reset',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
-        ({setSelf}) => setSelf('INIT'),
-        ({resetSelf}) => resetSelf(),
-      ],
+      effects: [({setSelf}) => setSelf('INIT'), ({resetSelf}) => resetSelf()],
     });
     expect(getValue(myAtom)).toEqual('DEFAULT');
   });
@@ -365,10 +362,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect init undefined',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
-        ({setSelf}) => setSelf('INIT'),
-        ({setSelf}) => setSelf(),
-      ],
+      effects: [({setSelf}) => setSelf('INIT'), ({setSelf}) => setSelf()],
     });
     expect(getValue(myAtom)).toEqual(undefined);
   });
@@ -378,7 +372,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect - init on set',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf, trigger}) => {
           inited++;
           setSelf('INIT');
@@ -401,7 +395,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect init set',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf, resetSelf}) => {
           setAtom = setSelf;
           resetAtom = resetSelf;
@@ -457,7 +451,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect init set promise',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf, onSet}) => {
           setSelf(
             new Promise(resolve => {
@@ -500,7 +494,7 @@ describe('Effects', () => {
       default: new Promise(resolve => {
         resolveDefault = resolve;
       }),
-      effects_UNSTABLE: [
+      effects: [
         ({onSet}) => {
           onSet(onSetHandler);
         },
@@ -538,7 +532,7 @@ describe('Effects', () => {
       const myAtom = atom({
         key: 'atom setSelf with set-updater',
         default: 'DEFAULT',
-        effects_UNSTABLE: [
+        effects: [
           ({setSelf, onSet}) => {
             onSet(newValue => {
               expect(set1).toBe(false);
@@ -568,7 +562,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect init reject promise',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf, onSet}) => {
           setSelf(
             new Promise((_resolve, reject) => {
@@ -598,7 +592,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect init overwrite promise',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf, onSet}) => {
           setSelf(
             new Promise(resolve => {
@@ -634,7 +628,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect abort promise init',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf, onSet}) => {
           setSelf(
             new Promise(resolve => {
@@ -664,7 +658,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect once per root',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) => {
           inited++;
           setSelf('INIT');
@@ -702,13 +696,13 @@ describe('Effects', () => {
     const atomA = atom({
       key: 'atom effect onSet A',
       default: 0,
-      effects_UNSTABLE: [({onSet}) => onSet(observer('a'))],
+      effects: [({onSet}) => onSet(observer('a'))],
     });
 
     const atomB = atom({
       key: 'atom effect onSet B',
       default: 0,
-      effects_UNSTABLE: [({onSet}) => onSet(observer('b'))],
+      effects: [({onSet}) => onSet(observer('b'))],
     });
 
     const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);
@@ -747,7 +741,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect onSet ordering',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({onSet}) => {
           onSet(() => {
             expect(set2).toBe(false);
@@ -803,12 +797,12 @@ describe('Effects', () => {
     const atomA = atom({
       key: 'atom effect onSte history A',
       default: 'DEFAULT_A',
-      effects_UNSTABLE: [historyEffect],
+      effects: [historyEffect],
     });
     const atomB = atom({
       key: 'atom effect onSte history B',
       default: 'DEFAULT_B',
-      effects_UNSTABLE: [historyEffect],
+      effects: [historyEffect],
     });
 
     const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);
@@ -849,7 +843,7 @@ describe('Effects', () => {
     const atomA = atom({
       key: 'atom effect cleanup - A',
       default: 'A',
-      effects_UNSTABLE: [
+      effects: [
         () => {
           refCountsA[0]++;
           return () => {
@@ -868,7 +862,7 @@ describe('Effects', () => {
     const atomB = atom({
       key: 'atom effect cleanup - B',
       default: 'B',
-      effects_UNSTABLE: [
+      effects: [
         () => {
           refCountsB[0]++;
           return () => {
@@ -944,7 +938,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effects onSet unsubscribe',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({onSet}) => {
           onSet(() => {
             onSetRan++;
@@ -1006,7 +1000,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect - concurrent update',
       default: 'DEFAULT',
-      effects_UNSTABLE: [({setSelf}) => setSelf('INIT')],
+      effects: [({setSelf}) => setSelf('INIT')],
     });
     const otherAtom = atom({
       key: 'atom effect - concurrent update / other atom',
@@ -1058,7 +1052,7 @@ describe('Effects', () => {
       const atomWithEffect = atom({
         key: 'atomWithEffect',
         default: 0,
-        effects_UNSTABLE: [
+        effects: [
           ({setSelf}) => {
             latestSetSelf = setSelf;
 
@@ -1103,7 +1097,7 @@ describe('Effects', () => {
       const myAtom = atom({
         key: 'atom effect - init from other atom',
         default: 'DEFAULT',
-        effects_UNSTABLE: [
+        effects: [
           ({node, setSelf, getLoadable, getInfo_UNSTABLE}) => {
             const otherValue = getLoadable(otherAtom).contents;
             expect(otherValue).toEqual('OTHER');
@@ -1129,7 +1123,7 @@ describe('Effects', () => {
       const myAtom = atom({
         key: 'atom effect - init from other atom async',
         default: 'DEFAULT',
-        effects_UNSTABLE: [
+        effects: [
           ({setSelf, getPromise}) => {
             const otherValue = getPromise(otherAtom);
             setSelf(otherValue);
@@ -1162,7 +1156,7 @@ describe('Effects', () => {
       const myAtom = atom({
         key: 'atom effect - async get',
         default: 'DEFAULT',
-        effects_UNSTABLE: [
+        effects: [
           // Test we can get default values
           ({node, getLoadable, getPromise, getInfo_UNSTABLE}) => {
             expect(getLoadable(node).contents).toEqual(
@@ -1209,7 +1203,7 @@ describe('Effects', () => {
       const asyncAtom = atom({
         key: 'atom effect - other atom async get',
         default: Promise.resolve('ASYNC_DEFAULT'),
-        effects_UNSTABLE: [
+        effects: [
           ({setSelf}) => void setSelf(Promise.resolve('ASYNC')),
           ({getPromise, getInfo_UNSTABLE}) => {
             expect(getInfo_UNSTABLE(asyncAtom).isSet).toBe(true);
@@ -1286,7 +1280,7 @@ describe('Effects', () => {
     const myAtom = atom({
       key: 'atom effect - storeID',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({storeID, setSelf}) => {
           effectStoreID = storeID;
           setSelf('INIT');
@@ -1372,7 +1366,7 @@ testRecoil('object is frozen when stored in atom', async () => {
   const initializedValueInAtom = atom({
     key: 'atom frozen initialized',
     default: {nested: 'DEFAULT'},
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) => setSelf({state: 'frozen', nested: {state: 'frozen'}}),
     ],
   });
@@ -1384,7 +1378,7 @@ testRecoil('object is frozen when stored in atom', async () => {
     {
       key: 'atom frozen initialized async',
       default: {state: 'DEFAULT', nested: {state: 'DEFAULT'}},
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) =>
           setSelf(
             Promise.resolve({state: 'frozen', nested: {state: 'frozen'}}),

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -396,6 +396,7 @@ describe('Effects', () => {
 
   testRecoil('async set', () => {
     let setAtom, resetAtom;
+    let effectRan = false;
 
     const myAtom = atom({
       key: 'atom effect init set',
@@ -405,7 +406,8 @@ describe('Effects', () => {
           setAtom = setSelf;
           resetAtom = resetSelf;
           setSelf(x => {
-            expect(x).toEqual('DEFAULT');
+            expect(x).toEqual(effectRan ? 'INIT' : 'DEFAULT');
+            effectRan = true;
             return 'INIT';
           });
         },

--- a/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -507,7 +507,7 @@ describe('Effects', () => {
     const myFamily = atomFamily<string, number>({
       key: 'atomFamily effect init',
       default: 'DEFAULT',
-      effects_UNSTABLE: [
+      effects: [
         ({setSelf}) => {
           inited++;
           setSelf('INIT');
@@ -536,7 +536,7 @@ describe('Effects', () => {
     const myFamily = atomFamily({
       key: 'atomFamily effect parameterized init',
       default: 'DEFAULT',
-      effects_UNSTABLE: param => [({setSelf}) => setSelf(param)],
+      effects: param => [({setSelf}) => setSelf(param)],
     });
 
     expect(get(myFamily(1))).toEqual(1);
@@ -549,7 +549,7 @@ describe('Effects', () => {
     const atoms = atomFamily({
       key: 'atomFamily effect cleanup',
       default: p => p,
-      effects_UNSTABLE: p => [
+      effects: p => [
         () => {
           refCounts[p]++;
           return () => {
@@ -603,7 +603,7 @@ describe('Effects', () => {
     const atoms = atomFamily({
       key: 'atomFamily effect - storeID',
       default: 'DEFAULT',
-      effects_UNSTABLE: rootKey => [
+      effects: rootKey => [
         ({storeID, setSelf}) => {
           expect(storeID).toEqual(storeIDs[rootKey]);
           setSelf(rootKey);

--- a/packages/recoil/recoil_values/__tests__/Recoil_atomWithFallback-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atomWithFallback-test.js
@@ -227,7 +227,7 @@ testRecoil('Effects', () => {
   const myAtom = atom<string>({
     key: 'atom with fallback effects init',
     default: myFallbackAtom,
-    effects_UNSTABLE: [
+    effects: [
       ({setSelf}) => {
         inited = true;
         setSelf('INIT');

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -49,6 +49,8 @@ const err = require('recoil-shared/util/Recoil_err');
 const ReactDOM = require('react-dom'); // @oss-only
 const StrictMode = React.StrictMode; // @oss-only
 
+const QUICK_TEST = false;
+
 // @fb-only: const IS_INTERNAL = true;
 const IS_INTERNAL = false; // @oss-only
 
@@ -363,46 +365,52 @@ const testGKs =
       });
     }
 
-    runTests({strictMode: false, concurrentMode: false});
-    runTests({strictMode: true, concurrentMode: false});
-    if (isConcurrentModeAvailable()) {
+    if (QUICK_TEST) {
       runTests({strictMode: false, concurrentMode: true});
-      // 2020-12-20: The internal <StrictMode> isn't yet enabled to run effects
-      // multiple times.  So, rely on GitHub CI actions to test this for now.
-      if (!IS_INTERNAL) {
-        runTests({strictMode: true, concurrentMode: true});
+    } else {
+      runTests({strictMode: false, concurrentMode: false});
+      runTests({strictMode: true, concurrentMode: false});
+      if (isConcurrentModeAvailable()) {
+        runTests({strictMode: false, concurrentMode: true});
+        // 2020-12-20: The internal <StrictMode> isn't yet enabled to run effects
+        // multiple times.  So, rely on GitHub CI actions to test this for now.
+        if (!IS_INTERNAL) {
+          runTests({strictMode: true, concurrentMode: true});
+        }
       }
     }
   };
 
-const WWW_GKS_TO_TEST = [
-  // OSS for React <18:
-  ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering
-  // Current internal default:
-  ['recoil_hamt_2020', 'recoil_mutable_source'],
-  // Internal with suppress, early rendering, and useTransition() support:
-  [
-    'recoil_hamt_2020',
-    'recoil_mutable_source',
-    'recoil_suppress_rerender_in_callback', // Also enables early rendering
-  ],
-  // OSS for React 18, test internally:
-  [
-    'recoil_hamt_2020',
-    'recoil_sync_external_store',
-    'recoil_suppress_rerender_in_callback', // Only used for fallback if no useSyncExternalStore()
-  ],
-  // Latest with GC:
-  [
-    'recoil_hamt_2020',
-    'recoil_sync_external_store',
-    'recoil_suppress_rerender_in_callback',
-    'recoil_memory_managament_2020',
-    'recoil_release_on_cascading_update_killswitch_2021',
-  ],
-  // Experimental mode for useTransition() support:
-  // ['recoil_hamt_2020', 'recoil_concurrent_legacy'],
-];
+const WWW_GKS_TO_TEST = QUICK_TEST
+  ? [['recoil_hamt_2020', 'recoil_sync_external_store']]
+  : [
+      // OSS for React <18:
+      ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering
+      // Current internal default:
+      ['recoil_hamt_2020', 'recoil_mutable_source'],
+      // Internal with suppress, early rendering, and useTransition() support:
+      [
+        'recoil_hamt_2020',
+        'recoil_mutable_source',
+        'recoil_suppress_rerender_in_callback', // Also enables early rendering
+      ],
+      // OSS for React 18, test internally:
+      [
+        'recoil_hamt_2020',
+        'recoil_sync_external_store',
+        'recoil_suppress_rerender_in_callback', // Only used for fallback if no useSyncExternalStore()
+      ],
+      // Latest with GC:
+      [
+        'recoil_hamt_2020',
+        'recoil_sync_external_store',
+        'recoil_suppress_rerender_in_callback',
+        'recoil_memory_managament_2020',
+        'recoil_release_on_cascading_update_killswitch_2021',
+      ],
+      // Experimental mode for useTransition() support:
+      // ['recoil_hamt_2020', 'recoil_concurrent_legacy'],
+    ];
 
 /**
  * GK combinations to exclude in OSS, presumably because these combinations pass

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -140,14 +140,17 @@ function renderConcurrentReactRoot<Props>(
   createRoot(container).render(contents);
 }
 
-function renderUnwrappedElements(elements: ?React.Node): HTMLDivElement {
-  const container = document.createElement('div');
+function renderUnwrappedElements(
+  elements: ?React.Node,
+  container?: ?HTMLDivElement,
+): HTMLDivElement {
+  const div = container ?? document.createElement('div');
   const renderReactRoot = isConcurrentModeEnabled()
     ? renderConcurrentReactRoot
     : renderLegacyReactRoot;
   act(() => {
     renderReactRoot(
-      container,
+      div,
       isStrictModeEnabled() ? (
         <StrictMode>{elements}</StrictMode>
       ) : (
@@ -155,10 +158,13 @@ function renderUnwrappedElements(elements: ?React.Node): HTMLDivElement {
       ),
     );
   });
-  return container;
+  return div;
 }
 
-function renderElements(elements: ?React.Node): HTMLDivElement {
+function renderElements(
+  elements: ?React.Node,
+  container?: ?HTMLDivElement,
+): HTMLDivElement {
   return renderUnwrappedElements(
     <RecoilRoot>
       {/* eslint-disable-next-line fb-www/no-null-fallback-for-error-boundary */}
@@ -166,11 +172,12 @@ function renderElements(elements: ?React.Node): HTMLDivElement {
         <React.Suspense fallback="loading">{elements}</React.Suspense>
       </ErrorBoundary>
     </RecoilRoot>,
+    container,
   );
 }
 
 function renderElementsWithSuspenseCount(
-  elements: ?React.Node,
+  elements: React.Node,
 ): [HTMLDivElement, JestMockFn<[], void>] {
   const suspenseCommit = jest.fn(() => {});
   function Fallback() {

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -107,6 +107,7 @@
  export interface AtomOptions<T> {
   key: NodeKey;
   default: RecoilValue<T> | Promise<T> | T;
+  effects?: ReadonlyArray<AtomEffect<T>>;
   effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
   dangerouslyAllowMutability?: boolean;
  }
@@ -378,6 +379,7 @@
   key: NodeKey;
   dangerouslyAllowMutability?: boolean;
   default: RecoilValue<T> | Promise<T> | T | ((param: P) => T | RecoilValue<T> | Promise<T>);
+  effects?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   effects_UNSTABLE?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
  }

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -574,13 +574,13 @@ isRecoilValue(mySelector1);
 }
 
 /**
- * effects_UNSTABLE on atom()
+ * effects on atom()
  */
 {
   atom({
     key: 'thisismyrandomkey',
     default: 0,
-    effects_UNSTABLE: [
+    effects: [
       ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
         node; // $ExpectType RecoilState<number>
         storeID; // $ExpectType StoreID
@@ -614,13 +614,13 @@ isRecoilValue(mySelector1);
 }
 
 /**
- * effects_UNSTABLE on atomFamily()
+ * effects on atomFamily()
  */
 {
   atomFamily({
     key: 'myrandomatomfamilykey',
     default: (param: number) => param,
-    effects_UNSTABLE: (param) => [
+    effects: (param) => [
       ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
         param; // $ExpectType number
 


### PR DESCRIPTION
Summary: For Atom effects rename `effects_UNSTABLE` option to just `effects` as the interface has mostly stabalized.  Continue to support `effects_UNSTBLE` for backward compatibility for now.

Differential Revision: D33373696

