### PR TITLE
Avoid canceling selectors with initializeState and GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - Fixes for `<StrictMode>` (#1473, #1444, #1509).
   - `useTransition()` is not yet supported for open source React.
 - Recoil updates now re-render earlier:
-  - Recoil and React state changes from the same batch now stay in sync.
+  - Recoil and React state changes from the same batch now stay in sync. (#1076)
   - Renders now occur before transaction observers instead of after.
 
 ### New Features
@@ -30,7 +30,7 @@
 - Atom Effects
   - Rename option from `effects_UNSTABLE` to just `effects` as the interface is mostly stabilizing (#1520)
   - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
-  - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
+  - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511, #1532)
   - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
   - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -328,10 +328,20 @@ function initialStoreState_DEPRECATED(store, initializeState): StoreState {
 // compatible with React StrictMode where effects may be re-run multiple times
 // but state initialization only happens once the first time.
 function initialStoreState(initializeState): StoreState {
+  // Initialize a snapshot and get its store
   const snapshot = freshSnapshot().map(initializeState);
   const storeState = snapshot.getStore_INTERNAL().getState();
+
+  // Counteract the snapshot auto-release
+  snapshot.retain();
+
+  // Cleanup any effects run during initialization and clear the handlers so
+  // they will re-initialize if used during rendering.  This allows atom effect
+  // initialization to take precedence over initializeState and be compatible
+  // with StrictMode semantics.
   storeState.nodeCleanupFunctions.forEach(cleanup => cleanup());
   storeState.nodeCleanupFunctions.clear();
+
   return storeState;
 }
 

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -233,7 +233,7 @@ class Snapshot {
     this.checkRefCount_INTERNAL();
     const mutableSnapshot = new MutableSnapshot(this, batchUpdates);
     mapper(mutableSnapshot); // if removing batchUpdates from `set` add it here
-    return cloneSnapshot(mutableSnapshot.getStore_INTERNAL());
+    return mutableSnapshot;
   };
 
   // eslint-disable-next-line fb-www/extra-arrow-initializer
@@ -242,7 +242,7 @@ class Snapshot {
       this.checkRefCount_INTERNAL();
       const mutableSnapshot = new MutableSnapshot(this, batchUpdates);
       await mapper(mutableSnapshot);
-      return cloneSnapshot(mutableSnapshot.getStore_INTERNAL());
+      return mutableSnapshot;
     };
 }
 

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -265,9 +265,7 @@ function selector<T>(
   let liveStoresCount = 0;
 
   function selectorIsLive() {
-    return true;
-    // TODO Workaround for now to avoid hanging selectors
-    // return !gkx('recoil_memory_managament_2020') || liveStoresCount > 0;
+    return !gkx('recoil_memory_managament_2020') || liveStoresCount > 0;
   }
 
   function getExecutionInfo(store: Store): ExecutionInfo<T> {


### PR DESCRIPTION
Summary:
When the Garbage Collection feature is enabled and `initializeState` was used in `<RecoilRoot>` then an extra release of the mapped snapshot for initialization was releasing selectors.  This caused any pending async selectors to cancel any resolutions.

Also, properly run atom effect cleanups when initialized in a snapshot that is part of a mapping, such as during `initializeState`.

Differential Revision: D33487063

