### PR TITLE
Remove reference to obsolete recoil_async_selector_refactor GK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
+- Lazily compute the properties of `useGetRecoilValueInfo_UNSTABLE()` and `Snapshot#getInfo_UNSTABLE()` results (#1549)
 - Memoize the results of lazy proxies. (#1548)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
+- Memoize the results of lazy proxies. (#1548)
 
 ### Breaking Changes
 - Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`. (#1509)

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -55,6 +55,11 @@ const testRecoil = getRecoilTestFn(() => {
   ({RecoilRoot} = require('../Recoil_RecoilRoot'));
 });
 
+// Use this to spread proxy results into an object for Jest's toMatchObject()
+function getInfo(snapshot, node) {
+  return {...snapshot.getInfo_UNSTABLE(node)};
+}
+
 // Test first since we are testing all registered nodes
 testRecoil('getNodes', () => {
   const snapshot = freshSnapshot();
@@ -354,67 +359,65 @@ testRecoil('getInfo', () => {
   });
 
   // Initial status
-  expect(snapshot.getInfo_UNSTABLE(myAtom)).toMatchObject({
+  expect(getInfo(snapshot, myAtom)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
     isActive: false,
     isSet: false,
     isModified: false,
     type: 'atom',
   });
-  expect(Array.from(snapshot.getInfo_UNSTABLE(myAtom).deps)).toEqual([]);
-  expect(
-    Array.from(snapshot.getInfo_UNSTABLE(myAtom).subscribers.nodes),
-  ).toEqual([]);
-  expect(snapshot.getInfo_UNSTABLE(selectorA)).toMatchObject({
+  expect(Array.from(getInfo(snapshot, myAtom).deps)).toEqual([]);
+  expect(Array.from(getInfo(snapshot, myAtom).subscribers.nodes)).toEqual([]);
+  expect(getInfo(snapshot, selectorA)).toMatchObject({
     loadable: undefined,
     isActive: false,
     isSet: false,
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(snapshot.getInfo_UNSTABLE(selectorA).deps)).toEqual([]);
-  expect(
-    Array.from(snapshot.getInfo_UNSTABLE(selectorA).subscribers.nodes),
-  ).toEqual([]);
-  expect(snapshot.getInfo_UNSTABLE(selectorB)).toMatchObject({
+  expect(Array.from(getInfo(snapshot, selectorA).deps)).toEqual([]);
+  expect(Array.from(getInfo(snapshot, selectorA).subscribers.nodes)).toEqual(
+    [],
+  );
+  expect(getInfo(snapshot, selectorB)).toMatchObject({
     loadable: undefined,
     isActive: false,
     isSet: false,
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(snapshot.getInfo_UNSTABLE(selectorB).deps)).toEqual([]);
-  expect(
-    Array.from(snapshot.getInfo_UNSTABLE(selectorB).subscribers.nodes),
-  ).toEqual([]);
+  expect(Array.from(getInfo(snapshot, selectorB).deps)).toEqual([]);
+  expect(Array.from(getInfo(snapshot, selectorB).subscribers.nodes)).toEqual(
+    [],
+  );
 
   // After reading values
   snapshot.getLoadable(selectorB);
-  expect(snapshot.getInfo_UNSTABLE(myAtom)).toMatchObject({
+  expect(getInfo(snapshot, myAtom)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
     isActive: true,
     isSet: false,
     isModified: false,
     type: 'atom',
   });
-  expect(Array.from(snapshot.getInfo_UNSTABLE(myAtom).deps)).toEqual([]);
-  expect(
-    Array.from(snapshot.getInfo_UNSTABLE(myAtom).subscribers.nodes),
-  ).toEqual(expect.arrayContaining([selectorA, selectorB]));
-  expect(snapshot.getInfo_UNSTABLE(selectorA)).toMatchObject({
+  expect(Array.from(getInfo(snapshot, myAtom).deps)).toEqual([]);
+  expect(Array.from(getInfo(snapshot, myAtom).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB]),
+  );
+  expect(getInfo(snapshot, selectorA)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
     isActive: true,
     isSet: false,
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(snapshot.getInfo_UNSTABLE(selectorA).deps)).toEqual(
+  expect(Array.from(getInfo(snapshot, selectorA).deps)).toEqual(
     expect.arrayContaining([myAtom]),
   );
-  expect(
-    Array.from(snapshot.getInfo_UNSTABLE(selectorA).subscribers.nodes),
-  ).toEqual(expect.arrayContaining([selectorB]));
-  expect(snapshot.getInfo_UNSTABLE(selectorB)).toMatchObject({
+  expect(Array.from(getInfo(snapshot, selectorA).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorB]),
+  );
+  expect(getInfo(snapshot, selectorB)).toMatchObject({
     loadable: expect.objectContaining({
       state: 'hasValue',
       contents: 'DEFAULTDEFAULT',
@@ -424,82 +427,82 @@ testRecoil('getInfo', () => {
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(snapshot.getInfo_UNSTABLE(selectorB).deps)).toEqual(
+  expect(Array.from(getInfo(snapshot, selectorB).deps)).toEqual(
     expect.arrayContaining([myAtom, selectorA]),
   );
-  expect(
-    Array.from(snapshot.getInfo_UNSTABLE(selectorB).subscribers.nodes),
-  ).toEqual([]);
+  expect(Array.from(getInfo(snapshot, selectorB).subscribers.nodes)).toEqual(
+    [],
+  );
 
   // After setting a value
   const setSnapshot = snapshot.map(({set}) => set(myAtom, 'SET'));
   setSnapshot.getLoadable(selectorB); // Read value to prime
-  expect(setSnapshot.getInfo_UNSTABLE(myAtom)).toMatchObject({
+  expect(getInfo(setSnapshot, myAtom)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
     isActive: true,
     isSet: true,
     isModified: true,
     type: 'atom',
   });
-  expect(Array.from(setSnapshot.getInfo_UNSTABLE(myAtom).deps)).toEqual([]);
-  expect(
-    Array.from(setSnapshot.getInfo_UNSTABLE(myAtom).subscribers.nodes),
-  ).toEqual(expect.arrayContaining([selectorA, selectorB]));
-  expect(setSnapshot.getInfo_UNSTABLE(selectorA)).toMatchObject({
+  expect(Array.from(getInfo(setSnapshot, myAtom).deps)).toEqual([]);
+  expect(Array.from(getInfo(setSnapshot, myAtom).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB]),
+  );
+  expect(getInfo(setSnapshot, selectorA)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
     isActive: true,
     isSet: false,
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(setSnapshot.getInfo_UNSTABLE(selectorA).deps)).toEqual(
+  expect(Array.from(getInfo(setSnapshot, selectorA).deps)).toEqual(
     expect.arrayContaining([myAtom]),
   );
-  expect(
-    Array.from(setSnapshot.getInfo_UNSTABLE(selectorA).subscribers.nodes),
-  ).toEqual(expect.arrayContaining([selectorB]));
-  expect(setSnapshot.getInfo_UNSTABLE(selectorB)).toMatchObject({
+  expect(Array.from(getInfo(setSnapshot, selectorA).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorB]),
+  );
+  expect(getInfo(setSnapshot, selectorB)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'SETSET'}),
     isActive: true,
     isSet: false,
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(setSnapshot.getInfo_UNSTABLE(selectorB).deps)).toEqual(
+  expect(Array.from(getInfo(setSnapshot, selectorB).deps)).toEqual(
     expect.arrayContaining([myAtom, selectorA]),
   );
-  expect(
-    Array.from(setSnapshot.getInfo_UNSTABLE(selectorB).subscribers.nodes),
-  ).toEqual([]);
+  expect(Array.from(getInfo(setSnapshot, selectorB).subscribers.nodes)).toEqual(
+    [],
+  );
 
   // After reseting a value
   const resetSnapshot = setSnapshot.map(({reset}) => reset(myAtom));
   resetSnapshot.getLoadable(selectorB); // prime snapshot
-  expect(resetSnapshot.getInfo_UNSTABLE(myAtom)).toMatchObject({
+  expect(getInfo(resetSnapshot, myAtom)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
     isActive: true,
     isSet: false,
     isModified: true,
     type: 'atom',
   });
-  expect(Array.from(resetSnapshot.getInfo_UNSTABLE(myAtom).deps)).toEqual([]);
-  expect(
-    Array.from(resetSnapshot.getInfo_UNSTABLE(myAtom).subscribers.nodes),
-  ).toEqual(expect.arrayContaining([selectorA, selectorB]));
-  expect(resetSnapshot.getInfo_UNSTABLE(selectorA)).toMatchObject({
+  expect(Array.from(getInfo(resetSnapshot, myAtom).deps)).toEqual([]);
+  expect(Array.from(getInfo(resetSnapshot, myAtom).subscribers.nodes)).toEqual(
+    expect.arrayContaining([selectorA, selectorB]),
+  );
+  expect(getInfo(resetSnapshot, selectorA)).toMatchObject({
     loadable: expect.objectContaining({state: 'hasValue', contents: 'DEFAULT'}),
     isActive: true,
     isSet: false,
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(resetSnapshot.getInfo_UNSTABLE(selectorA).deps)).toEqual(
+  expect(Array.from(getInfo(resetSnapshot, selectorA).deps)).toEqual(
     expect.arrayContaining([myAtom]),
   );
   expect(
-    Array.from(resetSnapshot.getInfo_UNSTABLE(selectorA).subscribers.nodes),
+    Array.from(getInfo(resetSnapshot, selectorA).subscribers.nodes),
   ).toEqual(expect.arrayContaining([selectorB]));
-  expect(resetSnapshot.getInfo_UNSTABLE(selectorB)).toMatchObject({
+  expect(getInfo(resetSnapshot, selectorB)).toMatchObject({
     loadable: expect.objectContaining({
       state: 'hasValue',
       contents: 'DEFAULTDEFAULT',
@@ -509,11 +512,11 @@ testRecoil('getInfo', () => {
     isModified: false,
     type: 'selector',
   });
-  expect(Array.from(resetSnapshot.getInfo_UNSTABLE(selectorB).deps)).toEqual(
+  expect(Array.from(getInfo(resetSnapshot, selectorB).deps)).toEqual(
     expect.arrayContaining([myAtom, selectorA]),
   );
   expect(
-    Array.from(resetSnapshot.getInfo_UNSTABLE(selectorB).subscribers.nodes),
+    Array.from(getInfo(resetSnapshot, selectorB).subscribers.nodes),
   ).toEqual([]);
 });
 

--- a/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -53,19 +53,20 @@ testRecoil(
       get: ({get}) => get(selectorA) + get(myAtom),
     });
 
-    let getRecoilValueInfo = _ => {
+    let getNodeInfo = _ => {
       expect(false).toBe(true);
       throw new Error('getRecoilValue not set');
     };
     function GetRecoilValueInfo() {
-      getRecoilValueInfo = useGetRecoilValueInfo();
+      const getRecoilValueInfo = useGetRecoilValueInfo();
+      getNodeInfo = node => ({...getRecoilValueInfo(node)});
       return null;
     }
 
     // Initial status
     renderElements(<GetRecoilValueInfo />);
 
-    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    expect(getNodeInfo(myAtom)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'DEFAULT',
@@ -75,46 +76,40 @@ testRecoil(
       isModified: false,
       type: 'atom',
     });
-    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
-      [],
-    );
+    expect(Array.from(getNodeInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getNodeInfo(myAtom).subscribers.nodes)).toEqual([]);
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
-      ).toEqual([]);
+      expect(Array.from(getNodeInfo(myAtom).subscribers.components)).toEqual(
+        [],
+      );
     }
-    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    expect(getNodeInfo(selectorA)).toMatchObject({
       loadable: undefined,
       isActive: false,
       isSet: false,
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual([]);
-    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
-      [],
-    );
+    expect(Array.from(getNodeInfo(selectorA).deps)).toEqual([]);
+    expect(Array.from(getNodeInfo(selectorA).subscribers.nodes)).toEqual([]);
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-      ).toEqual([]);
+      expect(Array.from(getNodeInfo(selectorA).subscribers.components)).toEqual(
+        [],
+      );
     }
-    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    expect(getNodeInfo(selectorB)).toMatchObject({
       loadable: undefined,
       isActive: false,
       isSet: false,
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual([]);
-    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-      [],
-    );
+    expect(Array.from(getNodeInfo(selectorB).deps)).toEqual([]);
+    expect(Array.from(getNodeInfo(selectorB).subscribers.nodes)).toEqual([]);
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-      ).toEqual([]);
+      expect(Array.from(getNodeInfo(selectorB).subscribers.components)).toEqual(
+        [],
+      );
     }
 
     // After reading values
@@ -129,7 +124,7 @@ testRecoil(
     );
     expect(c.textContent).toEqual('"DEFAULT""DEFAULTDEFAULT"');
 
-    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    expect(getNodeInfo(myAtom)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'DEFAULT',
@@ -139,16 +134,16 @@ testRecoil(
       isModified: false,
       type: 'atom',
     });
-    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+    expect(Array.from(getNodeInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getNodeInfo(myAtom).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorA, selectorB]),
     );
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
-      ).toEqual([{name: 'ReadsAndWritesAtom'}]);
+      expect(Array.from(getNodeInfo(myAtom).subscribers.components)).toEqual([
+        {name: 'ReadsAndWritesAtom'},
+      ]);
     }
-    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    expect(getNodeInfo(selectorA)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'DEFAULT',
@@ -158,18 +153,18 @@ testRecoil(
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+    expect(Array.from(getNodeInfo(selectorA).deps)).toEqual(
       expect.arrayContaining([myAtom]),
     );
-    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+    expect(Array.from(getNodeInfo(selectorA).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorB]),
     );
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-      ).toEqual([]);
+      expect(Array.from(getNodeInfo(selectorA).subscribers.components)).toEqual(
+        [],
+      );
     }
-    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    expect(getNodeInfo(selectorB)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'DEFAULTDEFAULT',
@@ -179,56 +174,54 @@ testRecoil(
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+    expect(Array.from(getNodeInfo(selectorB).deps)).toEqual(
       expect.arrayContaining([myAtom, selectorA]),
     );
-    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-      [],
-    );
+    expect(Array.from(getNodeInfo(selectorB).subscribers.nodes)).toEqual([]);
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-      ).toEqual([{name: 'ReadsAtom'}]);
+      expect(Array.from(getNodeInfo(selectorB).subscribers.components)).toEqual(
+        [{name: 'ReadsAtom'}],
+      );
     }
 
     // After setting a value
     act(() => setAtom('SET'));
 
-    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    expect(getNodeInfo(myAtom)).toMatchObject({
       loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
       isActive: true,
       isSet: true,
       isModified: true,
       type: 'atom',
     });
-    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+    expect(Array.from(getNodeInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getNodeInfo(myAtom).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorA, selectorB]),
     );
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
-      ).toEqual([{name: 'ReadsAndWritesAtom'}]);
+      expect(Array.from(getNodeInfo(myAtom).subscribers.components)).toEqual([
+        {name: 'ReadsAndWritesAtom'},
+      ]);
     }
-    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    expect(getNodeInfo(selectorA)).toMatchObject({
       loadable: expect.objectContaining({state: 'hasValue', contents: 'SET'}),
       isActive: true,
       isSet: false,
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+    expect(Array.from(getNodeInfo(selectorA).deps)).toEqual(
       expect.arrayContaining([myAtom]),
     );
-    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+    expect(Array.from(getNodeInfo(selectorA).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorB]),
     );
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-      ).toEqual([]);
+      expect(Array.from(getNodeInfo(selectorA).subscribers.components)).toEqual(
+        [],
+      );
     }
-    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    expect(getNodeInfo(selectorB)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'SETSET',
@@ -238,22 +231,20 @@ testRecoil(
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+    expect(Array.from(getNodeInfo(selectorB).deps)).toEqual(
       expect.arrayContaining([myAtom, selectorA]),
     );
-    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-      [],
-    );
+    expect(Array.from(getNodeInfo(selectorB).subscribers.nodes)).toEqual([]);
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-      ).toEqual([{name: 'ReadsAtom'}]);
+      expect(Array.from(getNodeInfo(selectorB).subscribers.components)).toEqual(
+        [{name: 'ReadsAtom'}],
+      );
     }
 
     // After reseting a value
     act(resetAtom);
 
-    expect(getRecoilValueInfo(myAtom)).toMatchObject({
+    expect(getNodeInfo(myAtom)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'DEFAULT',
@@ -263,16 +254,16 @@ testRecoil(
       isModified: true,
       type: 'atom',
     });
-    expect(Array.from(getRecoilValueInfo(myAtom).deps)).toEqual([]);
-    expect(Array.from(getRecoilValueInfo(myAtom).subscribers.nodes)).toEqual(
+    expect(Array.from(getNodeInfo(myAtom).deps)).toEqual([]);
+    expect(Array.from(getNodeInfo(myAtom).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorA, selectorB]),
     );
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(myAtom).subscribers.components),
-      ).toEqual([{name: 'ReadsAndWritesAtom'}]);
+      expect(Array.from(getNodeInfo(myAtom).subscribers.components)).toEqual([
+        {name: 'ReadsAndWritesAtom'},
+      ]);
     }
-    expect(getRecoilValueInfo(selectorA)).toMatchObject({
+    expect(getNodeInfo(selectorA)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'DEFAULT',
@@ -282,18 +273,18 @@ testRecoil(
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorA).deps)).toEqual(
+    expect(Array.from(getNodeInfo(selectorA).deps)).toEqual(
       expect.arrayContaining([myAtom]),
     );
-    expect(Array.from(getRecoilValueInfo(selectorA).subscribers.nodes)).toEqual(
+    expect(Array.from(getNodeInfo(selectorA).subscribers.nodes)).toEqual(
       expect.arrayContaining([selectorB]),
     );
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorA).subscribers.components),
-      ).toEqual([]);
+      expect(Array.from(getNodeInfo(selectorA).subscribers.components)).toEqual(
+        [],
+      );
     }
-    expect(getRecoilValueInfo(selectorB)).toMatchObject({
+    expect(getNodeInfo(selectorB)).toMatchObject({
       loadable: expect.objectContaining({
         state: 'hasValue',
         contents: 'DEFAULTDEFAULT',
@@ -303,16 +294,14 @@ testRecoil(
       isModified: false,
       type: 'selector',
     });
-    expect(Array.from(getRecoilValueInfo(selectorB).deps)).toEqual(
+    expect(Array.from(getNodeInfo(selectorB).deps)).toEqual(
       expect.arrayContaining([myAtom, selectorA]),
     );
-    expect(Array.from(getRecoilValueInfo(selectorB).subscribers.nodes)).toEqual(
-      [],
-    );
+    expect(Array.from(getNodeInfo(selectorB).subscribers.nodes)).toEqual([]);
     if (gks.includes('recoil_infer_component_names')) {
-      expect(
-        Array.from(getRecoilValueInfo(selectorB).subscribers.components),
-      ).toEqual([{name: 'ReadsAtom'}]);
+      expect(Array.from(getNodeInfo(selectorB).subscribers.components)).toEqual(
+        [{name: 'ReadsAtom'}],
+      );
     }
   },
   // @fb-only: {gks: [['recoil_infer_component_names', 'recoil_async_selector_refactor']]},

--- a/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGetRecoilValueInfo-test.js
@@ -304,5 +304,5 @@ testRecoil(
       );
     }
   },
-  // @fb-only: {gks: [['recoil_infer_component_names', 'recoil_async_selector_refactor']]},
+  // @fb-only: {gks: [['recoil_infer_component_names']]},
 );

--- a/packages/shared/util/__tests__/Recoil_lazyProxy-test.js
+++ b/packages/shared/util/__tests__/Recoil_lazyProxy-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+const lazyProxy = require('../Recoil_lazyProxy');
+
+test('lazyProxy', () => {
+  const lazyProp = jest.fn(() => 456);
+  const proxy = lazyProxy(
+    {
+      foo: 123,
+    },
+    {
+      bar: lazyProp,
+    },
+  );
+
+  expect(proxy.foo).toBe(123);
+  expect(proxy.bar).toBe(456);
+  expect(lazyProp).toHaveBeenCalledTimes(1);
+
+  expect(proxy.bar).toBe(456);
+  expect(lazyProp).toHaveBeenCalledTimes(1);
+});
+
+test('lazyProxy - keys', () => {
+  const proxy = lazyProxy(
+    {
+      foo: 123,
+    },
+    {
+      bar: () => 456,
+    },
+  );
+
+  expect(Object.keys(proxy)).toEqual(['foo', 'bar']);
+  expect('foo' in proxy).toBe(true);
+  expect('bar' in proxy).toBe(true);
+
+  const keys = [];
+  for (const key in proxy) {
+    keys.push(key);
+  }
+  expect(keys).toEqual(['foo', 'bar']);
+});


### PR DESCRIPTION
Summary: Remove reference to obsolete recoil_async_selector_refactor GK in unit tests.

Differential Revision: D33560371

