### PR TITLE
add Snapshot.isRetained() and check when retaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Callbacks from selector's `getCallback()` can now mutate, refresh, and transact Recoil state, in addition to reading it, for parity with `useRecoilCallback()`. (#1498)
 - Recoil StoreID's for `<RecoilRoot>` and `Snapshot` stores accessible via `useRecoilStoreID()` hook (#1417) or `storeID` parameter for atom effects (#1414).
 - `RecoilLoadable.all()` and `RecoilLoadable.of()` now accept either literal values, async Promises, or Loadables. (#1455, #1442)
+- Add `.isRetained()` method for Snapshots and check if snapshot is already released when using `.retain()` (#1546)
 
 ### Other Fixes and Optimizations
 

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -71,7 +71,7 @@ This is currently a DEV-only warning but will become a thrown exception in the n
 // evaluation functions are executed and async selectors resolve.
 class Snapshot {
   _store: Store;
-  _refCount: number = 0;
+  _refCount: number = 1;
 
   constructor(storeState: StoreState) {
     this._store = {
@@ -101,11 +101,23 @@ class Snapshot {
       initializeNode(this._store, nodeKey);
       updateRetainCount(this._store, nodeKey, 1);
     }
-    this.retain();
+
     this._autoRelease();
   }
 
   retain(): () => void {
+    if (__DEV__) {
+      if (this._refCount <= 0) {
+        throw err('Snapshot has already been released.');
+      }
+    } else {
+      if (this._refCount <= 0) {
+        recoverableViolation(
+          'Attempt to retain() Snapshot that was already released.',
+          'recoil',
+        );
+      }
+    }
     this._refCount++;
     let released = false;
     return () => {
@@ -141,6 +153,10 @@ class Snapshot {
       //   updateRetainCountToZero(this._store, k);
       // }
     }
+  }
+
+  isRetained(): boolean {
+    return this._refCount > 0;
   }
 
   checkRefCount_INTERNAL(): void {

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+import type {Snapshot} from '../Recoil_Snapshot';
+
 const {
   getRecoilTestFn,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
@@ -27,7 +29,6 @@ let React,
   asyncSelector,
   componentThatReadsAndWritesAtom,
   renderElements,
-  Snapshot,
   freshSnapshot,
   RecoilRoot;
 
@@ -50,7 +51,7 @@ const testRecoil = getRecoilTestFn(() => {
     componentThatReadsAndWritesAtom,
     renderElements,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
-  ({Snapshot, freshSnapshot} = require('../Recoil_Snapshot'));
+  ({freshSnapshot} = require('../Recoil_Snapshot'));
   ({RecoilRoot} = require('../Recoil_RecoilRoot'));
 });
 
@@ -493,6 +494,38 @@ testRecoil('getInfo', () => {
   expect(
     Array.from(resetSnapshot.getInfo_UNSTABLE(selectorB).subscribers.nodes),
   ).toEqual([]);
+});
+
+describe('Retention', () => {
+  testRecoil('auto-release', async () => {
+    const snapshot = freshSnapshot();
+    expect(snapshot.isRetained()).toBe(true);
+
+    await flushPromisesAndTimers();
+    expect(snapshot.isRetained()).toBe(false);
+
+    const devStatus = window.__DEV__;
+    window.__DEV__ = true;
+    expect(() => snapshot.retain()).toThrow('released');
+    window.__DEV__ = false;
+    expect(() => snapshot.retain()).not.toThrow('released');
+    window.__DEV__ = devStatus;
+
+    // TODO enable when recoil_memory_managament_2020 is enforced
+    // expect(() => snapshot.getID()).toThrow('release');
+  });
+
+  testRecoil('retain()', async () => {
+    const snapshot = freshSnapshot();
+    expect(snapshot.isRetained()).toBe(true);
+    const release2 = snapshot.retain();
+
+    await flushPromisesAndTimers();
+    expect(snapshot.isRetained()).toBe(true);
+
+    release2();
+    expect(snapshot.isRetained()).toBe(false);
+  });
 });
 
 describe('Atom effects', () => {


### PR DESCRIPTION
Summary: Add an `isRetained()` method for Snapshots and do a safety check in `retain()` to make sure we are not trying to retain snapshots that have already been released.

Differential Revision: D33559535

