### PR TITLE
getNodeInfo() always reports atom/selector type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ### Breaking Changes
 - Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`. (#1509)
+- `useGetRecoilValueInfo_UNSTABLE()` and `Snapshot#getInfo_UNSTABLE()` always report the node `type`. (#1547)
 
 ## 0.5.2 (2021-11-07)
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^4.2.0",
     "eslint": "^8.2.0",
-    "eslint-plugin-fb-www": "^1.0.7",
+    "eslint-plugin-fb-www": "^1.8.0",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -179,7 +179,7 @@ export type RecoilValueInfo<T> = {
   isActive: boolean,
   isSet: boolean,
   isModified: boolean, // TODO report modified selectors
-  type: 'atom' | 'selector' | void, // void until initialized for now
+  type: 'atom' | 'selector',
   deps: Iterable<RecoilValue<mixed>>,
   subscribers: {
     nodes: Iterable<RecoilValue<mixed>>,
@@ -194,11 +194,7 @@ function peekNodeInfo<T>(
 ): RecoilValueInfo<T> {
   const storeState = store.getState();
   const graph = store.getGraph(state.version);
-  const type = storeState.knownAtoms.has(key)
-    ? 'atom'
-    : storeState.knownSelectors.has(key)
-    ? 'selector'
-    : undefined;
+  const type = getNode(key).nodeType;
   const downstreamNodes = filterIterable(
     getDownstreamNodes(store, state, new Set([key])),
     nodeKey => nodeKey !== key,

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -303,7 +303,6 @@ function cloneStoreState(
     queuedComponentCallbacks_DEPRECATED: [],
     suspendedComponentResolvers: new Set(),
     graphsByVersion: new Map().set(version, store.getGraph(treeState.version)),
-    versionsUsedByComponent: new Map(),
     retention: {
       referenceCounts: new Map(),
       nodesRetainedByZone: new Map(),

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -73,6 +73,7 @@ This is currently a DEV-only warning but will become a thrown exception in the n
 // However, the data-flow-graph and selector values may evolve as selector
 // evaluation functions are executed and async selectors resolve.
 class Snapshot {
+  // eslint-disable-next-line fb-www/no-uninitialized-properties
   _store: Store;
   _refCount: number = 1;
 

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -76,12 +76,6 @@ export type StoreState = {
   knownAtoms: Set<NodeKey>,
   knownSelectors: Set<NodeKey>,
 
-  // Which state versions are being read by a given component. (COMMIT/SUSPEND)
-  // Added to when components commit or suspend after reading a version.
-  // Removed from when components (1) unmount (2) commit another version
-  // or (3) wake from suspense.
-  +versionsUsedByComponent: Map<ComponentID, StateID>,
-
   +retention: {
     referenceCounts: Map<NodeKey | RetentionZone, number>,
     nodesRetainedByZone: Map<RetentionZone, Set<NodeKey>>,
@@ -169,7 +163,6 @@ function makeEmptyStoreState(): StoreState {
     queuedComponentCallbacks_DEPRECATED: [],
     suspendedComponentResolvers: new Set(),
     graphsByVersion: new Map().set(currentTree.version, graph()),
-    versionsUsedByComponent: new Map(),
     retention: {
       referenceCounts: new Map(),
       nodesRetainedByZone: new Map(),

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -359,7 +359,7 @@ testRecoil('getInfo', () => {
     isActive: false,
     isSet: false,
     isModified: false,
-    type: undefined,
+    type: 'atom',
   });
   expect(Array.from(snapshot.getInfo_UNSTABLE(myAtom).deps)).toEqual([]);
   expect(
@@ -370,7 +370,7 @@ testRecoil('getInfo', () => {
     isActive: false,
     isSet: false,
     isModified: false,
-    type: undefined,
+    type: 'selector',
   });
   expect(Array.from(snapshot.getInfo_UNSTABLE(selectorA).deps)).toEqual([]);
   expect(
@@ -381,7 +381,7 @@ testRecoil('getInfo', () => {
     isActive: false,
     isSet: false,
     isModified: false,
-    type: undefined,
+    type: 'selector',
   });
   expect(Array.from(snapshot.getInfo_UNSTABLE(selectorB).deps)).toEqual([]);
   expect(

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+obviz
+ * @emails oncall+recoil
  * @flow strict-local
  * @format
  */

--- a/packages/recoil/core/__tests__/Recoil_perf-test.js
+++ b/packages/recoil/core/__tests__/Recoil_perf-test.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+obviz
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {Loadable, RecoilState, RecoilValue} from '../../Recoil_index';
+
+const {atom, selector} = require('../../Recoil_index');
+const {
+  getRecoilValueAsLoadable,
+  setRecoilValue,
+} = require('../Recoil_RecoilValueInterface');
+const {performance} = require('perf_hooks');
+const {makeStore} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
+
+const ITERATIONS = [1]; // Avoid iterating for automated testing
+// const ITERATIONS = [2, 2];
+// const ITERATIONS = [10, 100, 1000];
+// const ITERATIONS = [10, 100, 1000, 10000];
+// const ITERATIONS = [10, 100, 1000, 10000, 100000];
+
+function testPerf(name: string, fn: number => void) {
+  test.each(ITERATIONS)(name, iterations => {
+    store = makeStore();
+    const BEGIN = performance.now();
+    fn(iterations);
+    const END = performance.now();
+    console.log(`${name}(${iterations})`, END - BEGIN);
+  });
+}
+
+let store = makeStore();
+
+function getNodeLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
+  return getRecoilValueAsLoadable(store, recoilValue);
+}
+
+function getNodeValue<T>(recoilValue: RecoilValue<T>): T {
+  return getNodeLoadable(recoilValue).getValue();
+}
+
+function setNode(recoilValue, value: mixed) {
+  setRecoilValue(store, recoilValue, value);
+  // $FlowFixMe[unsafe-addition]
+  // $FlowFixMe[cannot-write]
+  store.getState().currentTree.version++;
+}
+
+let nextAtomKey = 0;
+
+function createAtoms(num): Array<RecoilState<string>> {
+  const atoms = Array(num);
+  const atomKey = nextAtomKey++;
+  for (let i = 0; i < num; i++) {
+    atoms[i] = atom({
+      key: `PERF-${atomKey}-${i}`,
+      default: 'DEFAULT',
+    });
+  }
+  return atoms;
+}
+
+const helpersSelector = () =>
+  selector({
+    key: `PERF-helpers-${nextAtomKey++}`,
+    get: ({getCallback}) => ({
+      getSnapshot: getCallback(
+        ({snapshot}) =>
+          () =>
+            snapshot,
+      ),
+    }),
+  });
+const getHelpers = () => getNodeValue(helpersSelector());
+
+testPerf('creating n atoms', iterations => {
+  createAtoms(iterations);
+});
+
+testPerf('getting n atoms', iterations => {
+  const atoms = createAtoms(iterations);
+  for (const node of atoms) {
+    getNodeValue(node);
+  }
+});
+
+testPerf('setting n atoms', iterations => {
+  const atoms = createAtoms(iterations);
+  for (const node of atoms) {
+    setNode(node, 'SET');
+  }
+});
+
+testPerf('cloning n snapshots', iterations => {
+  const atoms = createAtoms(iterations);
+  const {getSnapshot} = getHelpers();
+  for (const node of atoms) {
+    // Set node to avoid hitting cached snapshots
+    setNode(node, 'SET');
+    const snapshot = getSnapshot();
+    expect(getNodeValue(node)).toBe('SET');
+    expect(snapshot.getLoadable(node).contents).toBe('SET');
+  }
+});

--- a/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -73,7 +73,7 @@ testRecoil(
       isActive: false,
       isSet: false,
       isModified: false,
-      type: undefined,
+      type: 'atom',
     });
     expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
     expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
@@ -89,7 +89,7 @@ testRecoil(
       isActive: false,
       isSet: false,
       isModified: false,
-      type: undefined,
+      type: 'selector',
     });
     expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual([]);
     expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
@@ -105,7 +105,7 @@ testRecoil(
       isActive: false,
       isSet: false,
       isModified: false,
-      type: undefined,
+      type: 'selector',
     });
     expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual([]);
     expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(

--- a/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+obviz
+ * @emails oncall+recoil
  * @flow strict-local
  * @format
  */

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -1518,6 +1518,7 @@ testRecoil(
      * Run selector chain so that selectorB recalculates as a result of atomA
      * being changed to "3"
      */
+    mappedSnapshot.retain();
     await flushPromisesAndTimers();
 
     const loadableB = mappedSnapshot.getLoadable(selectorC);

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -52,7 +52,7 @@
   isActive: boolean;
   isSet: boolean;
   isModified: boolean; // TODO report modified selectors
-  type: 'atom' | 'selector' | undefined; // undefined until initialized for now
+  type: 'atom' | 'selector';
   deps: Iterable<RecoilValue<T>>;
   subscribers: {
     nodes: Iterable<RecoilValue<T>>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,10 +2180,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-fb-www@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.7.tgz#a78ad301a229107d1f194fbc71b3440168bdca52"
-  integrity sha512-BBQVht+TkWLGli59nn2CNRbJZ5+AnqG2B02VipgfzSeB68mqBNiEXbPZ5ZbuMMwSgDN+95WCsS6y1ZZntst3Qg==
+eslint-plugin-fb-www@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.8.0.tgz#0d1b410e7c8da604f380245c58160fd5c42ddaea"
+  integrity sha512-3lUKYRFp8XUzf/qVLG56f5PC2zWkkyWwc/kuLcm0JDow48VjVaJU06f9cCAtkRtbum4T9G6VXsjO+dWi9Eqn2w==
 
 eslint-plugin-flowtype@^8.0.3:
   version "8.0.3"


### PR DESCRIPTION
Summary: When `getNodeInfo_UNSTABLE()` was originally implemented the atom and selector internal node interface was more abstract.  Now there is an explicit `'atom' | 'selector'` type which we can use to always report the type of any registered node.

Differential Revision: D33559658

