### PR TITLE
Support SSR with recoil_sync_external_store mode

### DIFF
--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -30,9 +30,11 @@ const useMutableSource: <StoreState, T>(
   // flowlint-next-line unclear-type:off
   (React: any).useMutableSource ?? (React: any).unstable_useMutableSource;
 
+// https://github.com/reactwg/react-18/discussions/86
 const useSyncExternalStore: <T>(
   subscribe: (() => void) => () => void,
   getSnapshot: () => T,
+  getServerSnapshot?: () => T,
 ) => T =
   // flowlint-next-line unclear-type:off
   (React: any).useSyncExternalStore ??

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -347,7 +347,11 @@ function useRecoilValueLoadable_SYNC_EXTERNAL_STORE<T>(
     [storeRef, recoilValue, componentName],
   );
 
-  return useSyncExternalStore(subscribe, getMemoizedSnapshot).loadable;
+  return useSyncExternalStore(
+    subscribe,
+    getMemoizedSnapshot, // getSnapshot()
+    getMemoizedSnapshot, // getServerSnapshot() for SSR support
+  ).loadable;
 }
 
 function useRecoilValueLoadable_MUTABLE_SOURCE<T>(

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -111,7 +111,6 @@ const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const {
   startPerfBlock,
 } = require('recoil-shared/util/Recoil_PerformanceTimings');
-const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
 type SelectorCallbackInterface<T> = $ReadOnly<{
   // TODO Technically this could be RecoilValueReadOnly, but trying to parameterize
@@ -627,16 +626,11 @@ function selector<T>(
         return loadable.contents;
       })
       .catch(error => {
+        // The selector was released since the request began; ignore the response.
         if (error instanceof Canceled) {
-          recoverableViolation(
-            'Selector was released while it had dependencies',
-            'recoil',
-          );
           throw CANCELED;
         }
-
         if (!selectorIsLive()) {
-          // The selector was released since the request began; ignore the response.
           clearExecutionInfo(store, executionId);
           throw CANCELED;
         }

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -123,6 +123,7 @@ function renderLegacyReactRoot<Props>(
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;
+// $FlowFixMe[prop-missing] unstable_createRoot is not part of react-dom typing // @oss-only
 const createRoot = ReactDOM.createRoot ?? ReactDOM.unstable_createRoot; // @oss-only
 
 function isConcurrentModeAvailable(): boolean {


### PR DESCRIPTION
Summary:
Addresses `recoil_sync_external_store` mode not working with NextJS: [#1526](https://github.com/facebookexperimental/Recoil/issues/1526)

`useSyncExternalStore()` isn't really documented, but there is this note about it (https://github.com/reactwg/react-18/discussions/86) and the source code shows a third parameter for accepting a "server" snapshot.  Use this as well to support SSR and NextJS environments.

Differential Revision: D33460443

