### PR TITLE
Suppress Flow issue about react-dom.createRoot() and react-dom.unstable_createRoot()

### DIFF
--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -123,6 +123,7 @@ function renderLegacyReactRoot<Props>(
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;
+// $FlowFixMe[prop-missing] unstable_createRoot is not part of react-dom typing // @oss-only
 const createRoot = ReactDOM.createRoot ?? ReactDOM.unstable_createRoot; // @oss-only
 
 function isConcurrentModeAvailable(): boolean {


### PR DESCRIPTION
Summary: Recoil currently attempts to use `createRoot()` or `unstable_createRoot()` from `react-dom` for backward compatibility.  However, this function is not part of the Flow typing for `react-dom` for v17, so suppress the Flow error.

Differential Revision: D33459660

