### PR TITLE
Remove recoverableViolation from released selectors

### DIFF
--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -111,7 +111,6 @@ const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const {
   startPerfBlock,
 } = require('recoil-shared/util/Recoil_PerformanceTimings');
-const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
 type SelectorCallbackInterface<T> = $ReadOnly<{
   // TODO Technically this could be RecoilValueReadOnly, but trying to parameterize
@@ -627,16 +626,11 @@ function selector<T>(
         return loadable.contents;
       })
       .catch(error => {
+        // The selector was released since the request began; ignore the response.
         if (error instanceof Canceled) {
-          recoverableViolation(
-            'Selector was released while it had dependencies',
-            'recoil',
-          );
           throw CANCELED;
         }
-
         if (!selectorIsLive()) {
-          // The selector was released since the request began; ignore the response.
           clearExecutionInfo(store, executionId);
           throw CANCELED;
         }

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -123,6 +123,7 @@ function renderLegacyReactRoot<Props>(
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;
+// $FlowFixMe[prop-missing] unstable_createRoot is not part of react-dom typing // @oss-only
 const createRoot = ReactDOM.createRoot ?? ReactDOM.unstable_createRoot; // @oss-only
 
 function isConcurrentModeAvailable(): boolean {


### PR DESCRIPTION
Summary: Remove unnecessary `recoverableViolation()` call.

Differential Revision: D33444213

