### PR TITLE
rename `Get<>` to `CheckerReturnType<>`

### DIFF
--- a/packages/recoil-sync/RecoilSync_URL.js
+++ b/packages/recoil-sync/RecoilSync_URL.js
@@ -18,7 +18,7 @@ import type {
   StoreKey,
   SyncEffectOptions,
 } from './RecoilSync';
-import type {Get} from 'refine';
+import type {CheckerReturnType} from 'refine';
 
 const {DefaultValue, RecoilLoadable} = require('Recoil');
 
@@ -29,7 +29,7 @@ const err = require('recoil-shared/util/Recoil_err');
 const {assertion, mixed, writableDict} = require('refine');
 
 type NodeKey = string;
-type ItemState = Get<typeof itemStateChecker>;
+type ItemState = CheckerReturnType<typeof itemStateChecker>;
 type AtomRegistration = {
   history: HistoryOption,
   itemKeys: Set<ItemKey>,

--- a/packages/refine/Refine_Checkers.js
+++ b/packages/refine/Refine_Checkers.js
@@ -51,10 +51,10 @@ export type Checker<+V> = (value: mixed, path?: Path) => CheckResult<V>;
  * const check = array(record({a: number()}));
  *
  * // equal to: type MyArray = $ReadOnlyArray<{a: number}>;
- * type MyArray = GetType<typeof check>;
+ * type MyArray = CheckerReturnType<typeof check>;
  * ```
  */
-export type Get<CheckerFunction> = $Call<
+export type CheckerReturnType<CheckerFunction> = $Call<
   <T>(checker: Checker<T>) => T,
   CheckerFunction,
 >;

--- a/packages/refine/Refine_index.js
+++ b/packages/refine/Refine_index.js
@@ -17,7 +17,7 @@ export type {
   CheckFailure,
   CheckResult,
   CheckSuccess,
-  Get,
+  CheckerReturnType,
   Path,
 } from './Refine_Checkers';
 export type {OptionalPropertyChecker} from './Refine_ContainerCheckers';

--- a/packages/refine/__tests__/Refine_Primitives-test.js
+++ b/packages/refine/__tests__/Refine_Primitives-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-import type {Get} from '../Refine_Checkers';
+import type {CheckerReturnType} from '../Refine_Checkers';
 
 const {assertion, coercion} = require('../Refine_API');
 const {
@@ -75,7 +75,7 @@ describe('boolean', () => {
     invariant(result.type === 'success', 'should succeed');
 
     // test type extraction
-    type Result = Get<typeof coerce>;
+    type Result = CheckerReturnType<typeof coerce>;
     const test: Result = true;
     invariant(result.value === test, 'value should be true');
   });

--- a/typescript/refine-test.ts
+++ b/typescript/refine-test.ts
@@ -10,7 +10,7 @@
  */
 
 import {
-  Get,
+  CheckerReturnType,
   boolean,
   stringLiterals,
   string,
@@ -46,7 +46,7 @@ import {
  */
 {
   const checker = object({a: number()});
-  type MyType = Get<typeof checker>;
+  type MyType = CheckerReturnType<typeof checker>;
   const x: MyType = {
     a: 1,
   };
@@ -139,7 +139,7 @@ import {
 {
   const check = object({a: optional(string()), b: string()});
 
-  type ObjectWithOptional = Get<typeof check>;
+  type ObjectWithOptional = CheckerReturnType<typeof check>;
 
   const r1: ObjectWithOptional = {
     b: 'test',

--- a/typescript/refine.d.ts
+++ b/typescript/refine.d.ts
@@ -15,7 +15,7 @@ type CheckerResult<V> = V extends Checker<infer Result>
   ? OptionalResult
   : never;
 
-export type Get<V> = V extends Checker<infer Result> ? Result : never;
+export type CheckerReturnType<V> = V extends Checker<infer Result> ? Result : never;
 
 /**
  * This file is a manual translation of the flow types, which are the source of truth, so we should not introduce new terminology or behavior in this file.


### PR DESCRIPTION
Summary:
(title)

Follow up to change in docs here: https://github.com/facebookexperimental/Recoil/pull/1497

Differential Revision: D33412769

