### PR TITLE
memoize lazy properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
+- Memoize the results of lazy proxies. (#1548)
 
 ### Breaking Changes
 - Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`. (#1509)

--- a/packages/shared/util/__tests__/Recoil_lazyProxy-test.js
+++ b/packages/shared/util/__tests__/Recoil_lazyProxy-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const lazyProxy = require('../Recoil_lazyProxy');
+
+test('lazyProxy', () => {
+  const lazyProp = jest.fn(() => 456);
+  const proxy = lazyProxy(
+    {
+      foo: 123,
+    },
+    {
+      bar: lazyProp,
+    },
+  );
+
+  expect(proxy.foo).toBe(123);
+  expect(proxy.bar).toBe(456);
+  expect(lazyProp).toHaveBeenCalledTimes(1);
+
+  expect(proxy.bar).toBe(456);
+  expect(lazyProp).toHaveBeenCalledTimes(1);
+});
+
+test('lazyProxy - keys', () => {
+  const proxy = lazyProxy(
+    {
+      foo: 123,
+    },
+    {
+      bar: () => 456,
+    },
+  );
+
+  expect(Object.keys(proxy)).toEqual(['foo', 'bar']);
+  expect('foo' in proxy).toBe(true);
+  expect('bar' in proxy).toBe(true);
+
+  const keys = [];
+  for (const key in proxy) {
+    keys.push(key);
+  }
+  expect(keys).toEqual(['foo', 'bar']);
+});


### PR DESCRIPTION
Summary: Optimize lazy properties by only computing them once and then memoizing the value.  Also fix the proxy objects to report the proper set of keys for both the static and lazy dynamic properties.

Differential Revision: D33559815

