### PR TITLE
Experimental mode for useTransition()

### DIFF
--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -42,7 +42,7 @@ const useSyncExternalStore: <T>(
   (React: any).unstable_useSyncExternalStore;
 
 type ReactMode =
-  | 'CONCURRENT_LEGACY'
+  | 'CONCURRENT_SUPPORT'
   | 'SYNC_EXTERNAL_STORE'
   | 'MUTABLE_SOURCE'
   | 'LEGACY';
@@ -58,8 +58,8 @@ type ReactMode =
 function reactMode(): {mode: ReactMode, early: boolean, concurrent: boolean} {
   // NOTE: This mode is currently broken with some Suspense cases
   // see Recoil_selector-test.js
-  if (gkx('recoil_concurrent_legacy')) {
-    return {mode: 'CONCURRENT_LEGACY', early: true, concurrent: true};
+  if (gkx('recoil_concurrent_support')) {
+    return {mode: 'CONCURRENT_SUPPORT', early: true, concurrent: true};
   }
 
   if (gkx('recoil_sync_external_store') && useSyncExternalStore != null) {

--- a/packages/recoil/core/Recoil_RecoilValueInterface.js
+++ b/packages/recoil/core/Recoil_RecoilValueInterface.js
@@ -313,7 +313,11 @@ function subscribeToRecoilValue<T>(
 
   // Handle the case that, during the same tick that we are subscribing, an atom
   // has been updated by some effect handler. Otherwise we will miss the update.
-  if (reactMode().early) {
+  const mode = reactMode();
+  if (
+    mode.early &&
+    (mode.mode === 'LEGACY' || mode.mode === 'MUTABLE_SOURCE')
+  ) {
     const nextTree = store.getState().nextTree;
     if (nextTree && nextTree.dirtyAtoms.has(key)) {
       callback(nextTree);

--- a/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -751,7 +751,7 @@ testRecoil(
     if (
       (reactMode().mode === 'LEGACY' &&
         !gks.includes('recoil_suppress_rerender_in_callback')) ||
-      reactMode().mode === 'CONCURRENT_LEGACY'
+      reactMode().mode === 'CONCURRENT_SUPPORT'
     ) {
       baseCalls += 1;
     }
@@ -863,7 +863,7 @@ testRecoil(
     if (
       (reactMode().mode === 'LEGACY' &&
         !gks.includes('recoil_suppress_rerender_in_callback')) ||
-      reactMode().mode === 'CONCURRENT_LEGACY'
+      reactMode().mode === 'CONCURRENT_SUPPORT'
     ) {
       baseCalls += 1;
     }
@@ -877,7 +877,10 @@ testRecoil(
     expect(container.textContent).toEqual('0');
 
     // TODO: find out why OSS has additional render
-    if (!gks.includes('recoil_suppress_rerender_in_callback')) {
+    if (
+      reactMode().mode === 'LEGACY' &&
+      !gks.includes('recoil_suppress_rerender_in_callback')
+    ) {
       baseCalls += 1; // @oss-only
     }
 

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -409,7 +409,7 @@ const WWW_GKS_TO_TEST = QUICK_TEST
         'recoil_release_on_cascading_update_killswitch_2021',
       ],
       // Experimental mode for useTransition() support:
-      // ['recoil_hamt_2020', 'recoil_concurrent_legacy'],
+      ['recoil_hamt_2020', 'recoil_concurrent_support'],
     ];
 
 /**


### PR DESCRIPTION
Summary: Provide a new experimental rendering mode for Recoil to support `useTransition()`.  It accomplishes this by direclty mapping Recoil state to React state.

Differential Revision: D33693758

