### PR TITLE
TypeScript updates for 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
   - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511, #1532)
   - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
   - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
+  - Set `trigger` to `'set'` when initialized from a set in a Recoil transaction. (#1569)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 - Lazily compute the properties of `useGetRecoilValueInfo_UNSTABLE()` and `Snapshot#getInfo_UNSTABLE()` results (#1549)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
 - Fix transitive selector refresh for some cases (#1409)
 - Fix some corner cases with async selectors and multiple stores (#1568)
 - Atom Effects
-  - Rename option from `effects_UNSTABLE` to just `effects` as the interface is mostly stabilizing (#1520)
   - Run atom effects when atoms are initialized from a set during a transaction from `useRecoilTransaction_UNSTABLE()` (#1466)
   - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511, #1532)
   - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
@@ -46,6 +45,7 @@
 - Memoize the results of lazy proxies. (#1548)
 
 ### Breaking Changes
+- Rename atom effects from `effects_UNSTABLE` to just `effects`, as the interface is mostly stabilizing. (#1520)
 - Atom effect initialization takes precedence over initialization with `<RecoilRoot initializeState={...} >`. (#1509)
 - `useGetRecoilValueInfo_UNSTABLE()` and `Snapshot#getInfo_UNSTABLE()` always report the node `type`. (#1547)
 

--- a/packages/recoil/core/Recoil_AtomicUpdates.js
+++ b/packages/recoil/core/Recoil_AtomicUpdates.js
@@ -87,7 +87,7 @@ class TransactionInterfaceImpl {
       this._changes.set(recoilState.key, (valueOrUpdater: any)(current)); // flowlint-line unclear-type:off
     } else {
       // Initialize atom and run effects if not initialized yet
-      initializeNode(this._store, recoilState.key);
+      initializeNode(this._store, recoilState.key, 'set');
 
       this._changes.set(recoilState.key, valueOrUpdater);
     }

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -102,8 +102,8 @@ function initializeNodeIfNewToStore(
   });
 }
 
-function initializeNode(store: Store, key: NodeKey): void {
-  initializeNodeIfNewToStore(store, store.getState().currentTree, key, 'get');
+function initializeNode(store: Store, key: NodeKey, trigger: Trigger): void {
+  initializeNodeIfNewToStore(store, store.getState().currentTree, key, trigger);
 }
 
 function cleanUpNode(store: Store, key: NodeKey) {

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -502,7 +502,7 @@ function RecoilRoot_INTERNAL({
     // to re-initialize all known atoms after they were cleaned up.
     const store = storeRef.current;
     for (const atomKey of new Set(store.getState().knownAtoms)) {
-      initializeNode(store, atomKey);
+      initializeNode(store, atomKey, 'get');
     }
 
     return () => {

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -61,7 +61,7 @@ Recoil Snapshots only last for the duration of the callback they are provided to
 
   const release = snapshot.retain();
   try {
-    await useTheSnapshotAsynchronously(snapshot);
+    await doSomethingWithSnapshot(snapshot);
   } finally {
     release();
   }

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -102,7 +102,7 @@ class Snapshot {
     // this snapshot gets counted towards the node's live stores count).
     // TODO Optimize this when cloning snapshots for callbacks
     for (const nodeKey of this._store.getState().knownAtoms) {
-      initializeNode(this._store, nodeKey);
+      initializeNode(this._store, nodeKey, 'get');
       updateRetainCount(this._store, nodeKey, 1);
     }
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -69,6 +69,7 @@
   map(cb: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
   asyncMap(cb: (mutableSnapshot: MutableSnapshot) => Promise<void>): Promise<Snapshot>;
   retain(): () => void;
+  isRetained(): boolean;
  }
 
  export class MutableSnapshot extends Snapshot {

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -260,6 +260,7 @@ useRecoilCallback(({ snapshot, set, reset, refresh, gotoSnapshot, transact_UNSTA
 
   const release = snapshot.retain(); // $ExpectType () => void
   release(); // $ExpectType void
+  snapshot.isRetained(); // $ExpectType boolean
 
   transact_UNSTABLE(({get, set, reset}) => {
     const x: number = get(myAtom); // eslint-disable-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Summary:
* Add `isRetained()` to `Snapshot` methods
* Remove `undefined` from `type` in `RecoilStateInfo`

Drive-by cleanup of wording in warning when using released snapshots to change pseudo-function name to avoid starting with `use` so it doesn't look like a hook.

Differential Revision: D33593402

