### PR TITLE
Optimize snapshot cloning overhead for callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Callbacks from selector's `getCallback()` can now mutate, refresh, and transact Recoil state, in addition to reading it, for parity with `useRecoilCallback()`. (#1498)
 - Recoil StoreID's for `<RecoilRoot>` and `Snapshot` stores accessible via `useRecoilStoreID()` hook (#1417) or `storeID` parameter for atom effects (#1414).
 - `RecoilLoadable.all()` and `RecoilLoadable.of()` now accept either literal values, async Promises, or Loadables. (#1455, #1442)
+- Add `.isRetained()` method for Snapshots and check if snapshot is already released when using `.retain()` (#1546)
 
 ### Other Fixes and Optimizations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@
 - Add `.isRetained()` method for Snapshots and check if snapshot is already released when using `.retain()` (#1546)
 
 ### Other Fixes and Optimizations
-
-- Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
+- Reduce overhead of snapshot cloning
+  - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
+  - Cache the cloned snapshots from callbacks unless there was a state change. (#1533)
 - Fix transitive selector refresh for some cases (#1409)
 - Atom Effects
   - Rename option from `effects_UNSTABLE` to just `effects` as the interface is mostly stabilizing (#1520)

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -201,8 +201,8 @@ function sendEndOfBatchNotifications(store: Store) {
   );
 }
 
-function endBatch(storeRef) {
-  const storeState = storeRef.current.getState();
+function endBatch(store: Store) {
+  const storeState = store.getState();
   storeState.commitDepth++;
   try {
     const {nextTree} = storeState;
@@ -219,7 +219,7 @@ function endBatch(storeRef) {
     storeState.currentTree = nextTree;
     storeState.nextTree = null;
 
-    sendEndOfBatchNotifications(storeRef.current);
+    sendEndOfBatchNotifications(store);
 
     if (storeState.previousTree != null) {
       storeState.graphsByVersion.delete(storeState.previousTree.version);
@@ -232,7 +232,7 @@ function endBatch(storeRef) {
     storeState.previousTree = null;
 
     if (gkx('recoil_memory_managament_2020')) {
-      releaseScheduledRetainablesNow(storeRef.current);
+      releaseScheduledRetainablesNow(store);
     }
   } finally {
     storeState.commitDepth--;
@@ -271,7 +271,7 @@ function Batcher({
     // manipulate the order of useEffects during tests, since React seems to
     // call useEffect in an unpredictable order sometimes.
     Queue.enqueueExecution('Batcher', () => {
-      endBatch(storeRef);
+      endBatch(storeRef.current);
     });
   });
 

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -71,7 +71,7 @@ This is currently a DEV-only warning but will become a thrown exception in the n
 // evaluation functions are executed and async selectors resolve.
 class Snapshot {
   _store: Store;
-  _refCount: number = 0;
+  _refCount: number = 1;
 
   constructor(storeState: StoreState) {
     this._store = {
@@ -101,11 +101,23 @@ class Snapshot {
       initializeNode(this._store, nodeKey);
       updateRetainCount(this._store, nodeKey, 1);
     }
-    this.retain();
+
     this._autoRelease();
   }
 
   retain(): () => void {
+    if (__DEV__) {
+      if (this._refCount <= 0) {
+        throw err('Snapshot has already been released.');
+      }
+    } else {
+      if (this._refCount <= 0) {
+        recoverableViolation(
+          'Attempt to retain() Snapshot that was already released.',
+          'recoil',
+        );
+      }
+    }
     this._refCount++;
     let released = false;
     return () => {
@@ -141,6 +153,10 @@ class Snapshot {
       //   updateRetainCountToZero(this._store, k);
       // }
     }
+  }
+
+  isRetained(): boolean {
+    return this._refCount > 0;
   }
 
   checkRefCount_INTERNAL(): void {

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -47,6 +47,9 @@ const err = require('recoil-shared/util/Recoil_err');
 const filterIterable = require('recoil-shared/util/Recoil_filterIterable');
 const gkx = require('recoil-shared/util/Recoil_gkx');
 const mapIterable = require('recoil-shared/util/Recoil_mapIterable');
+const {
+  memoizeOneWithArgsHashAndInvalidation,
+} = require('recoil-shared/util/Recoil_Memoize');
 const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
@@ -318,16 +321,33 @@ function freshSnapshot(initializeState?: MutableSnapshot => void): Snapshot {
 }
 
 // Factory to clone a snapahot state
+const [memoizedCloneSnapshot, invalidateMemoizedSnapshot] =
+  memoizeOneWithArgsHashAndInvalidation(
+    (store, version) => {
+      const storeState = store.getState();
+      const treeState =
+        version === 'current'
+          ? storeState.currentTree
+          : nullthrows(storeState.previousTree);
+      return new Snapshot(cloneStoreState(store, treeState));
+    },
+    (store, version) =>
+      String(version) +
+      String(store.storeID) +
+      String(store.getState().currentTree.version) +
+      String(store.getState().previousTree?.version),
+  );
+
 function cloneSnapshot(
   store: Store,
   version: 'current' | 'previous' = 'current',
 ): Snapshot {
-  const storeState = store.getState();
-  const treeState =
-    version === 'current'
-      ? storeState.currentTree
-      : nullthrows(storeState.previousTree);
-  return new Snapshot(cloneStoreState(store, treeState));
+  const snapshot = memoizedCloneSnapshot(store, version);
+  if (!snapshot.isRetained()) {
+    invalidateMemoizedSnapshot();
+    return memoizedCloneSnapshot(store, version);
+  }
+  return snapshot;
 }
 
 class MutableSnapshot extends Snapshot {

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+import type {Snapshot} from '../Recoil_Snapshot';
+
 const {
   getRecoilTestFn,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
@@ -27,7 +29,6 @@ let React,
   asyncSelector,
   componentThatReadsAndWritesAtom,
   renderElements,
-  Snapshot,
   freshSnapshot,
   RecoilRoot;
 
@@ -50,7 +51,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     renderElements,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
-  ({Snapshot, freshSnapshot} = require('../Recoil_Snapshot'));
+  ({freshSnapshot} = require('../Recoil_Snapshot'));
   ({RecoilRoot} = require('../Recoil_RecoilRoot'));
 });
 
@@ -493,6 +494,38 @@ testRecoil('getInfo', () => {
   expect(
     Array.from(resetSnapshot.getInfo_UNSTABLE(selectorB).subscribers.nodes),
   ).toEqual([]);
+});
+
+describe('Retention', () => {
+  testRecoil('auto-release', async () => {
+    const snapshot = freshSnapshot();
+    expect(snapshot.isRetained()).toBe(true);
+
+    await flushPromisesAndTimers();
+    expect(snapshot.isRetained()).toBe(false);
+
+    const devStatus = window.__DEV__;
+    window.__DEV__ = true;
+    expect(() => snapshot.retain()).toThrow('released');
+    window.__DEV__ = false;
+    expect(() => snapshot.retain()).not.toThrow('released');
+    window.__DEV__ = devStatus;
+
+    // TODO enable when recoil_memory_managament_2020 is enforced
+    // expect(() => snapshot.getID()).toThrow('release');
+  });
+
+  testRecoil('retain()', async () => {
+    const snapshot = freshSnapshot();
+    expect(snapshot.isRetained()).toBe(true);
+    const release2 = snapshot.retain();
+
+    await flushPromisesAndTimers();
+    expect(snapshot.isRetained()).toBe(true);
+
+    release2();
+    expect(snapshot.isRetained()).toBe(false);
+  });
 });
 
 describe('Atom effects', () => {

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -26,6 +26,7 @@ let React,
   useRecoilValue,
   useRecoilState,
   useSetRecoilState,
+  useResetRecoilState,
   ReadsAtom,
   flushPromisesAndTimers,
   renderElements,
@@ -43,6 +44,7 @@ const testRecoil = getRecoilTestFn(() => {
     selector,
     useRecoilCallback,
     useSetRecoilState,
+    useResetRecoilState,
     useRecoilValue,
     useRecoilState,
   } = require('../../Recoil_index'));
@@ -574,5 +576,112 @@ describe('Selector Cache', () => {
 
     act(() => setMyAtom('a'));
     expect(container.textContent).toBe('a-3');
+  });
+});
+
+describe('Snapshot cache', () => {
+  testRecoil('Snapshot is cached', () => {
+    const myAtom = atom({
+      key: 'useRecoilCallback snapshot cached',
+      default: 'DEFAULT',
+    });
+
+    let getSnapshot;
+    let setMyAtom, resetMyAtom;
+    function Component() {
+      getSnapshot = useRecoilCallback(
+        ({snapshot}) =>
+          () =>
+            snapshot,
+      );
+      setMyAtom = useSetRecoilState(myAtom);
+      resetMyAtom = useResetRecoilState(myAtom);
+      return null;
+    }
+    renderElements(<Component />);
+
+    const getAtom = snapshot => snapshot?.getLoadable(myAtom).getValue();
+
+    const initialSnapshot = getSnapshot?.();
+    expect(getAtom(initialSnapshot)).toEqual('DEFAULT');
+
+    // If there are no state changes, the snapshot should be cached
+    const nextSnapshot = getSnapshot?.();
+    expect(getAtom(nextSnapshot)).toEqual('DEFAULT');
+    expect(nextSnapshot).toBe(initialSnapshot);
+
+    // With a state change, there is a new snapshot
+    act(() => setMyAtom('SET'));
+    const setSnapshot = getSnapshot?.();
+    expect(getAtom(setSnapshot)).toEqual('SET');
+    expect(setSnapshot).not.toBe(initialSnapshot);
+
+    const nextSetSnapshot = getSnapshot?.();
+    expect(getAtom(nextSetSnapshot)).toEqual('SET');
+    expect(nextSetSnapshot).toBe(setSnapshot);
+
+    act(() => setMyAtom('SET2'));
+    const set2Snapshot = getSnapshot?.();
+    expect(getAtom(set2Snapshot)).toEqual('SET2');
+    expect(set2Snapshot).not.toBe(initialSnapshot);
+    expect(set2Snapshot).not.toBe(setSnapshot);
+
+    const nextSet2Snapshot = getSnapshot?.();
+    expect(getAtom(nextSet2Snapshot)).toEqual('SET2');
+    expect(nextSet2Snapshot).toBe(set2Snapshot);
+
+    act(() => resetMyAtom());
+    const resetSnapshot = getSnapshot?.();
+    expect(getAtom(resetSnapshot)).toEqual('DEFAULT');
+    expect(resetSnapshot).not.toBe(initialSnapshot);
+    expect(resetSnapshot).not.toBe(setSnapshot);
+
+    const nextResetSnapshot = getSnapshot?.();
+    expect(getAtom(nextResetSnapshot)).toEqual('DEFAULT');
+    expect(nextResetSnapshot).toBe(resetSnapshot);
+  });
+
+  testRecoil('cached snapshot is invalidated if not retained', async () => {
+    const myAtom = atom({
+      key: 'useRecoilCallback snapshot cache retained',
+      default: 'DEFAULT',
+    });
+
+    let getSnapshot;
+    let setMyAtom;
+    function Component() {
+      getSnapshot = useRecoilCallback(
+        ({snapshot}) =>
+          () =>
+            snapshot,
+      );
+      setMyAtom = useSetRecoilState(myAtom);
+      return null;
+    }
+    renderElements(<Component />);
+
+    const getAtom = snapshot => snapshot?.getLoadable(myAtom).getValue();
+
+    act(() => setMyAtom('SET'));
+    const setSnapshot = getSnapshot?.();
+    expect(getAtom(setSnapshot)).toEqual('SET');
+
+    // If cached snapshot is released, a new snapshot is provided
+    await flushPromisesAndTimers();
+    const nextSetSnapshot = getSnapshot?.();
+    expect(nextSetSnapshot).not.toBe(setSnapshot);
+    expect(getAtom(nextSetSnapshot)).toEqual('SET');
+
+    act(() => setMyAtom('SET2'));
+    const set2Snapshot = getSnapshot?.();
+    expect(getAtom(set2Snapshot)).toEqual('SET2');
+    expect(set2Snapshot).not.toBe(setSnapshot);
+
+    // If cached snapshot is retained, then it is used again
+    set2Snapshot?.retain();
+    await flushPromisesAndTimers();
+    const nextSet2Snapshot = getSnapshot?.();
+    expect(getAtom(nextSet2Snapshot)).toEqual('SET2');
+    expect(nextSet2Snapshot).toBe(set2Snapshot);
   });
 });

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -108,10 +108,16 @@ function getError(recoilValue): Error {
 
 function setValue(recoilState, value) {
   setRecoilValue(store, recoilState, value);
+  // $FlowFixMe[unsafe-addition]
+  // $FlowFixMe[cannot-write]
+  store.getState().currentTree.version++;
 }
 
 function resetValue(recoilState) {
   setRecoilValue(store, recoilState, new DefaultValue());
+  // $FlowFixMe[unsafe-addition]
+  // $FlowFixMe[cannot-write]
+  store.getState().currentTree.version++;
 }
 
 testRecoil('useRecoilState - static selector', () => {
@@ -1604,9 +1610,16 @@ describe('getCallback', () => {
     });
 
     const menuItem = getValue(mySelector);
+    expect(getValue(myAtom)).toEqual('DEFAULT');
     await expect(menuItem.onClick()).resolves.toEqual('DEFAULT');
+
     act(() => setValue(myAtom, 'SET'));
+    expect(getValue(myAtom)).toEqual('SET');
     await expect(menuItem.onClick()).resolves.toEqual('SET');
+
+    act(() => setValue(myAtom, 'SET2'));
+    expect(getValue(myAtom)).toEqual('SET2');
+    await expect(menuItem.onClick()).resolves.toEqual('SET2');
   });
 
   testRecoil('snapshot', async () => {

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -54,7 +54,7 @@ const QUICK_TEST = false;
 // @fb-only: const IS_INTERNAL = true;
 const IS_INTERNAL = false; // @oss-only
 
-// TODO Use Snapshot for testing instead of this thunk?
+// TODO Use Snapshots for testing instead of this thunk?
 function makeStore(): Store {
   const storeState = makeEmptyStoreState();
   const store: Store = {

--- a/packages/shared/util/Recoil_Memoize.js
+++ b/packages/shared/util/Recoil_Memoize.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+/**
+ * Caches a function's results based on the key returned by the passed
+ * hashFunction.
+ */
+function memoizeWithArgsHash<TArgs: $ReadOnlyArray<mixed>, TReturn>(
+  fn: (...TArgs) => TReturn,
+  hashFunction: (...TArgs) => string,
+): (...TArgs) => TReturn {
+  let cache;
+  const memoizedFn: (...TArgs) => TReturn = (...args: TArgs): TReturn => {
+    if (!cache) {
+      cache = ({}: {[string]: TReturn});
+    }
+
+    // $FlowFixMe[incompatible-type]
+    const key = hashFunction(...args);
+    if (!Object.hasOwnProperty.call(cache, key)) {
+      cache[key] = fn.apply(this, args);
+    }
+    return cache[key];
+  };
+
+  return memoizedFn;
+}
+
+/**
+ * Caches a function's results based on a comparison of the arguments.
+ * Only caches the last return of the function.
+ * Defaults to reference equality
+ */
+function memoizeOneWithArgsHash<TArgs: $ReadOnlyArray<mixed>, TReturn>(
+  fn: (...TArgs) => TReturn,
+  hashFunction: (...TArgs) => string,
+): (...TArgs) => TReturn {
+  let lastKey: ?string;
+  let lastResult: TReturn;
+
+  // breaking cache when arguments change
+  const memoizedFn: (...TArgs) => TReturn = (...args: TArgs): TReturn => {
+    const key = hashFunction(...args);
+    if (lastKey === key) {
+      return lastResult;
+    }
+
+    lastKey = key;
+    lastResult = fn.apply(this, args);
+    return lastResult;
+  };
+
+  return memoizedFn;
+}
+
+/**
+ * Caches a function's results based on a comparison of the arguments.
+ * Only caches the last return of the function.
+ * Defaults to reference equality
+ */
+function memoizeOneWithArgsHashAndInvalidation<
+  TArgs: $ReadOnlyArray<mixed>,
+  TReturn,
+>(
+  fn: (...TArgs) => TReturn,
+  hashFunction: (...TArgs) => string,
+): [(...TArgs) => TReturn, () => void] {
+  let lastKey: ?string;
+  let lastResult: TReturn;
+
+  // breaking cache when arguments change
+  const memoizedFn: (...TArgs) => TReturn = (...args: TArgs): TReturn => {
+    const key = hashFunction(...args);
+    if (lastKey === key) {
+      return lastResult;
+    }
+
+    lastKey = key;
+    lastResult = fn.apply(this, args);
+    return lastResult;
+  };
+
+  const invalidate = () => {
+    lastKey = null;
+  };
+
+  return [memoizedFn, invalidate];
+}
+
+module.exports = {
+  memoizeWithArgsHash,
+  memoizeOneWithArgsHash,
+  memoizeOneWithArgsHashAndInvalidation,
+};

--- a/packages/shared/util/__tests__/Recoil_Memoize-test.js
+++ b/packages/shared/util/__tests__/Recoil_Memoize-test.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {
+  memoizeOneWithArgsHash,
+  memoizeOneWithArgsHashAndInvalidation,
+  memoizeWithArgsHash,
+} = require('../Recoil_Memoize');
+
+describe('memoizeWithArgsHash', () => {
+  it('caches functions based on the hash function', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeWithArgsHash(f, (_a, _b, c) => String(c));
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(f.mock.calls.length).toBe(2);
+  });
+  it('handles "hasOwnProperty" as a hash key with no errors', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeWithArgsHash(f, () => 'hasOwnProperty');
+    expect(mem()).toBe(0);
+    expect(() => mem()).not.toThrow();
+    expect(mem(1)).toBe(0);
+    expect(f.mock.calls.length).toBe(1);
+  });
+});
+
+describe('memoizeOneWithArgsHash', () => {
+  it('caches functions based on the arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeOneWithArgsHash(
+      f,
+      (a, b, c) => String(a) + String(b) + String(c),
+    );
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(1, 2, 3)).toBe(3);
+    expect(f.mock.calls.length).toBe(4);
+  });
+  it('caches functions based on partial arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeOneWithArgsHash(f, (_a, _b, c) => String(c));
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(1, 2, 4)).toBe(2);
+    expect(f.mock.calls.length).toBe(3);
+  });
+});
+
+describe('memoizeOneWithArgsHashAndInvalidation', () => {
+  it('caches functions based on the arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const [mem, invalidate] = memoizeOneWithArgsHashAndInvalidation(
+      f,
+      (a, b, c) => String(a) + String(b) + String(c),
+    );
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(1, 2, 3)).toBe(3);
+    expect(mem(1, 2, 3)).toBe(3);
+    invalidate();
+    expect(mem(1, 2, 3)).toBe(4);
+    expect(mem(1, 2, 3)).toBe(4);
+    expect(f.mock.calls.length).toBe(5);
+  });
+  it('caches functions based on partial arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const [mem, invalidate] = memoizeOneWithArgsHashAndInvalidation(
+      f,
+      (_a, _b, c) => String(c),
+    );
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(1, 2, 4)).toBe(2);
+    expect(mem(1, 2, 4)).toBe(2);
+    invalidate();
+    expect(mem(1, 2, 4)).toBe(3);
+    expect(mem(1, 2, 4)).toBe(3);
+    expect(f.mock.calls.length).toBe(4);
+  });
+});


### PR DESCRIPTION
Summary: If a user has a recoil callback, such as from `useRecoilCallback()`, and uses it to get a snapshot many times in a loop it could incur overhead for cloning the snapshot.  Optimize this by caching the cloned snapshot and only cloning a new one if the store or state has changed.

Differential Revision: D33490900

