### PR TITLE
remove default entry file for recoil-shared

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,11 +1,7 @@
 {
   "name": "recoil-shared",
   "description": "This is the internal package.json enabling CommonJS module",
-  "main": "Recoil_Shared.js",
   "haste_commonjs": true,
-  "files": [
-    "Recoil_Shared.js"
-  ],
   "directories": {
     "": "./"
   },


### PR DESCRIPTION
Summary:
"main" and "files" fileds are not necessary since we do not encourage direct use of "recoil-shared".

The entry file has been removed in D33474091 (https://github.com/facebookexperimental/recoil/commit/d3823ac8bdd3b60885c4f4f536fbb98697a99d70) by codemod

Reviewed By: drarmstr

Differential Revision: D33717946

