### PR TITLE
Suppress uninitialized store lint for Snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - Fixes for `<StrictMode>` (#1473, #1444, #1509).
   - `useTransition()` is not yet supported for open source React.
 - Recoil updates now re-render earlier:
-  - Recoil and React state changes from the same batch now stay in sync.
+  - Recoil and React state changes from the same batch now stay in sync. (#1076)
   - Renders now occur before transaction observers instead of after.
 
 ### New Features
@@ -30,7 +30,7 @@
 - Atom Effects
   - Rename option from `effects_UNSTABLE` to just `effects` as the interface is mostly stabilizing (#1520)
   - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
-  - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511)
+  - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511, #1532)
   - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
   - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
 - `RecoilLoadable.all()` and `RecoilLoadable.of()` now accept either literal values, async Promises, or Loadables. (#1455, #1442)
 
 ### Other Fixes and Optimizations
-- Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
+- Reduce overhead of snapshot cloning
+  - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
+  - Cache the cloned snapshots from callbacks unless there was a state change. (#1533)
 - Fix transitive selector refresh for some cases (#1409)
 - Atom Effects
   - Rename option from `effects_UNSTABLE` to just `effects` as the interface is mostly stabilizing (#1520)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^4.2.0",
     "eslint": "^8.2.0",
-    "eslint-plugin-fb-www": "^1.0.7",
+    "eslint-plugin-fb-www": "^1.8.0",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -328,10 +328,20 @@ function initialStoreState_DEPRECATED(store, initializeState): StoreState {
 // compatible with React StrictMode where effects may be re-run multiple times
 // but state initialization only happens once the first time.
 function initialStoreState(initializeState): StoreState {
+  // Initialize a snapshot and get its store
   const snapshot = freshSnapshot().map(initializeState);
   const storeState = snapshot.getStore_INTERNAL().getState();
+
+  // Counteract the snapshot auto-release
+  snapshot.retain();
+
+  // Cleanup any effects run during initialization and clear the handlers so
+  // they will re-initialize if used during rendering.  This allows atom effect
+  // initialization to take precedence over initializeState and be compatible
+  // with StrictMode semantics.
   storeState.nodeCleanupFunctions.forEach(cleanup => cleanup());
   storeState.nodeCleanupFunctions.clear();
+
   return storeState;
 }
 

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -201,8 +201,8 @@ function sendEndOfBatchNotifications(store: Store) {
   );
 }
 
-function endBatch(storeRef) {
-  const storeState = storeRef.current.getState();
+function endBatch(store: Store) {
+  const storeState = store.getState();
   storeState.commitDepth++;
   try {
     const {nextTree} = storeState;
@@ -219,7 +219,7 @@ function endBatch(storeRef) {
     storeState.currentTree = nextTree;
     storeState.nextTree = null;
 
-    sendEndOfBatchNotifications(storeRef.current);
+    sendEndOfBatchNotifications(store);
 
     if (storeState.previousTree != null) {
       storeState.graphsByVersion.delete(storeState.previousTree.version);
@@ -232,7 +232,7 @@ function endBatch(storeRef) {
     storeState.previousTree = null;
 
     if (gkx('recoil_memory_managament_2020')) {
-      releaseScheduledRetainablesNow(storeRef.current);
+      releaseScheduledRetainablesNow(store);
     }
   } finally {
     storeState.commitDepth--;
@@ -271,7 +271,7 @@ function Batcher({
     // manipulate the order of useEffects during tests, since React seems to
     // call useEffect in an unpredictable order sometimes.
     Queue.enqueueExecution('Batcher', () => {
-      endBatch(storeRef);
+      endBatch(storeRef.current);
     });
   });
 

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -233,7 +233,7 @@ class Snapshot {
     this.checkRefCount_INTERNAL();
     const mutableSnapshot = new MutableSnapshot(this, batchUpdates);
     mapper(mutableSnapshot); // if removing batchUpdates from `set` add it here
-    return cloneSnapshot(mutableSnapshot.getStore_INTERNAL());
+    return mutableSnapshot;
   };
 
   // eslint-disable-next-line fb-www/extra-arrow-initializer
@@ -242,7 +242,7 @@ class Snapshot {
       this.checkRefCount_INTERNAL();
       const mutableSnapshot = new MutableSnapshot(this, batchUpdates);
       await mapper(mutableSnapshot);
-      return cloneSnapshot(mutableSnapshot.getStore_INTERNAL());
+      return mutableSnapshot;
     };
 }
 

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -73,6 +73,7 @@ This is currently a DEV-only warning but will become a thrown exception in the n
 // However, the data-flow-graph and selector values may evolve as selector
 // evaluation functions are executed and async selectors resolve.
 class Snapshot {
+  // eslint-disable-next-line fb-www/no-uninitialized-properties
   _store: Store;
   _refCount: number = 1;
 

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -495,6 +495,31 @@ testRecoil('getInfo', () => {
   ).toEqual([]);
 });
 
+describe('Retention', () => {
+  testRecoil('auto-release', async () => {
+    const snapshot = freshSnapshot();
+    expect(snapshot.isRetained()).toBe(true);
+
+    await flushPromisesAndTimers();
+    expect(snapshot.isRetained()).toBe(false);
+    expect(() => snapshot.retain()).toThrow('released');
+    // TODO enable when recoil_memory_managament_2020 is enforced
+    // expect(() => snapshot.getID()).toThrow('release');
+  });
+
+  testRecoil('retain()', async () => {
+    const snapshot = freshSnapshot();
+    expect(snapshot.isRetained()).toBe(true);
+    const release2 = snapshot.retain();
+
+    await flushPromisesAndTimers();
+    expect(snapshot.isRetained()).toBe(true);
+
+    release2();
+    expect(snapshot.isRetained()).toBe(false);
+  });
+});
+
 describe('Atom effects', () => {
   testRecoil('Standalone snapshot', async ({gks}) => {
     let effectsRefCount = 0;

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -26,6 +26,7 @@ let React,
   useRecoilValue,
   useRecoilState,
   useSetRecoilState,
+  useResetRecoilState,
   ReadsAtom,
   flushPromisesAndTimers,
   renderElements,
@@ -43,6 +44,7 @@ const testRecoil = getRecoilTestFn(() => {
     selector,
     useRecoilCallback,
     useSetRecoilState,
+    useResetRecoilState,
     useRecoilValue,
     useRecoilState,
   } = require('../../Recoil_index'));
@@ -574,5 +576,112 @@ describe('Selector Cache', () => {
 
     act(() => setMyAtom('a'));
     expect(container.textContent).toBe('a-3');
+  });
+});
+
+describe('Snapshot cache', () => {
+  testRecoil('Snapshot is cached', () => {
+    const myAtom = atom({
+      key: 'useRecoilCallback snapshot cached',
+      default: 'DEFAULT',
+    });
+
+    let getSnapshot;
+    let setMyAtom, resetMyAtom;
+    function Component() {
+      getSnapshot = useRecoilCallback(
+        ({snapshot}) =>
+          () =>
+            snapshot,
+      );
+      setMyAtom = useSetRecoilState(myAtom);
+      resetMyAtom = useResetRecoilState(myAtom);
+      return null;
+    }
+    renderElements(<Component />);
+
+    const getAtom = snapshot => snapshot?.getLoadable(myAtom).getValue();
+
+    const initialSnapshot = getSnapshot?.();
+    expect(getAtom(initialSnapshot)).toEqual('DEFAULT');
+
+    // If there are no state changes, the snapshot should be cached
+    const nextSnapshot = getSnapshot?.();
+    expect(getAtom(nextSnapshot)).toEqual('DEFAULT');
+    expect(nextSnapshot).toBe(initialSnapshot);
+
+    // With a state change, there is a new snapshot
+    act(() => setMyAtom('SET'));
+    const setSnapshot = getSnapshot?.();
+    expect(getAtom(setSnapshot)).toEqual('SET');
+    expect(setSnapshot).not.toBe(initialSnapshot);
+
+    const nextSetSnapshot = getSnapshot?.();
+    expect(getAtom(nextSetSnapshot)).toEqual('SET');
+    expect(nextSetSnapshot).toBe(setSnapshot);
+
+    act(() => setMyAtom('SET2'));
+    const set2Snapshot = getSnapshot?.();
+    expect(getAtom(set2Snapshot)).toEqual('SET2');
+    expect(set2Snapshot).not.toBe(initialSnapshot);
+    expect(set2Snapshot).not.toBe(setSnapshot);
+
+    const nextSet2Snapshot = getSnapshot?.();
+    expect(getAtom(nextSet2Snapshot)).toEqual('SET2');
+    expect(nextSet2Snapshot).toBe(set2Snapshot);
+
+    act(() => resetMyAtom());
+    const resetSnapshot = getSnapshot?.();
+    expect(getAtom(resetSnapshot)).toEqual('DEFAULT');
+    expect(resetSnapshot).not.toBe(initialSnapshot);
+    expect(resetSnapshot).not.toBe(setSnapshot);
+
+    const nextResetSnapshot = getSnapshot?.();
+    expect(getAtom(nextResetSnapshot)).toEqual('DEFAULT');
+    expect(nextResetSnapshot).toBe(resetSnapshot);
+  });
+
+  testRecoil('cached snapshot is invalidated if not retained', async () => {
+    const myAtom = atom({
+      key: 'useRecoilCallback snapshot cache retained',
+      default: 'DEFAULT',
+    });
+
+    let getSnapshot;
+    let setMyAtom;
+    function Component() {
+      getSnapshot = useRecoilCallback(
+        ({snapshot}) =>
+          () =>
+            snapshot,
+      );
+      setMyAtom = useSetRecoilState(myAtom);
+      return null;
+    }
+    renderElements(<Component />);
+
+    const getAtom = snapshot => snapshot?.getLoadable(myAtom).getValue();
+
+    act(() => setMyAtom('SET'));
+    const setSnapshot = getSnapshot?.();
+    expect(getAtom(setSnapshot)).toEqual('SET');
+
+    // If cached snapshot is released, a new snapshot is provided
+    await flushPromisesAndTimers();
+    const nextSetSnapshot = getSnapshot?.();
+    expect(nextSetSnapshot).not.toBe(setSnapshot);
+    expect(getAtom(nextSetSnapshot)).toEqual('SET');
+
+    act(() => setMyAtom('SET2'));
+    const set2Snapshot = getSnapshot?.();
+    expect(getAtom(set2Snapshot)).toEqual('SET2');
+    expect(set2Snapshot).not.toBe(setSnapshot);
+
+    // If cached snapshot is retained, then it is used again
+    set2Snapshot?.retain();
+    await flushPromisesAndTimers();
+    const nextSet2Snapshot = getSnapshot?.();
+    expect(getAtom(nextSet2Snapshot)).toEqual('SET2');
+    expect(nextSet2Snapshot).toBe(set2Snapshot);
   });
 });

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -265,9 +265,7 @@ function selector<T>(
   let liveStoresCount = 0;
 
   function selectorIsLive() {
-    return true;
-    // TODO Workaround for now to avoid hanging selectors
-    // return !gkx('recoil_memory_managament_2020') || liveStoresCount > 0;
+    return !gkx('recoil_memory_managament_2020') || liveStoresCount > 0;
   }
 
   function getExecutionInfo(store: Store): ExecutionInfo<T> {

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -108,10 +108,16 @@ function getError(recoilValue): Error {
 
 function setValue(recoilState, value) {
   setRecoilValue(store, recoilState, value);
+  // $FlowFixMe[unsafe-addition]
+  // $FlowFixMe[cannot-write]
+  store.getState().currentTree.version++;
 }
 
 function resetValue(recoilState) {
   setRecoilValue(store, recoilState, new DefaultValue());
+  // $FlowFixMe[unsafe-addition]
+  // $FlowFixMe[cannot-write]
+  store.getState().currentTree.version++;
 }
 
 testRecoil('useRecoilState - static selector', () => {
@@ -1604,9 +1610,16 @@ describe('getCallback', () => {
     });
 
     const menuItem = getValue(mySelector);
+    expect(getValue(myAtom)).toEqual('DEFAULT');
     await expect(menuItem.onClick()).resolves.toEqual('DEFAULT');
+
     act(() => setValue(myAtom, 'SET'));
+    expect(getValue(myAtom)).toEqual('SET');
     await expect(menuItem.onClick()).resolves.toEqual('SET');
+
+    act(() => setValue(myAtom, 'SET2'));
+    expect(getValue(myAtom)).toEqual('SET2');
+    await expect(menuItem.onClick()).resolves.toEqual('SET2');
   });
 
   testRecoil('snapshot', async () => {

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -54,7 +54,7 @@ const QUICK_TEST = false;
 // @fb-only: const IS_INTERNAL = true;
 const IS_INTERNAL = false; // @oss-only
 
-// TODO Use Snapshot for testing instead of this thunk?
+// TODO Use Snapshots for testing instead of this thunk?
 function makeStore(): Store {
   const storeState = makeEmptyStoreState();
   const store: Store = {

--- a/packages/shared/util/Recoil_Memoize.js
+++ b/packages/shared/util/Recoil_Memoize.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+/**
+ * Caches a function's results based on the key returned by the passed
+ * hashFunction.
+ */
+function memoizeWithArgsHash<TArgs: $ReadOnlyArray<mixed>, TReturn>(
+  fn: (...TArgs) => TReturn,
+  hashFunction: (...TArgs) => string,
+): (...TArgs) => TReturn {
+  let cache;
+  const memoizedFn: (...TArgs) => TReturn = (...args: TArgs): TReturn => {
+    if (!cache) {
+      cache = ({}: {[string]: TReturn});
+    }
+
+    // $FlowFixMe[incompatible-type]
+    const key = hashFunction(...args);
+    if (!Object.hasOwnProperty.call(cache, key)) {
+      cache[key] = fn.apply(this, args);
+    }
+    return cache[key];
+  };
+
+  return memoizedFn;
+}
+
+/**
+ * Caches a function's results based on a comparison of the arguments.
+ * Only caches the last return of the function.
+ * Defaults to reference equality
+ */
+function memoizeOneWithArgsHash<TArgs: $ReadOnlyArray<mixed>, TReturn>(
+  fn: (...TArgs) => TReturn,
+  hashFunction: (...TArgs) => string,
+): (...TArgs) => TReturn {
+  let lastKey: ?string;
+  let lastResult: TReturn;
+
+  // breaking cache when arguments change
+  const memoizedFn: (...TArgs) => TReturn = (...args: TArgs): TReturn => {
+    const key = hashFunction(...args);
+    if (lastKey === key) {
+      return lastResult;
+    }
+
+    lastKey = key;
+    lastResult = fn.apply(this, args);
+    return lastResult;
+  };
+
+  return memoizedFn;
+}
+
+/**
+ * Caches a function's results based on a comparison of the arguments.
+ * Only caches the last return of the function.
+ * Defaults to reference equality
+ */
+function memoizeOneWithArgsHashAndInvalidation<
+  TArgs: $ReadOnlyArray<mixed>,
+  TReturn,
+>(
+  fn: (...TArgs) => TReturn,
+  hashFunction: (...TArgs) => string,
+): [(...TArgs) => TReturn, () => void] {
+  let lastKey: ?string;
+  let lastResult: TReturn;
+
+  // breaking cache when arguments change
+  const memoizedFn: (...TArgs) => TReturn = (...args: TArgs): TReturn => {
+    const key = hashFunction(...args);
+    if (lastKey === key) {
+      return lastResult;
+    }
+
+    lastKey = key;
+    lastResult = fn.apply(this, args);
+    return lastResult;
+  };
+
+  const invalidate = () => {
+    lastKey = null;
+  };
+
+  return [memoizedFn, invalidate];
+}
+
+module.exports = {
+  memoizeWithArgsHash,
+  memoizeOneWithArgsHash,
+  memoizeOneWithArgsHashAndInvalidation,
+};

--- a/packages/shared/util/__tests__/Recoil_Memoize-test.js
+++ b/packages/shared/util/__tests__/Recoil_Memoize-test.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const {
+  memoizeOneWithArgsHash,
+  memoizeOneWithArgsHashAndInvalidation,
+  memoizeWithArgsHash,
+} = require('../Recoil_Memoize');
+
+describe('memoizeWithArgsHash', () => {
+  it('caches functions based on the hash function', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeWithArgsHash(f, (_a, _b, c) => String(c));
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(f.mock.calls.length).toBe(2);
+  });
+  it('handles "hasOwnProperty" as a hash key with no errors', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeWithArgsHash(f, () => 'hasOwnProperty');
+    expect(mem()).toBe(0);
+    expect(() => mem()).not.toThrow();
+    expect(mem(1)).toBe(0);
+    expect(f.mock.calls.length).toBe(1);
+  });
+});
+
+describe('memoizeOneWithArgsHash', () => {
+  it('caches functions based on the arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeOneWithArgsHash(
+      f,
+      (a, b, c) => String(a) + String(b) + String(c),
+    );
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(1, 2, 3)).toBe(3);
+    expect(f.mock.calls.length).toBe(4);
+  });
+  it('caches functions based on partial arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const mem = memoizeOneWithArgsHash(f, (_a, _b, c) => String(c));
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(1, 2, 4)).toBe(2);
+    expect(f.mock.calls.length).toBe(3);
+  });
+});
+
+describe('memoizeOneWithArgsHashAndInvalidation', () => {
+  it('caches functions based on the arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const [mem, invalidate] = memoizeOneWithArgsHashAndInvalidation(
+      f,
+      (a, b, c) => String(a) + String(b) + String(c),
+    );
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(0, 0, 3)).toBe(2);
+    expect(mem(1, 2, 3)).toBe(3);
+    expect(mem(1, 2, 3)).toBe(3);
+    invalidate();
+    expect(mem(1, 2, 3)).toBe(4);
+    expect(mem(1, 2, 3)).toBe(4);
+    expect(f.mock.calls.length).toBe(5);
+  });
+  it('caches functions based on partial arguments', () => {
+    let i = 0;
+    const f = jest.fn(() => i++);
+    const [mem, invalidate] = memoizeOneWithArgsHashAndInvalidation(
+      f,
+      (_a, _b, c) => String(c),
+    );
+    expect(mem()).toBe(0);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(0, 0, 3)).toBe(1);
+    expect(mem(1, 2, 3)).toBe(1);
+    expect(mem(1, 2, 4)).toBe(2);
+    expect(mem(1, 2, 4)).toBe(2);
+    invalidate();
+    expect(mem(1, 2, 4)).toBe(3);
+    expect(mem(1, 2, 4)).toBe(3);
+    expect(f.mock.calls.length).toBe(4);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,10 +2180,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-fb-www@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.7.tgz#a78ad301a229107d1f194fbc71b3440168bdca52"
-  integrity sha512-BBQVht+TkWLGli59nn2CNRbJZ5+AnqG2B02VipgfzSeB68mqBNiEXbPZ5ZbuMMwSgDN+95WCsS6y1ZZntst3Qg==
+eslint-plugin-fb-www@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.8.0.tgz#0d1b410e7c8da604f380245c58160fd5c42ddaea"
+  integrity sha512-3lUKYRFp8XUzf/qVLG56f5PC2zWkkyWwc/kuLcm0JDow48VjVaJU06f9cCAtkRtbum4T9G6VXsjO+dWi9Eqn2w==
 
 eslint-plugin-flowtype@^8.0.3:
   version "8.0.3"


### PR DESCRIPTION
Summary: Suppress the uninitialized store lint warning for Snapshot when it is initialized in the constructor.

Differential Revision: D33494577

