### PR TITLE
[docs] Document custom hooks that use Recoil states

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -4,7 +4,7 @@ title: Testing
 
 ## Testing Recoil state inside of a React component
 
-It can be helpful to test Recoil state when testing a component. You can compare the new state  against expected values using this pattern. It uses a React functional component, `useRecoilValue` and `useEffect`, to observe an `atom`/`selector`'s changes and execute a callback every time the user performs an action that modifies the state.
+It can be helpful to test Recoil state when testing a component. You can compare the new state against expected values using this pattern. It uses a React functional component, `useRecoilValue` and `useEffect`, to observe an `atom`/`selector`'s changes and execute a callback every time the user performs an action that modifies the state.
 
 ```jsx
 export const RecoilObserver = ({node, onChange}) => {
@@ -14,8 +14,8 @@ export const RecoilObserver = ({node, onChange}) => {
 };
 ```
 
-* **`node`**: can be an atom or a selector.
-* **`onChange`**: this function will be called every time the state changes.
+- **`node`**: can be an atom or a selector.
+- **`onChange`**: this function will be called every time the state changes.
 
 ### Example: Form state modified by user
 
@@ -53,7 +53,7 @@ describe('The form state should', () => {
       <RecoilRoot>
         <RecoilObserver node={nameAtom} onChange={onChange} />
         <Form />
-      </RecoilRoot>
+      </RecoilRoot>,
     );
 
     const component = screen.getByTestId('name_input');
@@ -76,7 +76,7 @@ A common pattern for atoms is using asynchronous queries fetch the state of the 
 function flushPromisesAndTimers(): Promise<void> {
   return act(
     () =>
-      new Promise(resolve => {
+      new Promise((resolve) => {
         setTimeout(resolve, 100);
         jest.runAllTimers();
       }),
@@ -92,7 +92,7 @@ function flushPromisesAndTimers(): Promise<void> {
 const getDefaultTitleAtomState = async () => {
   const response = await fetch('https://example.com/returns/a/json');
   return await response.json(); // { title: 'real title' };
-}
+};
 
 const titleState = atom({
   key: 'titleState',
@@ -114,31 +114,71 @@ function Title() {
 ```jsx
 describe('Title Component', () => {
   test('display the title correctly', async () => {
-    const mockState = { title: 'test title' };
+    const mockState = {title: 'test title'};
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve(mockState),
-      })
+      }),
     );
-    
+
     render(
       <RecoilRoot>
         <Suspense fallback={<div>loading...</div>}>
           <Title />
         </Suspense>
-      </RecoilRoot>
+      </RecoilRoot>,
     );
     await flushPromisesAndTimers();
-    
-    expect(screen.getByText(mockState.title)).toBeInTheDocument()
-    expect(screen.getByText('loading...')).not.toBeInTheDocument()
+
+    expect(screen.getByText(mockState.title)).toBeInTheDocument();
+    expect(screen.getByText('loading...')).not.toBeInTheDocument();
   });
+});
+```
+
+## Testing Recoil state inside a Custom Hook
+
+Sometimes it becomes convenient to write a custom React hook that relies on Recoil states. Since you test the hook in a React context, it also needs to be wrapped in `RecoilRoot`. Luckily, you can use [React Hooks Testing Library](https://react-hooks-testing-library.com/) to achieve this.
+
+### Example: React Hooks Testing Library
+
+#### State
+
+```jsx
+const countState = atom({
+  key: 'countAtom',
+  default: 0,
+});
+```
+
+#### Hook
+
+```jsx
+const useMyCustomHook = () => {
+  const [count, setCount] = useRecoilState(countState);
+  // Insert other Recoil state here...
+  // Insert other effects here...
+  return {
+    count,
+    setCount,
+  };
+};
+```
+
+#### Test
+
+```jsx
+test('Test useMyCustomHook', () => {
+  const {result} = renderHook(() => useMyCustomHook(), {
+    wrapper: RecoilRoot,
+  });
+  expect(result.current.count).toEqual(0);
 });
 ```
 
 ## Testing Recoil state outside of React
 
-It can be useful to manipulate and evaluate Recoil selectors outside of a React context for testing.  This can be done by working with a Recoil [`Snapshot`](/docs/api-reference/core/Snapshot).  You can build a fresh snapshot using `snapshot_UNSTABLE()` and then use that `Snapshot` to evaluate selectors for testing.
+It can be useful to manipulate and evaluate Recoil selectors outside of a React context for testing. This can be done by working with a Recoil [`Snapshot`](/docs/api-reference/core/Snapshot). You can build a fresh snapshot using `snapshot_UNSTABLE()` and then use that `Snapshot` to evaluate selectors for testing.
 
 ### Example: Jest unit testing selectors
 
@@ -156,5 +196,5 @@ test('Test multipliedState', () => {
 
   const testSnapshot = snapshot_UNSTABLE(({set}) => set(numberState, 1));
   expect(testSnapshot.getLoadable(multipliedState).valueOrThrow()).toBe(100);
-})
+});
 ```


### PR DESCRIPTION
Per #1522, include an example of how to test a custom hook that relies on Recoil states. This example uses React Hooks Testing Library