### PR TITLE
Ensure there is a friendly error when using Recoil hooks outside of <RecoilRoot>

### DIFF
--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -404,6 +404,11 @@ function useRecoilValueLoadable_MUTABLE_SOURCE<T>(
   );
 
   const source = useRecoilMutableSource();
+  if (source == null) {
+    throw err(
+      'Recoil hooks must be used in components contained within a <RecoilRoot> component.',
+    );
+  }
   const loadable = useMutableSource(source, getLoadableWithTesting, subscribe);
   const prevLoadableRef = useRef(loadable);
   useEffect(() => {

--- a/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -38,6 +38,7 @@ let React,
   errorThrowingAsyncSelector,
   flushPromisesAndTimers,
   renderElements,
+  renderUnwrappedElements,
   renderElementsWithSuspenseCount,
   recoilComponentGetRecoilValueCount_FOR_TESTING,
   useRecoilState,
@@ -67,6 +68,7 @@ const testRecoil = getRecoilTestFn(() => {
     errorThrowingAsyncSelector,
     flushPromisesAndTimers,
     renderElements,
+    renderUnwrappedElements,
     renderElementsWithSuspenseCount,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
   ({reactMode} = require('../../core/Recoil_ReactMode'));
@@ -1868,3 +1870,14 @@ testRecoil(
     expect(values.get('someNonvalidatedAtom')).toBe(123);
   },
 );
+
+testRecoil('Hooks cannot be used outside of RecoilRoot', () => {
+  const myAtom = atom({key: 'hook outside RecoilRoot', default: 'INVALID'});
+  function Test() {
+    useRecoilValue(myAtom);
+    return 'TEST';
+  }
+
+  // Make sure there is a friendly error message mentioning <RecoilRoot>
+  expect(() => renderUnwrappedElements(<Test />)).toThrow('<RecoilRoot>');
+});


### PR DESCRIPTION
Summary: Ensure there is a friendly error when using Recoil hooks outside of `<RecoilRoot>`

Reviewed By: csantos42

Differential Revision: D33157344

