### PR TITLE
Organize unit tests

### DIFF
--- a/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -30,24 +30,16 @@ let React,
   Queue,
   batchUpdates,
   atom,
-  errorSelector,
   selector,
   selectorFamily,
   ReadsAtom,
-  asyncSelector,
-  errorThrowingAsyncSelector,
-  flushPromisesAndTimers,
   renderElements,
   renderUnwrappedElements,
-  renderElementsWithSuspenseCount,
   recoilComponentGetRecoilValueCount_FOR_TESTING,
   useRecoilState,
   useRecoilStateLoadable,
   useRecoilValue,
-  useRecoilValueLoadable,
   useSetRecoilState,
-  useSetUnvalidatedAtomValues,
-  useTransactionObservation_DEPRECATED,
   reactMode,
   invariant;
 
@@ -59,17 +51,12 @@ const testRecoil = getRecoilTestFn(() => {
   Queue = require('../../adt/Recoil_Queue');
   ({batchUpdates} = require('../../core/Recoil_Batching'));
   atom = require('../../recoil_values/Recoil_atom');
-  errorSelector = require('../../recoil_values/Recoil_errorSelector');
   selector = require('../../recoil_values/Recoil_selector');
   selectorFamily = require('../../recoil_values/Recoil_selectorFamily');
   ({
     ReadsAtom,
-    asyncSelector,
-    errorThrowingAsyncSelector,
-    flushPromisesAndTimers,
     renderElements,
     renderUnwrappedElements,
-    renderElementsWithSuspenseCount,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
   ({reactMode} = require('../../core/Recoil_ReactMode'));
   ({
@@ -77,11 +64,8 @@ const testRecoil = getRecoilTestFn(() => {
     useRecoilState,
     useRecoilStateLoadable,
     useRecoilValue,
-    useRecoilValueLoadable,
     useSetRecoilState,
-    useSetUnvalidatedAtomValues,
   } = require('../Recoil_Hooks'));
-  ({useTransactionObservation_DEPRECATED} = require('../Recoil_SnapshotHooks'));
 
   invariant = require('recoil-shared/util/Recoil_invariant');
 });
@@ -92,14 +76,6 @@ function counterAtom(persistence?: PersistenceSettings<number>) {
   return atom({
     key: `atom${nextID++}`,
     default: 0,
-    persistence_UNSTABLE: persistence,
-  });
-}
-
-function booleanAtom(persistence?: PersistenceSettings<boolean>) {
-  return atom<boolean>({
-    key: `atom${nextID++}`,
-    default: false,
     persistence_UNSTABLE: persistence,
   });
 }
@@ -146,26 +122,6 @@ function additionSelector(
     get: ({get}) => fn(get(depA), get(depB)),
   });
   return [sel, fn];
-}
-
-// flowlint-next-line unclear-type:off
-function asyncSelectorThatPushesPromisesOntoArray(dep: RecoilValue<any>) {
-  const promises = [];
-  const sel = selector({
-    key: `selector${nextID++}`,
-    get: ({get}) => {
-      get(dep);
-      let resolve = _ => invariant(false, 'bug in test code'); // make flow happy with initialization
-      let reject = _ => invariant(false, 'bug in test code');
-      const p = new Promise((res, rej) => {
-        resolve = res;
-        reject = rej;
-      });
-      promises.push([resolve, reject]);
-      return p;
-    },
-  });
-  return [sel, promises];
 }
 
 function componentThatReadsAndWritesAtom<T>(
@@ -222,22 +178,6 @@ function componentThatToggles(a, b) {
   return [Toggle, toggle];
 }
 
-function ObservesTransactions({fn}) {
-  useTransactionObservation_DEPRECATED(fn);
-  return null;
-}
-
-function advanceTimersBy(ms) {
-  // Jest does the right thing for runAllTimers but not advanceTimersByTime:
-  act(() => {
-    jest.runAllTicks();
-    jest.runAllImmediates();
-    jest.advanceTimersByTime(ms);
-    jest.runAllImmediates(); // order seems backwards but matches jest.runAllTimers().
-    jest.runAllTicks();
-  });
-}
-
 function baseRenderCount(gks): number {
   return reactMode().mode === 'LEGACY' &&
     !gks.includes('recoil_suppress_rerender_in_callback')
@@ -270,698 +210,302 @@ testRecoil('Components are re-rendered when atoms change', async () => {
   expect(container.textContent).toEqual('1');
 });
 
-testRecoil('Selectors are updated when upstream atoms change', () => {
-  const anAtom = counterAtom();
-  const [aSelector, _] = plusOneSelector(anAtom);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={aSelector} />
-    </>,
-  );
-  expect(container.textContent).toEqual('1');
-  act(() => updateValue(1));
-  expect(container.textContent).toEqual('2');
-});
+describe('Render counts', () => {
+  testRecoil(
+    'Component subscribed to atom is rendered just once',
+    ({gks, strictMode}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+      const sm = strictMode ? 2 : 1;
 
-testRecoil('Selectors can depend on other selectors', () => {
-  const anAtom = counterAtom();
-  const [selectorA, _] = plusOneSelector(anAtom);
-  const [selectorB, __] = plusOneSelector(selectorA);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={selectorB} />
-    </>,
-  );
-  expect(container.textContent).toEqual('2');
-  act(() => updateValue(1));
-  expect(container.textContent).toEqual('3');
-});
+      const anAtom = counterAtom();
+      const [Component, updateValue] = componentThatReadsAndWritesAtom(anAtom);
+      renderElements(
+        <>
+          <Component />
+        </>,
+      );
 
-testRecoil('Selectors can depend on async selectors', async () => {
-  jest.useFakeTimers();
-  const anAtom = counterAtom();
-  const [selectorA, _] = plusOneAsyncSelector(anAtom);
-  const [selectorB, __] = plusOneSelector(selectorA);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={selectorB} />
-    </>,
-  );
-  expect(container.textContent).toEqual('loading');
-
-  act(() => jest.runAllTimers());
-  await flushPromisesAndTimers();
-  expect(container.textContent).toEqual('2');
-
-  act(() => updateValue(1));
-
-  expect(container.textContent).toEqual('loading');
-
-  act(() => jest.runAllTimers());
-  await flushPromisesAndTimers();
-  expect(container.textContent).toEqual('3');
-});
-
-testRecoil('Async selectors can depend on async selectors', async () => {
-  jest.useFakeTimers();
-  const anAtom = counterAtom();
-  const [selectorA, _] = plusOneAsyncSelector(anAtom);
-  const [selectorB, __] = plusOneAsyncSelector(selectorA);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={selectorB} />
-    </>,
+      expect(Component).toHaveBeenCalledTimes((BASE_CALLS + 1) * sm);
+      act(() => updateValue(1));
+      expect(Component).toHaveBeenCalledTimes((BASE_CALLS + 2) * sm);
+    },
   );
 
-  if (reactMode().mode !== 'LEGACY') {
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('2');
-
-    act(() => updateValue(1));
-    expect(container.textContent).toEqual('loading');
-
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('3');
-  } else {
-    // we need to test the useRecoilValueLoadable_LEGACY method
-
-    expect(container.textContent).toEqual('loading');
-
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('2');
-
-    act(() => updateValue(1));
-    expect(container.textContent).toEqual('loading');
-
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('3');
-  }
-});
-
-testRecoil('Dep of upstream selector can change while pending', async () => {
-  const anAtom = counterAtom();
-  const [upstreamSel, upstreamResolvers] =
-    asyncSelectorThatPushesPromisesOntoArray(anAtom);
-  const [downstreamSel, downstreamResolvers] =
-    asyncSelectorThatPushesPromisesOntoArray(upstreamSel);
-
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={downstreamSel} />
-    </>,
-  );
-
-  // Initially, upstream has returned a promise so there is one upstream resolver.
-  // Downstream is waiting on upstream so it hasn't returned anything yet.
-  expect(container.textContent).toEqual('loading');
-  expect(upstreamResolvers.length).toEqual(1);
-  expect(downstreamResolvers.length).toEqual(0);
-
-  // Resolve upstream; downstream should now have returned a new promise:
-  upstreamResolvers[0][0](123);
-  await flushPromisesAndTimers();
-  expect(downstreamResolvers.length).toEqual(1);
-
-  // Update atom to a new value while downstream is pending:
-  act(() => updateValue(1));
-  await flushPromisesAndTimers();
-
-  // Upstream returns a new promise for the new atom value.
-  // Downstream is once again waiting on upstream so it hasn't returned a new
-  // promise for the new value.
-  expect(upstreamResolvers.length).toEqual(2);
-  expect(downstreamResolvers.length).toEqual(1);
-
-  // Resolve the new upstream promise:
-  upstreamResolvers[1][0](123);
-  await flushPromisesAndTimers();
-
-  // Downstream can now return its new promise:
-  expect(downstreamResolvers.length).toEqual(2);
-
-  // If we resolve downstream's new promise we should see the result:
-  downstreamResolvers[1][0](123);
-  await flushPromisesAndTimers();
-  expect(container.textContent).toEqual('123');
-});
-
-testRecoil('Errors are propogated through selectors', () => {
-  const errorThrower = errorSelector('ERROR');
-  const [downstreamSelector] = plusOneSelector(errorThrower);
-  const container = renderElements(
-    <>
-      <ReadsAtom atom={downstreamSelector} />
-    </>,
-  );
-  expect(container.textContent).toEqual('error');
-});
-
-testRecoil(
-  'Rejected promises are propogated through selectors (immediate rejection)',
-  async () => {
+  testRecoil('Write-only components are not subscribed', ({strictMode}) => {
     const anAtom = counterAtom();
-    const errorThrower = errorThrowingAsyncSelector('ERROR', anAtom);
-    const [downstreamSelector] = plusOneAsyncSelector(errorThrower);
-    const container = renderElements(
-      <>
-        <ReadsAtom atom={downstreamSelector} />
-      </>,
-    );
-    expect(container.textContent).toEqual('loading');
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('error');
-  },
-);
-
-testRecoil(
-  'Rejected promises are propogated through selectors (later rejection)',
-  async () => {
-    const anAtom = counterAtom();
-    const [errorThrower, _resolve, reject] = asyncSelector(anAtom);
-    const [downstreamSelector] = plusOneAsyncSelector(errorThrower);
-    const container = renderElements(
-      <>
-        <ReadsAtom atom={downstreamSelector} />
-      </>,
-    );
-    expect(container.textContent).toEqual('loading');
-    act(() => reject(new Error()));
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('error');
-  },
-);
-
-testRecoil(
-  'Component subscribed to atom is rendered just once',
-  ({gks, strictMode}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-    const sm = strictMode ? 2 : 1;
-
-    const anAtom = counterAtom();
-    const [Component, updateValue] = componentThatReadsAndWritesAtom(anAtom);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
     renderElements(
       <>
         <Component />
       </>,
     );
-
-    expect(Component).toHaveBeenCalledTimes((BASE_CALLS + 1) * sm);
+    expect(Component).toHaveBeenCalledTimes(strictMode ? 2 : 1);
     act(() => updateValue(1));
-    expect(Component).toHaveBeenCalledTimes((BASE_CALLS + 2) * sm);
-  },
-);
-
-testRecoil('Write-only components are not subscribed', ({strictMode}) => {
-  const anAtom = counterAtom();
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  renderElements(
-    <>
-      <Component />
-    </>,
-  );
-  expect(Component).toHaveBeenCalledTimes(strictMode ? 2 : 1);
-  act(() => updateValue(1));
-  expect(Component).toHaveBeenCalledTimes(strictMode ? 2 : 1);
-});
-
-testRecoil(
-  'Component that depends on atom in multiple ways is rendered just once',
-  ({gks, strictMode}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-    const sm = strictMode ? 2 : 1;
-
-    const anAtom = counterAtom();
-    const [aSelector, _] = plusOneSelector(anAtom);
-    const [WriteComp, updateValue] = componentThatWritesAtom(anAtom);
-    const ReadComp = componentThatReadsTwoAtoms(anAtom, aSelector);
-    renderElements(
-      <>
-        <WriteComp />
-        <ReadComp />
-      </>,
-    );
-
-    expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 1) * sm);
-    act(() => updateValue(1));
-    expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 2) * sm);
-  },
-);
-
-testRecoil('Selector functions are evaluated just once', () => {
-  const anAtom = counterAtom();
-  const [aSelector, selectorFn] = plusOneSelector(anAtom);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={aSelector} />
-    </>,
-  );
-  expect(selectorFn).toHaveBeenCalledTimes(1);
-  act(() => updateValue(1));
-  expect(selectorFn).toHaveBeenCalledTimes(2);
-});
-
-testRecoil(
-  'Selector functions are evaluated just once even if multiple upstreams change',
-  () => {
-    const atomA = counterAtom();
-    const atomB = counterAtom();
-    const [aSelector, selectorFn] = additionSelector(atomA, atomB);
-    const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
-    const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
-    renderElements(
-      <>
-        <ComponentA />
-        <ComponentB />
-        <ReadsAtom atom={aSelector} />
-      </>,
-    );
-    expect(selectorFn).toHaveBeenCalledTimes(1);
-    act(() => {
-      batchUpdates(() => {
-        updateValueA(1);
-        updateValueB(1);
-      });
-    });
-    expect(selectorFn).toHaveBeenCalledTimes(2);
-  },
-);
-
-testRecoil(
-  'Component that depends on multiple atoms via selector is rendered just once',
-  ({gks}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-
-    const atomA = counterAtom();
-    const atomB = counterAtom();
-    const [aSelector, _] = additionSelector(atomA, atomB);
-    const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
-    const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
-    const [ReadComp, commit] = componentThatReadsAtomWithCommitCount(aSelector);
-    renderElements(
-      <>
-        <ComponentA />
-        <ComponentB />
-        <ReadComp />
-      </>,
-    );
-
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
-    act(() => {
-      batchUpdates(() => {
-        updateValueA(1);
-        updateValueB(1);
-      });
-    });
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
-  },
-);
-
-testRecoil(
-  'Component that depends on multiple atoms directly is rendered just once',
-  ({gks, strictMode}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-    const sm = strictMode ? 2 : 1;
-
-    const atomA = counterAtom();
-    const atomB = counterAtom();
-    const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
-    const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
-    const ReadComp = componentThatReadsTwoAtoms(atomA, atomB);
-    renderElements(
-      <>
-        <ComponentA />
-        <ComponentB />
-        <ReadComp />
-      </>,
-    );
-
-    expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 1) * sm);
-    act(() => {
-      batchUpdates(() => {
-        updateValueA(1);
-        updateValueB(1);
-      });
-    });
-    expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 2) * sm);
-  },
-);
-
-testRecoil(
-  'Component is rendered just once when atom is changed twice',
-  ({gks}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-
-    const atomA = counterAtom();
-    const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
-    const [ReadComp, commit] = componentThatReadsAtomWithCommitCount(atomA);
-    renderElements(
-      <>
-        <ComponentA />
-        <ReadComp />
-      </>,
-    );
-
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
-    act(() => {
-      batchUpdates(() => {
-        updateValueA(1);
-        updateValueA(2);
-      });
-    });
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
-  },
-);
-
-testRecoil(
-  'Component does not re-read atom when rendered due to another atom changing, parent re-render, or other state change',
-  () => {
-    // useSyncExternalStore() will always call getSnapshot() to see if it has
-    // mutated between render and commit.
-    if (
-      reactMode().mode === 'LEGACY' ||
-      reactMode().mode === 'SYNC_EXTERNAL_STORE'
-    ) {
-      return;
-    }
-
-    const atomA = counterAtom();
-    const atomB = counterAtom();
-
-    let _, setLocal;
-    let _a, setA;
-    let _b, _setB;
-    function Component() {
-      [_, setLocal] = useState(0);
-      [_a, setA] = useRecoilState(atomA);
-      [_b, _setB] = useRecoilState(atomB);
-      return null;
-    }
-
-    let __, setParentLocal;
-    function Parent() {
-      [__, setParentLocal] = useState(0);
-      return <Component />;
-    }
-
-    renderElements(<Parent />);
-
-    const initialCalls = recoilComponentGetRecoilValueCount_FOR_TESTING.current;
-    expect(initialCalls).toBeGreaterThan(0);
-
-    // No re-read when setting local state on the component:
-    act(() => {
-      setLocal(1);
-    });
-    expect(recoilComponentGetRecoilValueCount_FOR_TESTING.current).toBe(
-      initialCalls,
-    );
-
-    // No re-read when setting local state on its parent causing it to re-render:
-    act(() => {
-      setParentLocal(1);
-    });
-    expect(recoilComponentGetRecoilValueCount_FOR_TESTING.current).toBe(
-      initialCalls,
-    );
-
-    // Setting an atom causes a re-read for that atom only, not others:
-    act(() => {
-      setA(1);
-    });
-    expect(recoilComponentGetRecoilValueCount_FOR_TESTING.current).toBe(
-      initialCalls + 1,
-    );
-  },
-);
-
-testRecoil(
-  'Components re-render only one time if selectorFamily changed',
-  ({gks, strictMode}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-    const sm = strictMode ? 2 : 1;
-
-    const atomA = counterAtom();
-
-    const selectAFakeId = selectorFamily({
-      key: 'selectItem',
-      get:
-        _id =>
-        ({get}) =>
-          get(atomA),
-    });
-
-    const Component = (jest.fn(function ReadFromSelector({id}) {
-      return useRecoilValue(selectAFakeId(id));
-      // $FlowFixMe[unclear-type]
-    }): Function);
-
-    let increment;
-
-    const App = () => {
-      const [state, setState] = useRecoilState(atomA);
-      increment = () => setState(s => s + 1);
-      return <Component id={state} />;
-    };
-
-    const container = renderElements(<App />);
-
-    let baseCalls = BASE_CALLS;
-
-    expect(container.textContent).toEqual('0');
-    expect(Component).toHaveBeenCalledTimes((baseCalls + 1) * sm);
-
-    act(() => increment());
-
-    if (
-      (reactMode().mode === 'LEGACY' &&
-        !gks.includes('recoil_suppress_rerender_in_callback')) ||
-      reactMode().mode === 'CONCURRENT_SUPPORT'
-    ) {
-      baseCalls += 1;
-    }
-
-    expect(container.textContent).toEqual('1');
-    expect(Component).toHaveBeenCalledTimes((baseCalls + 2) * sm);
-  },
-);
-
-testRecoil('Can subscribe to and also change an atom in the same batch', () => {
-  const anAtom = counterAtom();
-
-  let setVisible;
-  function Switch({children}) {
-    const [visible, mySetVisible] = useState(false);
-    setVisible = mySetVisible;
-    return visible ? children : null;
-  }
-
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <Switch>
-        <ReadsAtom atom={anAtom} />
-      </Switch>
-    </>,
-  );
-
-  expect(container.textContent).toEqual('');
-
-  act(() => {
-    batchUpdates(() => {
-      setVisible(true);
-      updateValue(1337);
-    });
+    expect(Component).toHaveBeenCalledTimes(strictMode ? 2 : 1);
   });
-  expect(container.textContent).toEqual('1337');
-});
 
-testRecoil('Atom values are retained when atom has no subscribers', () => {
-  const anAtom = counterAtom();
+  testRecoil(
+    'Component that depends on atom in multiple ways is rendered just once',
+    ({gks, strictMode}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+      const sm = strictMode ? 2 : 1;
 
-  let setVisible;
-  function Switch({children}) {
-    const [visible, mySetVisible] = useState(true);
-    setVisible = mySetVisible;
-    return visible ? children : null;
-  }
+      const anAtom = counterAtom();
+      const [aSelector, _] = plusOneSelector(anAtom);
+      const [WriteComp, updateValue] = componentThatWritesAtom(anAtom);
+      const ReadComp = componentThatReadsTwoAtoms(anAtom, aSelector);
+      renderElements(
+        <>
+          <WriteComp />
+          <ReadComp />
+        </>,
+      );
 
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <Switch>
-        <ReadsAtom atom={anAtom} />
-      </Switch>
-    </>,
+      expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 1) * sm);
+      act(() => updateValue(1));
+      expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 2) * sm);
+    },
   );
 
-  act(() => updateValue(1337));
-  expect(container.textContent).toEqual('1337');
-  act(() => setVisible(false));
-  expect(container.textContent).toEqual('');
-  act(() => setVisible(true));
-  expect(container.textContent).toEqual('1337');
+  testRecoil(
+    'Component that depends on multiple atoms via selector is rendered just once',
+    ({gks}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+
+      const atomA = counterAtom();
+      const atomB = counterAtom();
+      const [aSelector, _] = additionSelector(atomA, atomB);
+      const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
+      const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
+      const [ReadComp, commit] =
+        componentThatReadsAtomWithCommitCount(aSelector);
+      renderElements(
+        <>
+          <ComponentA />
+          <ComponentB />
+          <ReadComp />
+        </>,
+      );
+
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+      act(() => {
+        batchUpdates(() => {
+          updateValueA(1);
+          updateValueB(1);
+        });
+      });
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
+    },
+  );
+
+  testRecoil(
+    'Component that depends on multiple atoms directly is rendered just once',
+    ({gks, strictMode}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+      const sm = strictMode ? 2 : 1;
+
+      const atomA = counterAtom();
+      const atomB = counterAtom();
+      const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
+      const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
+      const ReadComp = componentThatReadsTwoAtoms(atomA, atomB);
+      renderElements(
+        <>
+          <ComponentA />
+          <ComponentB />
+          <ReadComp />
+        </>,
+      );
+
+      expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 1) * sm);
+      act(() => {
+        batchUpdates(() => {
+          updateValueA(1);
+          updateValueB(1);
+        });
+      });
+      expect(ReadComp).toHaveBeenCalledTimes((BASE_CALLS + 2) * sm);
+    },
+  );
+
+  testRecoil(
+    'Component is rendered just once when atom is changed twice',
+    ({gks}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+
+      const atomA = counterAtom();
+      const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
+      const [ReadComp, commit] = componentThatReadsAtomWithCommitCount(atomA);
+      renderElements(
+        <>
+          <ComponentA />
+          <ReadComp />
+        </>,
+      );
+
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+      act(() => {
+        batchUpdates(() => {
+          updateValueA(1);
+          updateValueA(2);
+        });
+      });
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
+    },
+  );
+
+  testRecoil(
+    'Component does not re-read atom when rendered due to another atom changing, parent re-render, or other state change',
+    () => {
+      // useSyncExternalStore() will always call getSnapshot() to see if it has
+      // mutated between render and commit.
+      if (
+        reactMode().mode === 'LEGACY' ||
+        reactMode().mode === 'SYNC_EXTERNAL_STORE'
+      ) {
+        return;
+      }
+
+      const atomA = counterAtom();
+      const atomB = counterAtom();
+
+      let _, setLocal;
+      let _a, setA;
+      let _b, _setB;
+      function Component() {
+        [_, setLocal] = useState(0);
+        [_a, setA] = useRecoilState(atomA);
+        [_b, _setB] = useRecoilState(atomB);
+        return null;
+      }
+
+      let __, setParentLocal;
+      function Parent() {
+        [__, setParentLocal] = useState(0);
+        return <Component />;
+      }
+
+      renderElements(<Parent />);
+
+      const initialCalls =
+        recoilComponentGetRecoilValueCount_FOR_TESTING.current;
+      expect(initialCalls).toBeGreaterThan(0);
+
+      // No re-read when setting local state on the component:
+      act(() => {
+        setLocal(1);
+      });
+      expect(recoilComponentGetRecoilValueCount_FOR_TESTING.current).toBe(
+        initialCalls,
+      );
+
+      // No re-read when setting local state on its parent causing it to re-render:
+      act(() => {
+        setParentLocal(1);
+      });
+      expect(recoilComponentGetRecoilValueCount_FOR_TESTING.current).toBe(
+        initialCalls,
+      );
+
+      // Setting an atom causes a re-read for that atom only, not others:
+      act(() => {
+        setA(1);
+      });
+      expect(recoilComponentGetRecoilValueCount_FOR_TESTING.current).toBe(
+        initialCalls + 1,
+      );
+    },
+  );
+
+  testRecoil(
+    'Components re-render only one time if selectorFamily changed',
+    ({gks, strictMode}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+      const sm = strictMode ? 2 : 1;
+
+      const atomA = counterAtom();
+
+      const selectAFakeId = selectorFamily({
+        key: 'selectItem',
+        get:
+          _id =>
+          ({get}) =>
+            get(atomA),
+      });
+
+      const Component = (jest.fn(function ReadFromSelector({id}) {
+        return useRecoilValue(selectAFakeId(id));
+        // $FlowFixMe[unclear-type]
+      }): Function);
+
+      let increment;
+
+      const App = () => {
+        const [state, setState] = useRecoilState(atomA);
+        increment = () => setState(s => s + 1);
+        return <Component id={state} />;
+      };
+
+      const container = renderElements(<App />);
+
+      let baseCalls = BASE_CALLS;
+
+      expect(container.textContent).toEqual('0');
+      expect(Component).toHaveBeenCalledTimes((baseCalls + 1) * sm);
+
+      act(() => increment());
+
+      if (
+        (reactMode().mode === 'LEGACY' &&
+          !gks.includes('recoil_suppress_rerender_in_callback')) ||
+        reactMode().mode === 'CONCURRENT_SUPPORT'
+      ) {
+        baseCalls += 1;
+      }
+
+      expect(container.textContent).toEqual('1');
+      expect(Component).toHaveBeenCalledTimes((baseCalls + 2) * sm);
+    },
+  );
 });
 
-testRecoil(
-  'Components unsubscribe from atoms when rendered without using them',
-  ({gks, strictMode}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-    const sm = strictMode ? 2 : 1;
+describe('Component Subscriptions', () => {
+  testRecoil(
+    'Can subscribe to and also change an atom in the same batch',
+    () => {
+      const anAtom = counterAtom();
 
-    const atomA = counterAtom();
-    const atomB = counterAtom();
-    const [WriteA, updateValueA] = componentThatWritesAtom(atomA);
-    const [WriteB, updateValueB] = componentThatWritesAtom(atomB);
+      let setVisible;
+      function Switch({children}) {
+        const [visible, mySetVisible] = useState(false);
+        setVisible = mySetVisible;
+        return visible ? children : null;
+      }
 
-    const Component = (jest.fn(function Read({state}) {
-      const [value] = useRecoilState(state);
-      return value;
-    }): any); // flowlint-line unclear-type:off
+      const [Component, updateValue] = componentThatWritesAtom(anAtom);
+      const container = renderElements(
+        <>
+          <Component />
+          <Switch>
+            <ReadsAtom atom={anAtom} />
+          </Switch>
+        </>,
+      );
 
-    let toggleSwitch;
-    const Switch = () => {
-      const [value, setValue] = useState(false);
-      toggleSwitch = () => setValue(true);
-      return value ? <Component state={atomB} /> : <Component state={atomA} />;
-    };
+      expect(container.textContent).toEqual('');
 
-    const container = renderElements(
-      <>
-        <Switch />
-        <WriteA />
-        <WriteB />
-      </>,
-    );
+      act(() => {
+        batchUpdates(() => {
+          setVisible(true);
+          updateValue(1337);
+        });
+      });
+      expect(container.textContent).toEqual('1337');
+    },
+  );
 
-    let baseCalls = BASE_CALLS;
-
-    expect(container.textContent).toEqual('0');
-    expect(Component).toHaveBeenCalledTimes((baseCalls + 1) * sm);
-
-    act(() => updateValueA(1));
-    expect(container.textContent).toEqual('1');
-    expect(Component).toHaveBeenCalledTimes((baseCalls + 2) * sm);
-
-    if (
-      (reactMode().mode === 'LEGACY' &&
-        !gks.includes('recoil_suppress_rerender_in_callback')) ||
-      reactMode().mode === 'CONCURRENT_SUPPORT'
-    ) {
-      baseCalls += 1;
-    }
-
-    act(() => toggleSwitch());
-    expect(container.textContent).toEqual('0');
-    expect(Component).toHaveBeenCalledTimes((baseCalls + 3) * sm);
-
-    // Now update the atom that it used to be subscribed to but should be no longer:
-    act(() => updateValueA(2));
-    expect(container.textContent).toEqual('0');
-
-    // TODO: find out why OSS has additional render
-    if (
-      reactMode().mode === 'LEGACY' &&
-      !gks.includes('recoil_suppress_rerender_in_callback')
-    ) {
-      baseCalls += 1; // @oss-only
-    }
-
-    expect(Component).toHaveBeenCalledTimes((baseCalls + 3) * sm); // Important part: same as before
-
-    // It is subscribed to the atom that it switched to:
-    act(() => updateValueB(3));
-    expect(container.textContent).toEqual('3');
-    expect(Component).toHaveBeenCalledTimes((baseCalls + 4) * sm);
-  },
-);
-
-testRecoil(
-  'Selectors unsubscribe from upstream when they have no subscribers',
-  () => {
-    const atomA = counterAtom();
-    const atomB = counterAtom();
-    const [WriteA, updateValueA] = componentThatWritesAtom(atomA);
-
-    // Do two layers of selectors to test that the unsubscribing is recursive:
-    const selectorMapFn1 = jest.fn(x => x);
-    const sel1 = selector({
-      key: 'selUpstream',
-      get: ({get}) => selectorMapFn1(get(atomA)),
-    });
-
-    const selectorMapFn2 = jest.fn(x => x);
-    const sel2 = selector({
-      key: 'selDownstream',
-      get: ({get}) => selectorMapFn2(get(sel1)),
-    });
-
-    let toggleSwitch;
-    const Switch = () => {
-      const [value, setValue] = useState(false);
-      toggleSwitch = () => setValue(true);
-      return value ? <ReadsAtom atom={atomB} /> : <ReadsAtom atom={sel2} />;
-    };
-
-    const container = renderElements(
-      <>
-        <Switch />
-        <WriteA />
-      </>,
-    );
-    expect(container.textContent).toEqual('0');
-    expect(selectorMapFn1).toHaveBeenCalledTimes(1);
-    expect(selectorMapFn2).toHaveBeenCalledTimes(1);
-
-    act(() => updateValueA(1));
-    expect(container.textContent).toEqual('1');
-    expect(selectorMapFn1).toHaveBeenCalledTimes(2);
-    expect(selectorMapFn2).toHaveBeenCalledTimes(2);
-
-    act(() => toggleSwitch());
-    expect(container.textContent).toEqual('0');
-    expect(selectorMapFn1).toHaveBeenCalledTimes(2);
-    expect(selectorMapFn2).toHaveBeenCalledTimes(2);
-
-    act(() => updateValueA(2));
-    expect(container.textContent).toEqual('0');
-    expect(selectorMapFn1).toHaveBeenCalledTimes(2);
-    expect(selectorMapFn2).toHaveBeenCalledTimes(2);
-  },
-);
-
-testRecoil(
-  'Unsubscribes happen in case of unmounting of a suspended component',
-  () => {
+  testRecoil('Atom values are retained when atom has no subscribers', () => {
     const anAtom = counterAtom();
-    const [aSelector, _selFn] = plusOneSelector(anAtom);
-    const [_asyncSel, _adjustTimeout] = plusOneAsyncSelector(aSelector);
-    // FIXME to implement
-  },
-);
-
-testRecoil(
-  'Selectors stay up to date if deps are changed while they have no subscribers',
-  () => {
-    const anAtom = counterAtom();
-    const [aSelector, _] = plusOneSelector(anAtom);
 
     let setVisible;
     function Switch({children}) {
@@ -975,183 +519,223 @@ testRecoil(
       <>
         <Component />
         <Switch>
-          <ReadsAtom atom={aSelector} />
+          <ReadsAtom atom={anAtom} />
         </Switch>
       </>,
     );
 
-    act(() => updateValue(1));
-    expect(container.textContent).toEqual('2');
+    act(() => updateValue(1337));
+    expect(container.textContent).toEqual('1337');
     act(() => setVisible(false));
     expect(container.textContent).toEqual('');
-    act(() => updateValue(2));
-    expect(container.textContent).toEqual('');
     act(() => setVisible(true));
-    expect(container.textContent).toEqual('3');
-  },
-);
-
-testRecoil('Selectors can be invertible', () => {
-  const anAtom = counterAtom();
-  const aSelector = selector({
-    key: 'invertible1',
-    get: ({get}) => get(anAtom),
-    set: ({set}, newValue) => set(anAtom, newValue),
+    expect(container.textContent).toEqual('1337');
   });
 
-  const [Component, updateValue] = componentThatWritesAtom(aSelector);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={anAtom} />
-    </>,
-  );
+  testRecoil(
+    'Components unsubscribe from atoms when rendered without using them',
+    ({gks, strictMode}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+      const sm = strictMode ? 2 : 1;
 
-  expect(container.textContent).toEqual('0');
-  act(() => updateValue(1));
-  expect(container.textContent).toEqual('1');
-});
+      const atomA = counterAtom();
+      const atomB = counterAtom();
+      const [WriteA, updateValueA] = componentThatWritesAtom(atomA);
+      const [WriteB, updateValueB] = componentThatWritesAtom(atomB);
 
-testRecoil('Selector dependencies can change over time', () => {
-  const atomA = counterAtom();
-  const atomB = counterAtom();
-  const aSelector = selector({
-    key: 'depsChange',
-    get: ({get}) => {
-      const a = get(atomA);
-      if (a === 1337) {
-        const b = get(atomB);
-        return b;
-      } else {
-        return a;
+      const Component = (jest.fn(function Read({state}) {
+        const [value] = useRecoilState(state);
+        return value;
+      }): any); // flowlint-line unclear-type:off
+
+      let toggleSwitch;
+      const Switch = () => {
+        const [value, setValue] = useState(false);
+        toggleSwitch = () => setValue(true);
+        return value ? (
+          <Component state={atomB} />
+        ) : (
+          <Component state={atomA} />
+        );
+      };
+
+      const container = renderElements(
+        <>
+          <Switch />
+          <WriteA />
+          <WriteB />
+        </>,
+      );
+
+      let baseCalls = BASE_CALLS;
+
+      expect(container.textContent).toEqual('0');
+      expect(Component).toHaveBeenCalledTimes((baseCalls + 1) * sm);
+
+      act(() => updateValueA(1));
+      expect(container.textContent).toEqual('1');
+      expect(Component).toHaveBeenCalledTimes((baseCalls + 2) * sm);
+
+      if (
+        (reactMode().mode === 'LEGACY' &&
+          !gks.includes('recoil_suppress_rerender_in_callback')) ||
+        reactMode().mode === 'CONCURRENT_SUPPORT'
+      ) {
+        baseCalls += 1;
       }
-    },
-  });
 
-  const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
-  const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
+      act(() => toggleSwitch());
+      expect(container.textContent).toEqual('0');
+      expect(Component).toHaveBeenCalledTimes((baseCalls + 3) * sm);
 
-  const container = renderElements(
-    <>
-      <ComponentA />
-      <ComponentB />
-      <ReadsAtom atom={aSelector} />
-    </>,
-  );
+      // Now update the atom that it used to be subscribed to but should be no longer:
+      act(() => updateValueA(2));
+      expect(container.textContent).toEqual('0');
 
-  expect(container.textContent).toEqual('0');
-  act(() => updateValueA(1337));
-  expect(container.textContent).toEqual('0');
-  act(() => updateValueB(1));
-
-  expect(container.textContent).toEqual('1');
-  act(() => updateValueA(2));
-  expect(container.textContent).toEqual('2');
-});
-
-testRecoil('Selectors can gain and lose depnedencies', ({gks}) => {
-  const BASE_CALLS = baseRenderCount(gks);
-
-  const switchAtom = booleanAtom();
-  const inputAtom = counterAtom();
-
-  // Depends on inputAtom only when switchAtom is true:
-  const aSelector = selector<number>({
-    key: 'gainsDeps',
-    get: ({get}) => {
-      if (get(switchAtom)) {
-        return get(inputAtom);
-      } else {
-        return Infinity;
+      // TODO: find out why OSS has additional render
+      if (
+        reactMode().mode === 'LEGACY' &&
+        !gks.includes('recoil_suppress_rerender_in_callback')
+      ) {
+        baseCalls += 1; // @oss-only
       }
-    },
-  });
 
-  const [ComponentA, setSwitch] = componentThatWritesAtom(switchAtom);
-  const [ComponentB, setInput] = componentThatWritesAtom(inputAtom);
-  const [ComponentC, commit] = componentThatReadsAtomWithCommitCount(aSelector);
-  const container = renderElements(
-    <>
-      <ComponentA />
-      <ComponentB />
-      <ComponentC />
-    </>,
+      expect(Component).toHaveBeenCalledTimes((baseCalls + 3) * sm); // Important part: same as before
+
+      // It is subscribed to the atom that it switched to:
+      act(() => updateValueB(3));
+      expect(container.textContent).toEqual('3');
+      expect(Component).toHaveBeenCalledTimes((baseCalls + 4) * sm);
+    },
   );
 
-  expect(container.textContent).toEqual('Infinity');
-  expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+  testRecoil(
+    'Selectors unsubscribe from upstream when they have no subscribers',
+    () => {
+      const atomA = counterAtom();
+      const atomB = counterAtom();
+      const [WriteA, updateValueA] = componentThatWritesAtom(atomA);
 
-  // Input is not a dep yet, so this has no effect:
-  act(() => setInput(1));
-  expect(container.textContent).toEqual('Infinity');
-  expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+      // Do two layers of selectors to test that the unsubscribing is recursive:
+      const selectorMapFn1 = jest.fn(x => x);
+      const sel1 = selector({
+        key: 'selUpstream',
+        get: ({get}) => selectorMapFn1(get(atomA)),
+      });
 
-  // Flip switch:
-  act(() => setSwitch(true));
-  expect(container.textContent).toEqual('1');
-  expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
+      const selectorMapFn2 = jest.fn(x => x);
+      const sel2 = selector({
+        key: 'selDownstream',
+        get: ({get}) => selectorMapFn2(get(sel1)),
+      });
 
-  // Now changing input causes a re-render:
-  act(() => setInput(2));
-  expect(container.textContent).toEqual('2');
-  expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 3);
+      let toggleSwitch;
+      const Switch = () => {
+        const [value, setValue] = useState(false);
+        toggleSwitch = () => setValue(true);
+        return value ? <ReadsAtom atom={atomB} /> : <ReadsAtom atom={sel2} />;
+      };
 
-  // Now that we've added the dep, we can remove it...
-  act(() => setSwitch(false));
-  expect(container.textContent).toEqual('Infinity');
-  expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 4);
+      const container = renderElements(
+        <>
+          <Switch />
+          <WriteA />
+        </>,
+      );
+      expect(container.textContent).toEqual('0');
+      expect(selectorMapFn1).toHaveBeenCalledTimes(1);
+      expect(selectorMapFn2).toHaveBeenCalledTimes(1);
 
-  // ... and again changing input will not cause a re-render:
-  act(() => setInput(3));
-  expect(container.textContent).toEqual('Infinity');
-  expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 4);
-});
+      act(() => updateValueA(1));
+      expect(container.textContent).toEqual('1');
+      expect(selectorMapFn1).toHaveBeenCalledTimes(2);
+      expect(selectorMapFn2).toHaveBeenCalledTimes(2);
 
-testRecoil('Selector depedencies are updated transactionally', () => {
-  const atomA = counterAtom();
-  const atomB = counterAtom();
-  const atomC = counterAtom();
+      act(() => toggleSwitch());
+      expect(container.textContent).toEqual('0');
+      expect(selectorMapFn1).toHaveBeenCalledTimes(2);
+      expect(selectorMapFn2).toHaveBeenCalledTimes(2);
 
-  const [observedSelector, selectorFn] = plusOneSelector(atomC);
-
-  const aSelector = selector({
-    key: 'transactionally',
-    get: ({get}) => {
-      const a = get(atomA);
-      const b = get(atomB);
-      return a !== 0 && b === 0
-        ? get(observedSelector) // We want to test this never happens
-        : null;
+      act(() => updateValueA(2));
+      expect(container.textContent).toEqual('0');
+      expect(selectorMapFn1).toHaveBeenCalledTimes(2);
+      expect(selectorMapFn2).toHaveBeenCalledTimes(2);
     },
-  });
-
-  const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
-  const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
-  const [ComponentC, updateValueC] = componentThatWritesAtom(atomC);
-  renderElements(
-    <>
-      <ComponentA />
-      <ComponentB />
-      <ComponentC />
-      <ReadsAtom atom={aSelector} />
-    </>,
   );
 
-  act(() => {
-    batchUpdates(() => {
-      updateValueA(1);
-      updateValueB(1);
-    });
-  });
+  testRecoil(
+    'Unsubscribes happen in case of unmounting of a suspended component',
+    () => {
+      const anAtom = counterAtom();
+      const [aSelector, _selFn] = plusOneSelector(anAtom);
+      const [_asyncSel, _adjustTimeout] = plusOneAsyncSelector(aSelector);
+      // FIXME to implement
+    },
+  );
 
-  // observedSelector wasn't evaluated:
-  expect(selectorFn).toHaveBeenCalledTimes(0);
+  testRecoil(
+    'Selectors stay up to date if deps are changed while they have no subscribers',
+    () => {
+      const anAtom = counterAtom();
+      const [aSelector, _] = plusOneSelector(anAtom);
 
-  // nor were any subscriptions created for it:
-  act(() => {
-    updateValueC(1);
-  });
-  expect(selectorFn).toHaveBeenCalledTimes(0);
+      let setVisible;
+      function Switch({children}) {
+        const [visible, mySetVisible] = useState(true);
+        setVisible = mySetVisible;
+        return visible ? children : null;
+      }
+
+      const [Component, updateValue] = componentThatWritesAtom(anAtom);
+      const container = renderElements(
+        <>
+          <Component />
+          <Switch>
+            <ReadsAtom atom={aSelector} />
+          </Switch>
+        </>,
+      );
+
+      act(() => updateValue(1));
+      expect(container.textContent).toEqual('2');
+      act(() => setVisible(false));
+      expect(container.textContent).toEqual('');
+      act(() => updateValue(2));
+      expect(container.textContent).toEqual('');
+      act(() => setVisible(true));
+      expect(container.textContent).toEqual('3');
+    },
+  );
+
+  testRecoil(
+    'Selector subscriptions are correct when a selector is unsubscribed the second time',
+    async () => {
+      // This regression test would fail by an exception being thrown because subscription refcounts
+      // would would fall below zero.
+      const anAtom = counterAtom();
+      const [sel, _] = plusOneSelector(anAtom);
+      const [Toggle, toggle] = componentThatToggles(
+        <ReadsAtom atom={sel} />,
+        null,
+      );
+      const container = renderElements(
+        <>
+          <Toggle />
+        </>,
+      );
+
+      expect(container.textContent).toEqual('1');
+
+      act(() => toggle.current());
+      expect(container.textContent).toEqual('');
+
+      act(() => toggle.current());
+      expect(container.textContent).toEqual('1');
+
+      act(() => toggle.current());
+      expect(container.textContent).toEqual('');
+    },
+  );
 });
 
 testRecoil('Can set an atom during rendering', () => {
@@ -1330,391 +914,6 @@ testRecoil(
   },
 );
 
-testRecoil('Basic async selector test', async () => {
-  jest.useFakeTimers();
-  const anAtom = counterAtom();
-  const [aSelector, _] = plusOneAsyncSelector(anAtom);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={aSelector} />
-    </>,
-  );
-  // Begins in loading state, then shows initial value:
-  expect(container.textContent).toEqual('loading');
-  act(() => jest.runAllTimers());
-  await flushPromisesAndTimers();
-  expect(container.textContent).toEqual('1');
-  // Changing dependency makes it go back to loading, then to show new value:
-  act(() => updateValue(1));
-  expect(container.textContent).toEqual('loading');
-  act(() => jest.runAllTimers());
-  expect(container.textContent).toEqual('2');
-  // Returning to a seen value does not cause the loading state:
-  act(() => updateValue(0));
-  expect(container.textContent).toEqual('1');
-});
-
-testRecoil('Ability to not use Suspense', () => {
-  jest.useFakeTimers();
-  const anAtom = counterAtom();
-  const [aSelector, _] = plusOneAsyncSelector(anAtom);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-
-  function ReadsAtomWithoutSuspense({state}) {
-    const loadable = useRecoilValueLoadable(state);
-    if (loadable.state === 'loading') {
-      return 'loading not with suspense';
-    } else if (loadable.state === 'hasValue') {
-      return loadable.contents;
-    } else {
-      throw loadable.contents;
-    }
-  }
-
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtomWithoutSuspense state={aSelector} />
-    </>,
-  );
-  // Begins in loading state, then shows initial value:
-  expect(container.textContent).toEqual('loading not with suspense');
-  act(() => jest.runAllTimers());
-  expect(container.textContent).toEqual('1');
-  // Changing dependency makes it go back to loading, then to show new value:
-  act(() => updateValue(1));
-  expect(container.textContent).toEqual('loading not with suspense');
-  act(() => jest.runAllTimers());
-  expect(container.textContent).toEqual('2');
-  // Returning to a seen value does not cause the loading state:
-  act(() => updateValue(0));
-  expect(container.textContent).toEqual('1');
-});
-
-testRecoil(
-  'Ability to not use Suspense - with value instead of loadable',
-  () => {
-    jest.useFakeTimers();
-    const anAtom = counterAtom();
-    const [aSelector, _] = plusOneAsyncSelector(anAtom);
-    const [Component, updateValue] = componentThatWritesAtom(anAtom);
-
-    function ReadsAtomWithoutSuspense({state}) {
-      return (
-        useRecoilValueLoadable(state).valueMaybe() ??
-        'loading not with suspense'
-      );
-    }
-
-    const container = renderElements(
-      <>
-        <Component />
-        <ReadsAtomWithoutSuspense state={aSelector} />
-      </>,
-    );
-    // Begins in loading state, then shows initial value:
-    expect(container.textContent).toEqual('loading not with suspense');
-    act(() => jest.runAllTimers());
-    expect(container.textContent).toEqual('1');
-    // Changing dependency makes it go back to loading, then to show new value:
-    act(() => updateValue(1));
-    expect(container.textContent).toEqual('loading not with suspense');
-    act(() => jest.runAllTimers());
-    expect(container.textContent).toEqual('2');
-    // Returning to a seen value does not cause the loading state:
-    act(() => updateValue(0));
-    expect(container.textContent).toEqual('1');
-  },
-);
-
-testRecoil(
-  'Selector can alternate between synchronous and asynchronous',
-  async () => {
-    jest.useFakeTimers();
-    const anAtom = counterAtom();
-    const aSelector = selector({
-      key: 'alternatingSelector',
-      get: ({get}) => {
-        const x = get(anAtom);
-        if (x === 1337) {
-          return new Promise(() => {});
-        }
-        if (x % 2 === 0) {
-          return x;
-        } else {
-          return new Promise(resolve => {
-            setTimeout(() => resolve(x), 100);
-          });
-        }
-      },
-    });
-    const [Component, updateValue] = componentThatWritesAtom(anAtom);
-    const container = renderElements(
-      <>
-        <Component />
-        <ReadsAtom atom={aSelector} />
-      </>,
-    );
-
-    // Transition from sync to async:
-    expect(container.textContent).toEqual('0');
-    act(() => updateValue(1));
-    expect(container.textContent).toEqual('loading');
-    advanceTimersBy(101);
-    expect(container.textContent).toEqual('1');
-
-    // Transition from async to sync (with async being in hasValue state):
-    act(() => updateValue(2));
-    expect(container.textContent).toEqual('2');
-
-    // Transition from async to sync (with async being in loading state):
-    act(() => updateValue(1337));
-    expect(container.textContent).toEqual('loading');
-    act(() => updateValue(4));
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('4');
-
-    // Transition from sync to async with still unresolved promise from before:
-    act(() => updateValue(5));
-    expect(container.textContent).toEqual('loading');
-    advanceTimersBy(101);
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('5');
-  },
-);
-
-testRecoil(
-  'Async selectors do not re-query when re-subscribed from having no subscribers',
-  async () => {
-    const anAtom = counterAtom();
-    const [sel, resolvers] = asyncSelectorThatPushesPromisesOntoArray(anAtom);
-    const [Component, updateValue] = componentThatWritesAtom(anAtom);
-    const [Toggle, toggle] = componentThatToggles(
-      <ReadsAtom atom={sel} />,
-      null,
-    );
-    const container = renderElements(
-      <>
-        <Component />
-        <Toggle />
-      </>,
-    );
-    expect(container.textContent).toEqual('loading');
-    expect(resolvers.length).toBe(1);
-    act(() => updateValue(2));
-    await flushPromisesAndTimers();
-    expect(resolvers.length).toBe(2);
-    resolvers[1][0]('hello');
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('"hello"');
-
-    // Cause sel to have no subscribers:
-    act(() => toggle.current());
-    expect(container.textContent).toEqual('');
-
-    // Once it's used again, it should not issue another request:
-    act(() => toggle.current());
-    expect(resolvers.length).toBe(2);
-    expect(container.textContent).toEqual('"hello"');
-  },
-);
-
-testRecoil(
-  'Selector subscriptions are correct when a selector is unsubscribed the second time',
-  async () => {
-    // This regression test would fail by an exception being thrown because subscription refcounts
-    // would would fall below zero.
-    const anAtom = counterAtom();
-    const [sel, _] = plusOneSelector(anAtom);
-    const [Toggle, toggle] = componentThatToggles(
-      <ReadsAtom atom={sel} />,
-      null,
-    );
-    const container = renderElements(
-      <>
-        <Toggle />
-      </>,
-    );
-
-    expect(container.textContent).toEqual('1');
-
-    act(() => toggle.current());
-    expect(container.textContent).toEqual('');
-
-    act(() => toggle.current());
-    expect(container.textContent).toEqual('1');
-
-    act(() => toggle.current());
-    expect(container.textContent).toEqual('');
-  },
-);
-
-testRecoil('Can move out of suspense by changing deps', async () => {
-  const anAtom = counterAtom();
-  const [aSelector, resolvers] =
-    asyncSelectorThatPushesPromisesOntoArray(anAtom);
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={aSelector} />
-    </>,
-  );
-  // While still waiting for first request, let a second faster request happen:
-  expect(container.textContent).toEqual('loading');
-  expect(resolvers.length).toEqual(1);
-  act(() => updateValue(1));
-  await flushPromisesAndTimers();
-  expect(resolvers.length).toEqual(2);
-  expect(container.textContent).toEqual('loading');
-  // When the faster second request resolves, we should see its result:
-  resolvers[1][0]('hello');
-  await flushPromisesAndTimers();
-  await flushPromisesAndTimers();
-  expect(container.textContent).toEqual('"hello"');
-});
-
-testRecoil('Can use an already-resolved promise', async () => {
-  jest.useFakeTimers();
-  const anAtom = counterAtom();
-  const [Component, updateValue] = componentThatWritesAtom(anAtom);
-  const sel = selector({
-    key: `selector${nextID++}`,
-    get: ({get}) => {
-      const x = get(anAtom);
-      return Promise.resolve(x + 1);
-    },
-  });
-  const container = renderElements(
-    <>
-      <Component />
-      <ReadsAtom atom={sel} />
-    </>,
-  );
-  await flushPromisesAndTimers();
-  await flushPromisesAndTimers();
-  expect(container.textContent).toEqual('1');
-  act(() => updateValue(1));
-  await flushPromisesAndTimers();
-  await flushPromisesAndTimers();
-  expect(container.textContent).toEqual('2');
-});
-
-testRecoil(
-  'Resolution of suspense causes render just once',
-  async ({gks, strictMode, concurrentMode}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-    const sm = strictMode && concurrentMode ? 2 : 1;
-
-    jest.useFakeTimers();
-    const anAtom = counterAtom();
-    const [aSelector, _] = plusOneAsyncSelector(anAtom);
-    const [Component, updateValue] = componentThatWritesAtom(anAtom);
-    const [ReadComp, commit] = componentThatReadsAtomWithCommitCount(aSelector);
-    const [__, suspense] = renderElementsWithSuspenseCount(
-      <>
-        <Component />
-        <ReadComp />
-      </>,
-    );
-
-    // Begins in loading state, then shows initial value:
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(suspense).toHaveBeenCalledTimes(1 * sm);
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
-    // Changing dependency makes it go back to loading, then to show new value:
-    act(() => updateValue(1));
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(suspense).toHaveBeenCalledTimes(2 * sm);
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
-    // Returning to a seen value does not cause the loading state:
-    act(() => updateValue(0));
-    await flushPromisesAndTimers();
-    expect(suspense).toHaveBeenCalledTimes(2 * sm);
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 3);
-  },
-);
-
-testRecoil(
-  'Wakeup from Suspense to previous value',
-  async ({gks, strictMode, concurrentMode}) => {
-    const BASE_CALLS = baseRenderCount(gks);
-    const sm = strictMode && concurrentMode ? 2 : 1;
-
-    const myAtom = atom({
-      key: `atom${nextID++}`,
-      default: {value: 0},
-    });
-    const mySelector = selector({
-      key: `selector${nextID++}`,
-      get: ({get}) => get(myAtom).value,
-    });
-
-    const [Component, updateValue] = componentThatWritesAtom(myAtom);
-    const [ReadComp, commit] =
-      componentThatReadsAtomWithCommitCount(mySelector);
-    const [container, suspense] = renderElementsWithSuspenseCount(
-      <>
-        <Component />
-        <ReadComp />
-      </>,
-    );
-
-    // Render initial state "0"
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('0');
-    expect(suspense).toHaveBeenCalledTimes(0 * sm);
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
-
-    // Set selector to a pending state should cause component to suspend
-    act(() => updateValue({value: new Promise(() => {})}));
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('loading');
-    expect(suspense).toHaveBeenCalledTimes(1 * sm);
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
-
-    // Setting selector back to the previous state before it was pending should
-    // wake it up and render in previous state
-    act(() => updateValue({value: 0}));
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('0');
-    expect(suspense).toHaveBeenCalledTimes(1 * sm);
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
-
-    // Setting selector to a new state "1" should update and re-render
-    act(() => updateValue({value: 1}));
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('1');
-    expect(suspense).toHaveBeenCalledTimes(1 * sm);
-    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 3);
-
-    // Setting selector to the same value "1" should avoid a re-render
-    act(() => updateValue({value: 1}));
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(container.textContent).toEqual('1');
-    expect(suspense).toHaveBeenCalledTimes(1 * sm);
-    expect(commit).toHaveBeenCalledTimes(
-      BASE_CALLS +
-        3 +
-        ((reactMode().mode === 'LEGACY' ||
-          reactMode().mode === 'MUTABLE_SOURCE') &&
-        !gks.includes('recoil_suppress_rerender_in_callback')
-          ? 1
-          : 0),
-    );
-  },
-);
-
 testRecoil('Sync React and Recoil state changes', ({gks}) => {
   if (
     reactMode().mode === 'MUTABLE_SOURCE' &&
@@ -1748,131 +947,6 @@ testRecoil('Sync React and Recoil state changes', ({gks}) => {
   });
   expect(c.textContent).toBe('1 - 1');
 });
-
-testRecoil(
-  'useTransactionObservation_DEPRECATED: Transaction dirty atoms are set',
-  async () => {
-    const anAtom = counterAtom({
-      type: 'url',
-      validator: x => (x: any), // flowlint-line unclear-type:off
-    });
-    const [aSelector, _] = plusOneSelector(anAtom);
-    const [anAsyncSelector, __] = plusOneAsyncSelector(aSelector);
-    const [Component, updateValue] = componentThatWritesAtom(anAtom);
-    const modifiedAtomsList = [];
-    renderElements(
-      <>
-        <Component />
-        <ReadsAtom atom={aSelector} />
-        <React.Suspense fallback="loading">
-          <ReadsAtom atom={anAsyncSelector} />
-        </React.Suspense>
-        <ObservesTransactions
-          fn={({modifiedAtoms}) => {
-            modifiedAtomsList.push(modifiedAtoms);
-          }}
-        />
-      </>,
-    );
-
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-    act(() => updateValue(1));
-    await flushPromisesAndTimers();
-    expect(modifiedAtomsList.length).toBe(3);
-    expect(modifiedAtomsList[1].size).toBe(1);
-    expect(modifiedAtomsList[1].has(anAtom.key)).toBe(true);
-    for (const modifiedAtoms of modifiedAtomsList) {
-      expect(modifiedAtoms.has(aSelector.key)).toBe(false);
-      expect(modifiedAtoms.has(anAsyncSelector.key)).toBe(false);
-    }
-  },
-);
-
-testRecoil(
-  'Can restore persisted values before atom def code is loaded',
-  () => {
-    let theAtom = null;
-    let setUnvalidatedAtomValues;
-    function SetsUnvalidatedAtomValues() {
-      setUnvalidatedAtomValues = useSetUnvalidatedAtomValues();
-      return null;
-    }
-    let setVisible;
-    function Switch({children}) {
-      const [visible, mySetVisible] = useState(false);
-      setVisible = mySetVisible;
-      return visible ? children : null;
-    }
-    function MyReadsAtom({getAtom}) {
-      const [value] = useRecoilState((getAtom(): any)); // flowlint-line unclear-type:off
-      return value;
-    }
-    const container = renderElements(
-      <>
-        <SetsUnvalidatedAtomValues />
-        <Switch>
-          <MyReadsAtom getAtom={() => theAtom} />
-        </Switch>
-      </>,
-    );
-    act(() => {
-      setUnvalidatedAtomValues(new Map().set('notDefinedYetAtom', 123));
-    });
-    const validator = jest.fn(() => 789);
-    theAtom = atom({
-      key: 'notDefinedYetAtom',
-      default: 456,
-      persistence_UNSTABLE: {
-        type: 'url',
-        validator,
-      },
-    });
-    act(() => {
-      setVisible(true);
-    });
-    expect(validator.mock.calls[0][0]).toBe(123);
-    expect(container.textContent).toBe('789');
-  },
-);
-
-testRecoil(
-  'useTransactionObservation_DEPRECATED: Nonvalidated atoms are included in transaction observation',
-  () => {
-    const anAtom = counterAtom({
-      type: 'url',
-      validator: x => (x: any), // flowlint-line unclear-type:off
-    });
-
-    const [Component, updateValue] = componentThatWritesAtom(anAtom);
-
-    let setUnvalidatedAtomValues;
-    function SetsUnvalidatedAtomValues() {
-      setUnvalidatedAtomValues = useSetUnvalidatedAtomValues();
-      return null;
-    }
-
-    let values = new Map();
-    renderElements(
-      <>
-        <Component />
-        <SetsUnvalidatedAtomValues />
-        <ObservesTransactions
-          fn={({atomValues}) => {
-            values = atomValues;
-          }}
-        />
-      </>,
-    );
-    act(() => {
-      setUnvalidatedAtomValues(new Map().set('someNonvalidatedAtom', 123));
-    });
-    values = new Map();
-    act(() => updateValue(1));
-    expect(values.size).toBe(2);
-    expect(values.get('someNonvalidatedAtom')).toBe(123);
-  },
-);
 
 testRecoil('Hooks cannot be used outside of RecoilRoot', () => {
   const myAtom = atom({key: 'hook outside RecoilRoot', default: 'INVALID'});

--- a/packages/recoil/hooks/__tests__/Recoil_useTransactionObservation_DEPRECATED-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useTransactionObservation_DEPRECATED-test.js
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {
+  RecoilState,
+  RecoilValue,
+  RecoilValueReadOnly,
+} from '../../core/Recoil_RecoilValue';
+import type {PersistenceSettings} from '../../recoil_values/Recoil_atom';
+
+const {
+  getRecoilTestFn,
+} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
+
+let React,
+  useState,
+  act,
+  atom,
+  selector,
+  ReadsAtom,
+  flushPromisesAndTimers,
+  renderElements,
+  renderUnwrappedElements,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+  useSetUnvalidatedAtomValues,
+  useTransactionObservation_DEPRECATED;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({useState} = require('react'));
+  ({act} = require('ReactTestUtils'));
+
+  atom = require('../../recoil_values/Recoil_atom');
+  selector = require('../../recoil_values/Recoil_selector');
+  ({
+    ReadsAtom,
+    flushPromisesAndTimers,
+    renderElements,
+    renderUnwrappedElements,
+  } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
+  ({
+    useRecoilState,
+    useRecoilValue,
+    useSetRecoilState,
+    useSetUnvalidatedAtomValues,
+  } = require('../Recoil_Hooks'));
+  ({useTransactionObservation_DEPRECATED} = require('../Recoil_SnapshotHooks'));
+});
+
+let nextID = 0;
+
+function counterAtom(persistence?: PersistenceSettings<number>) {
+  return atom({
+    key: `atom${nextID++}`,
+    default: 0,
+    persistence_UNSTABLE: persistence,
+  });
+}
+
+function plusOneSelector(dep: RecoilValue<number>) {
+  const fn = jest.fn(x => x + 1);
+  const sel = selector({
+    key: `selector${nextID++}`,
+    get: ({get}) => fn(get(dep)),
+  });
+  return [sel, fn];
+}
+
+function plusOneAsyncSelector(
+  dep: RecoilValue<number>,
+): [RecoilValueReadOnly<number>, (number) => void] {
+  let nextTimeoutAmount = 100;
+  const fn = jest.fn(x => {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve(x + 1);
+      }, nextTimeoutAmount);
+    });
+  });
+  const sel = selector({
+    key: `selector${nextID++}`,
+    get: ({get}) => fn(get(dep)),
+  });
+  return [
+    sel,
+    x => {
+      nextTimeoutAmount = x;
+    },
+  ];
+}
+
+function componentThatWritesAtom<T>(
+  recoilState: RecoilState<T>,
+  // flowlint-next-line unclear-type:off
+): [any, ((T => T) | T) => void] {
+  let updateValue;
+  const Component = jest.fn(() => {
+    updateValue = useSetRecoilState(recoilState);
+    return null;
+  });
+  // flowlint-next-line unclear-type:off
+  return [(Component: any), x => updateValue(x)];
+}
+
+function ObservesTransactions({fn}) {
+  useTransactionObservation_DEPRECATED(fn);
+  return null;
+}
+
+testRecoil(
+  'useTransactionObservation_DEPRECATED: Transaction dirty atoms are set',
+  async () => {
+    const anAtom = counterAtom({
+      type: 'url',
+      validator: x => (x: any), // flowlint-line unclear-type:off
+    });
+    const [aSelector, _] = plusOneSelector(anAtom);
+    const [anAsyncSelector, __] = plusOneAsyncSelector(aSelector);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const modifiedAtomsList = [];
+    renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={aSelector} />
+        <React.Suspense fallback="loading">
+          <ReadsAtom atom={anAsyncSelector} />
+        </React.Suspense>
+        <ObservesTransactions
+          fn={({modifiedAtoms}) => {
+            modifiedAtomsList.push(modifiedAtoms);
+          }}
+        />
+      </>,
+    );
+
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    act(() => updateValue(1));
+    await flushPromisesAndTimers();
+    expect(modifiedAtomsList.length).toBe(3);
+    expect(modifiedAtomsList[1].size).toBe(1);
+    expect(modifiedAtomsList[1].has(anAtom.key)).toBe(true);
+    for (const modifiedAtoms of modifiedAtomsList) {
+      expect(modifiedAtoms.has(aSelector.key)).toBe(false);
+      expect(modifiedAtoms.has(anAsyncSelector.key)).toBe(false);
+    }
+  },
+);
+
+testRecoil(
+  'Can restore persisted values before atom def code is loaded',
+  () => {
+    let theAtom = null;
+    let setUnvalidatedAtomValues;
+    function SetsUnvalidatedAtomValues() {
+      setUnvalidatedAtomValues = useSetUnvalidatedAtomValues();
+      return null;
+    }
+    let setVisible;
+    function Switch({children}) {
+      const [visible, mySetVisible] = useState(false);
+      setVisible = mySetVisible;
+      return visible ? children : null;
+    }
+    function MyReadsAtom({getAtom}) {
+      const [value] = useRecoilState((getAtom(): any)); // flowlint-line unclear-type:off
+      return value;
+    }
+    const container = renderElements(
+      <>
+        <SetsUnvalidatedAtomValues />
+        <Switch>
+          <MyReadsAtom getAtom={() => theAtom} />
+        </Switch>
+      </>,
+    );
+    act(() => {
+      setUnvalidatedAtomValues(new Map().set('notDefinedYetAtom', 123));
+    });
+    const validator = jest.fn(() => 789);
+    theAtom = atom({
+      key: 'notDefinedYetAtom',
+      default: 456,
+      persistence_UNSTABLE: {
+        type: 'url',
+        validator,
+      },
+    });
+    act(() => {
+      setVisible(true);
+    });
+    expect(validator.mock.calls[0][0]).toBe(123);
+    expect(container.textContent).toBe('789');
+  },
+);
+
+testRecoil(
+  'useTransactionObservation_DEPRECATED: Nonvalidated atoms are included in transaction observation',
+  () => {
+    const anAtom = counterAtom({
+      type: 'url',
+      validator: x => (x: any), // flowlint-line unclear-type:off
+    });
+
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+
+    let setUnvalidatedAtomValues;
+    function SetsUnvalidatedAtomValues() {
+      setUnvalidatedAtomValues = useSetUnvalidatedAtomValues();
+      return null;
+    }
+
+    let values = new Map();
+    renderElements(
+      <>
+        <Component />
+        <SetsUnvalidatedAtomValues />
+        <ObservesTransactions
+          fn={({atomValues}) => {
+            values = atomValues;
+          }}
+        />
+      </>,
+    );
+    act(() => {
+      setUnvalidatedAtomValues(new Map().set('someNonvalidatedAtom', 123));
+    });
+    values = new Map();
+    act(() => updateValue(1));
+    expect(values.size).toBe(2);
+    expect(values.get('someNonvalidatedAtom')).toBe(123);
+  },
+);
+
+testRecoil('Hooks cannot be used outside of RecoilRoot', () => {
+  const myAtom = atom({key: 'hook outside RecoilRoot', default: 'INVALID'});
+  function Test() {
+    useRecoilValue(myAtom);
+    return 'TEST';
+  }
+
+  // Make sure there is a friendly error message mentioning <RecoilRoot>
+  expect(() => renderUnwrappedElements(<Test />)).toThrow('<RecoilRoot>');
+});

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -17,31 +17,17 @@ const {
   getRecoilTestFn,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 
-let React,
-  store,
+let store,
   atom,
-  nullthrows,
-  useEffect,
-  useState,
-  Profiler,
   noWait,
   act,
-  useRecoilCallback,
-  useRecoilState,
-  useRecoilValue,
-  useRecoilValueLoadable,
-  useSetRecoilState,
-  useResetRecoilState,
   constSelector,
   errorSelector,
   getRecoilValueAsLoadable,
   setRecoilValue,
   selector,
   asyncSelector,
-  ReadsAtom,
-  renderElements,
   resolvingAsyncSelector,
-  loadingAsyncSelector,
   flushPromisesAndTimers,
   DefaultValue,
   freshSnapshot;
@@ -51,21 +37,10 @@ const testRecoil = getRecoilTestFn(() => {
     makeStore,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 
-  React = require('react');
-  ({useEffect, useState, Profiler} = require('react'));
   ({act} = require('ReactTestUtils'));
   atom = require('../Recoil_atom');
-  ({
-    useRecoilState,
-    useRecoilValue,
-    useRecoilValueLoadable,
-    useSetRecoilState,
-    useResetRecoilState,
-  } = require('../../hooks/Recoil_Hooks'));
-  ({useRecoilCallback} = require('../../hooks/Recoil_useRecoilCallback'));
   constSelector = require('../Recoil_constSelector');
   errorSelector = require('../Recoil_errorSelector');
-  nullthrows = require('recoil-shared/util/Recoil_nullthrows');
   ({
     getRecoilValueAsLoadable,
     setRecoilValue,
@@ -74,10 +49,7 @@ const testRecoil = getRecoilTestFn(() => {
   ({freshSnapshot} = require('../../core/Recoil_Snapshot'));
   ({
     asyncSelector,
-    ReadsAtom,
-    renderElements,
     resolvingAsyncSelector,
-    loadingAsyncSelector,
     flushPromisesAndTimers,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
   ({noWait} = require('../Recoil_WaitFor'));
@@ -119,12 +91,6 @@ function resetValue(recoilState) {
   // $FlowFixMe[cannot-write]
   store.getState().currentTree.version++;
 }
-
-testRecoil('useRecoilState - static selector', () => {
-  const staticSel = constSelector('HELLO');
-  const c = renderElements(<ReadsAtom atom={staticSel} />);
-  expect(c.textContent).toEqual('"HELLO"');
-});
 
 testRecoil('selector get', () => {
   const staticSel = constSelector('HELLO');
@@ -181,15 +147,6 @@ testRecoil('selector reset', () => {
   expect(getValue(selectorRW)).toEqual('DEFAULT');
 });
 
-testRecoil('useRecoilState - resolved async selector', async () => {
-  const resolvingSel = resolvingAsyncSelector('HELLO');
-  const c = renderElements(<ReadsAtom atom={resolvingSel} />);
-  expect(c.textContent).toEqual('loading');
-  act(() => jest.runAllTimers());
-  await flushPromisesAndTimers();
-  expect(c.textContent).toEqual('"HELLO"');
-});
-
 testRecoil('selector - evaluate to RecoilValue', () => {
   const atomA = atom({key: 'selector/const atom A', default: 'A'});
   const atomB = atom({key: 'selector/const atom B', default: 'B'});
@@ -204,1005 +161,332 @@ testRecoil('selector - evaluate to RecoilValue', () => {
   expect(getValue(mySelector)).toEqual('B');
 });
 
-testRecoil('selector - catching exceptions', () => {
-  const throwingSel = errorSelector('MY ERROR');
-  expect(getValue(throwingSel)).toBeInstanceOf(Error);
+describe('Catching Deps', () => {
+  testRecoil('selector - catching exceptions', () => {
+    const throwingSel = errorSelector('MY ERROR');
+    expect(getValue(throwingSel)).toBeInstanceOf(Error);
 
-  const catchingSelector = selector({
-    key: 'selector/catching selector',
-    get: ({get}) => {
-      try {
-        return get(throwingSel);
-      } catch (e) {
-        expect(e instanceof Error).toBe(true);
-        expect(e.message).toContain('MY ERROR');
-        return 'CAUGHT';
-      }
-    },
-  });
-  expect(getValue(catchingSelector)).toEqual('CAUGHT');
-});
-
-testRecoil('selector - catching exception (non Error)', () => {
-  const throwingSel = selector({
-    key: '__error/non Error thrown',
-    get: () => {
-      // eslint-disable-next-line no-throw-literal
-      throw 'MY ERROR';
-    },
-  });
-
-  const catchingSelector = selector({
-    key: 'selector/catching selector',
-    get: ({get}) => {
-      try {
-        return get(throwingSel);
-      } catch (e) {
-        expect(e).toBe('MY ERROR');
-        return 'CAUGHT';
-      }
-    },
-  });
-
-  expect(getValue(catchingSelector)).toEqual('CAUGHT');
-});
-
-testRecoil('selector - catching loads', () => {
-  const loadingSel = resolvingAsyncSelector('READY');
-  expect(getValue(loadingSel) instanceof Promise).toBe(true);
-
-  const blockedSelector = selector({
-    key: 'selector/blocked selector',
-    get: ({get}) => get(loadingSel),
-  });
-  expect(getValue(blockedSelector) instanceof Promise).toBe(true);
-
-  const bypassSelector = selector({
-    key: 'selector/bypassing selector',
-    get: ({get}) => {
-      try {
-        return get(loadingSel);
-      } catch (promise) {
-        expect(promise instanceof Promise).toBe(true);
-        return 'BYPASS';
-      }
-    },
-  });
-  expect(getValue(bypassSelector)).toBe('BYPASS');
-  act(() => jest.runAllTimers());
-  expect(getValue(bypassSelector)).toEqual('READY');
-});
-
-testRecoil('useRecoilState - selector catching exceptions', () => {
-  const throwingSel = errorSelector('MY ERROR');
-  const c1 = renderElements(<ReadsAtom atom={throwingSel} />);
-  expect(c1.textContent).toEqual('error');
-
-  const catchingSelector = selector({
-    key: 'useRecoilState/catching selector',
-    get: ({get}) => {
-      try {
-        return get(throwingSel);
-      } catch (e) {
-        expect(e instanceof Error).toBe(true);
-        expect(e.message).toContain('MY ERROR');
-        return 'CAUGHT';
-      }
-    },
-  });
-  const c2 = renderElements(<ReadsAtom atom={catchingSelector} />);
-  expect(c2.textContent).toEqual('"CAUGHT"');
-});
-
-testRecoil('useRecoilState - selector catching exceptions (non Errors)', () => {
-  const throwingSel = selector({
-    key: '__error/non Error thrown',
-    get: () => {
-      // eslint-disable-next-line no-throw-literal
-      throw 'MY ERROR';
-    },
-  });
-
-  const c1 = renderElements(<ReadsAtom atom={throwingSel} />);
-  expect(c1.textContent).toEqual('error');
-
-  const catchingSelector = selector({
-    key: 'useRecoilState/catching selector',
-    get: ({get}) => {
-      try {
-        return get(throwingSel);
-      } catch (e) {
-        expect(e).toBe('MY ERROR');
-        return 'CAUGHT';
-      }
-    },
-  });
-
-  const c2 = renderElements(<ReadsAtom atom={catchingSelector} />);
-  expect(c2.textContent).toEqual('"CAUGHT"');
-});
-
-testRecoil('useRecoilState - async selector', async () => {
-  const resolvingSel = resolvingAsyncSelector('READY');
-
-  // On first read it is blocked on the async selector
-  const c1 = renderElements(<ReadsAtom atom={resolvingSel} />);
-  expect(c1.textContent).toEqual('loading');
-
-  // When that resolves the data is ready
-  act(() => jest.runAllTimers());
-  await flushPromisesAndTimers();
-  expect(c1.textContent).toEqual('"READY"');
-});
-
-testRecoil('useRecoilState - selector blocked on dependency', async () => {
-  const resolvingSel = resolvingAsyncSelector('READY');
-  const blockedSelector = selector({
-    key: 'useRecoilState/blocked selector',
-    get: ({get}) => get(resolvingSel),
-  });
-
-  // On first read, the selectors dependency is still loading
-  const c2 = renderElements(<ReadsAtom atom={blockedSelector} />);
-  expect(c2.textContent).toEqual('loading');
-
-  // When the dependency resolves, the data is ready
-  act(() => jest.runAllTimers());
-  await flushPromisesAndTimers();
-  expect(c2.textContent).toEqual('"READY"');
-});
-
-testRecoil('useRecoilState - selector catching loads', async () => {
-  const resolvingSel = resolvingAsyncSelector('READY');
-  const bypassSelector = selector({
-    key: 'useRecoilState/bypassing selector',
-    get: ({get}) => {
-      try {
-        const value = get(resolvingSel);
-        expect(value).toBe('READY');
-        return value;
-      } catch (promise) {
-        expect(promise instanceof Promise).toBe(true);
-        return 'BYPASS';
-      }
-    },
-  });
-
-  // On first read the dependency is not yet available, but the
-  // selector catches and bypasses it.
-  const c3 = renderElements(<ReadsAtom atom={bypassSelector} />);
-  expect(c3.textContent).toEqual('"BYPASS"');
-
-  // When the dependency does resolve, the selector re-evaluates
-  // with the new data.
-  act(() => jest.runAllTimers());
-  expect(c3.textContent).toEqual('"READY"');
-});
-
-testRecoil('useRecoilState - selector catching all of 2 loads', async () => {
-  const [resolvingSel1, res1] = asyncSelector();
-  const [resolvingSel2, res2] = asyncSelector();
-
-  const bypassSelector = selector({
-    key: 'useRecoilState/bypassing selector all',
-    get: ({get}) => {
-      let ready = 0;
-      try {
-        const value1 = get(resolvingSel1);
-        expect(value1).toBe('READY1');
-        ready++;
-        const value2 = get(resolvingSel2);
-        expect(value2).toBe('READY2');
-        ready++;
-        return ready;
-      } catch (promise) {
-        expect(promise instanceof Promise).toBe(true);
-        return ready;
-      }
-    },
-  });
-
-  // On first read the dependency is not yet available, but the
-  // selector catches and bypasses it.
-  const c3 = renderElements(<ReadsAtom atom={bypassSelector} />);
-  expect(c3.textContent).toEqual('0');
-
-  // After the first resolution, we're still waiting on the second
-  res1('READY1');
-  act(() => jest.runAllTimers());
-  expect(c3.textContent).toEqual('1');
-
-  // When both are available, we are done!
-  res2('READY2');
-  act(() => jest.runAllTimers());
-  expect(c3.textContent).toEqual('2');
-});
-
-testRecoil('useRecoilState - selector catching any of 2 loads', async () => {
-  const resolvingSel1 = resolvingAsyncSelector('READY');
-  const resolvingSel2 = resolvingAsyncSelector('READY');
-  const bypassSelector = selector({
-    key: 'useRecoilState/bypassing selector any',
-    get: ({get}) => {
-      let ready = 0;
-      for (const resolvingSel of [resolvingSel1, resolvingSel2]) {
-        try {
-          const value = get(resolvingSel);
-          expect(value).toBe('READY');
-          ready++;
-        } catch (promise) {
-          expect(promise instanceof Promise).toBe(true);
-          ready = ready;
-        }
-      }
-      return ready;
-    },
-  });
-
-  // On first read the dependency is not yet available, but the
-  // selector catches and bypasses it.
-  const c3 = renderElements(<ReadsAtom atom={bypassSelector} />);
-  expect(c3.textContent).toEqual('0');
-
-  // Because both dependencies are tried, they should both resolve
-  // in parallel after one event loop.
-  act(() => jest.runAllTimers());
-  expect(c3.textContent).toEqual('2');
-});
-
-// Test the ability to catch a promise for a pending dependency that we can
-// then handle by returning an async promise.
-testRecoil(
-  'useRecoilState - selector catching promise and resolving asynchronously',
-  async () => {
-    const [originalDep, resolveOriginal] = asyncSelector();
-    const [bypassDep, resolveBypass] = asyncSelector();
-    const catchPromiseSelector = selector({
-      key: 'useRecoilState/catch then async',
+    const catchingSelector = selector({
+      key: 'selector/catching selector',
       get: ({get}) => {
         try {
-          return get(originalDep);
-        } catch (promise) {
-          expect(promise instanceof Promise).toBe(true);
-          return bypassDep;
+          return get(throwingSel);
+        } catch (e) {
+          expect(e instanceof Error).toBe(true);
+          expect(e.message).toContain('MY ERROR');
+          return 'CAUGHT';
         }
       },
     });
-    const c = renderElements(<ReadsAtom atom={catchPromiseSelector} />);
-
-    expect(c.textContent).toEqual('loading');
-    act(() => jest.runAllTimers());
-    expect(c.textContent).toEqual('loading');
-    resolveBypass('BYPASS');
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(c.textContent).toEqual('"BYPASS"');
-    resolveOriginal('READY');
-    act(() => jest.runAllTimers());
-    await flushPromisesAndTimers();
-    expect(c.textContent).toEqual('"READY"');
-  },
-);
-
-// This tests ability to catch a pending result as a promise and
-// that the promise resolves to the dependency's value and it is handled
-// as an asynchronous selector
-testRecoil('useRecoilState - selector catching promise 2', async () => {
-  let dependencyPromiseTest;
-  const resolvingSel = resolvingAsyncSelector('READY');
-  const catchPromiseSelector = selector({
-    key: 'useRecoilState/catch then async 2',
-    get: ({get}) => {
-      try {
-        return get(resolvingSel);
-      } catch (promise) {
-        expect(promise instanceof Promise).toBe(true);
-        // eslint-disable-next-line jest/valid-expect
-        dependencyPromiseTest = expect(promise).resolves.toBe('READY');
-
-        return promise.then(pending => {
-          const result = pending.value;
-          expect(result).toBe('READY');
-          return result.value + ' NOW';
-        });
-      }
-    },
+    expect(getValue(catchingSelector)).toEqual('CAUGHT');
   });
-  const c = renderElements(<ReadsAtom atom={catchPromiseSelector} />);
 
-  expect(c.textContent).toEqual('loading');
-
-  await flushPromisesAndTimers();
-
-  // NOTE!!!
-  // The output here may be "READY NOW" if we optimize the selector to
-  // cache the result of the async evaluation when the dependency is available
-  // in the cache key with the dependency being available.  Currently it does not
-  // So, when the dependency is ready and the component re-renders it will
-  // re-evaluate.  At that point the dependency is now READY and thus we only
-  // get READY and not READY NOW.
-  // expect(c.textContent).toEqual('"READY NOW"');
-  expect(c.textContent).toEqual('"READY"');
-
-  // Test that the promise for the dependency that we got actually resolved
-  // to the dependency's value.
-  await dependencyPromiseTest;
-});
-
-// Test that Recoil will throw an error with a useful debug message instead of
-// infinite recurssion when there is a circular dependency
-testRecoil('Detect circular dependencies', () => {
-  const selectorA = selector({
-    key: 'circular/A',
-    get: ({get}) => get(selectorC),
-  });
-  const selectorB = selector({
-    key: 'circular/B',
-    get: ({get}) => get(selectorA),
-  });
-  const selectorC = selector({
-    key: 'circular/C',
-    get: ({get}) => get(selectorB),
-  });
-  const devStatus = window.__DEV__;
-  window.__DEV__ = true;
-  expect(getValue(selectorC)).toBeInstanceOf(Error);
-  expect(getError(selectorC).message).toEqual(
-    expect.stringContaining('circular/A'),
-  );
-  window.__DEV__ = devStatus;
-});
-
-testRecoil(
-  'selector is able to track dependencies discovered asynchronously',
-  async () => {
-    const anAtom = atom({key: 'atomTrackedAsync', default: 'Async Dep Value'});
-
-    const selectorWithAsyncDeps = selector({
-      key: 'selectorTrackDepsIncrementally',
-      get: async ({get}) => {
-        await Promise.resolve(); // needed to simulate discovering a dependency asynchronously
-
-        return get(anAtom);
+  testRecoil('selector - catching exception (non Error)', () => {
+    const throwingSel = selector({
+      key: '__error/non Error thrown',
+      get: () => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'MY ERROR';
       },
     });
 
-    let setAtom;
-
-    function Component() {
-      [, setAtom] = useRecoilState(anAtom);
-      const selVal = useRecoilValue(selectorWithAsyncDeps);
-
-      return selVal;
-    }
-
-    const container = renderElements(<Component />);
-
-    expect(container.textContent).toEqual('loading');
-
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers(); // HACK: not sure why but this is needed in OSS
-
-    expect(container.textContent).toEqual('Async Dep Value');
-
-    act(() => setAtom('CHANGED Async Dep'));
-
-    expect(container.textContent).toEqual('loading');
-
-    await flushPromisesAndTimers();
-
-    expect(container.textContent).toEqual('CHANGED Async Dep');
-  },
-);
-
-/**
- * This test is an extension of the 'selector is able to track dependencies
- * discovered asynchronously' test: in addition to testing that a selector
- * responds to changes in dependencies that were discovered asynchronously, the
- * selector should run through the entire selector in response to those changes.
- */
-testRecoil(
-  'selector should rerun entire selector when a dep changes',
-  async () => {
-    const resolvingSel1 = resolvingAsyncSelector(1);
-    const resolvingSel2 = resolvingAsyncSelector(2);
-    const anAtom3 = atom({key: 'atomTrackedAsync3', default: 3});
-
-    const selectorWithAsyncDeps = selector({
-      key: 'selectorNotCacheIncDeps',
-      get: async ({get}) => {
-        const val1 = get(resolvingSel1);
-
-        await Promise.resolve();
-
-        const val2 = get(resolvingSel2);
-
-        await Promise.resolve();
-
-        const val3 = get(anAtom3);
-
-        return val1 + val2 + val3;
-      },
-    });
-
-    let setAtom;
-
-    function Component() {
-      [, setAtom] = useRecoilState(anAtom3);
-      const selVal = useRecoilValue(selectorWithAsyncDeps);
-
-      return selVal;
-    }
-
-    const container = renderElements(<Component />);
-
-    expect(container.textContent).toEqual('loading');
-
-    await flushPromisesAndTimers();
-
-    // HACK: not sure why but these are needed in OSS
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-
-    expect(container.textContent).toEqual('6');
-
-    act(() => setAtom(4));
-
-    expect(container.textContent).toEqual('loading');
-
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-    await flushPromisesAndTimers();
-
-    expect(container.textContent).toEqual('7');
-  },
-);
-
-testRecoil("Updating with same value doesn't rerender", ({gks}) => {
-  if (!gks.includes('recoil_suppress_rerender_in_callback')) {
-    return;
-  }
-
-  const myAtom = atom({
-    key: 'selector same value rerender / atom',
-    default: {value: 'DEFAULT'},
-  });
-  const mySelector = selector({
-    key: 'selector - same value rerender',
-    get: ({get}) => get(myAtom).value,
-  });
-
-  let setAtom;
-  let resetAtom;
-  let renders = 0;
-  function SelectorComponent() {
-    const value = useRecoilValue(mySelector);
-    const setAtomValue = useSetRecoilState(myAtom);
-    const resetAtomValue = useResetRecoilState(myAtom);
-    setAtom = x => setAtomValue({value: x});
-    resetAtom = resetAtomValue;
-    return value;
-  }
-  expect(renders).toEqual(0);
-  const c = renderElements(
-    <Profiler
-      id="test"
-      onRender={() => {
-        renders++;
-      }}>
-      <SelectorComponent />
-    </Profiler>,
-  );
-
-  // Initial render happens one time in www and 2 times in oss.
-  // resetting the counter to 1 after the initial render to make them
-  // the same in both repos. 2 renders probably need to be looked into.
-  renders = 1;
-
-  expect(c.textContent).toEqual('DEFAULT');
-
-  act(() => setAtom('SET'));
-  expect(c.textContent).toEqual('SET');
-  expect(renders).toEqual(2);
-
-  act(() => setAtom('SET'));
-  expect(c.textContent).toEqual('SET');
-  expect(renders).toEqual(2);
-
-  act(() => setAtom('CHANGE'));
-  expect(c.textContent).toEqual('CHANGE');
-  expect(renders).toEqual(3);
-
-  act(resetAtom);
-  expect(c.textContent).toEqual('DEFAULT');
-  expect(renders).toEqual(4);
-
-  act(resetAtom);
-  expect(c.textContent).toEqual('DEFAULT');
-  expect(renders).toEqual(4);
-});
-
-// Test the following scenario:
-// 0. Recoil state version 1 with A=FOO and B=BAR
-// 1. Component renders with A for a value of FOO
-// 2. Component renders with B for a value of BAR
-// 3. Recoil state updated to version 2 with A=FOO and B=FOO
-//
-// Step 2 may be problematic if we attempt to suppress re-renders and don't
-// properly keep track of previous component values when the mutable source changes.
-testRecoil('Updating with changed selector', ({gks}) => {
-  if (!gks.includes('recoil_suppress_rerender_in_callback')) {
-    return;
-  }
-
-  const atomA = atom({
-    key: 'selector change rerender / atomA',
-    default: {value: 'FOO'},
-  });
-  const atomB = atom({
-    key: 'selector change rerender / atomB',
-    default: {value: 'BAR'},
-  });
-  const selectorA = selector({
-    key: 'selector change rerender / selectorA',
-    get: ({get}) => get(atomA).value,
-  });
-  const selectorB = selector({
-    key: 'selector change rerender / selectorB',
-    get: ({get}) => get(atomB).value,
-  });
-
-  let setSide;
-  let setB;
-  function SelectorComponent() {
-    const [side, setSideState] = useState('A');
-    setSide = setSideState;
-
-    setB = useRecoilCallback(({snapshot, gotoSnapshot}) => value => {
-      gotoSnapshot(
-        snapshot.map(({set}) => {
-          set(atomB, {value});
-        }),
-      );
-    });
-
-    return useRecoilValue(side === 'A' ? selectorA : selectorB);
-  }
-  const c = renderElements(<SelectorComponent />);
-
-  expect(c.textContent).toEqual('FOO');
-
-  // When we change the selector we are looking up it will render other atom's value
-  act(() => setSide('B'));
-  expect(c.textContent).toEqual('BAR');
-
-  // When we change Recoil state the component should re-render with new value.
-  // True even if we keep track of previous renders values to suppress re-renders when they don't change.
-  // If we don't keep track properly when the atom changes, this may break.
-  act(() => setB('FOO'));
-  expect(c.textContent).toEqual('FOO');
-
-  // When we swap back to atomA it now has the same value as atomB.
-  act(() => setSide('A'));
-  expect(c.textContent).toEqual('FOO');
-});
-
-testRecoil('Change component prop to suspend and wake', () => {
-  const awakeSelector = constSelector('WAKE');
-  const suspendedSelector = loadingAsyncSelector();
-
-  function TestComponent({side}) {
-    return (
-      useRecoilValue(side === 'AWAKE' ? awakeSelector : suspendedSelector) ??
-      'LOADING'
-    );
-  }
-
-  let setSide;
-  const SelectorComponent = function () {
-    const [side, setSideState] = useState('AWAKE');
-    setSide = setSideState;
-    return <TestComponent side={side} />;
-  };
-  const c = renderElements(<SelectorComponent />);
-
-  expect(c.textContent).toEqual('WAKE');
-
-  act(() => setSide('SLEEP'));
-  expect(c.textContent).toEqual('loading');
-
-  act(() => setSide('AWAKE'));
-  expect(c.textContent).toEqual('WAKE');
-});
-
-/**
- * This test ensures that we are not running the selector's get() an unnecessary
- * number of times in response to async selectors resolving (i.e. by retrying
- * more times than we have to or creating numerous promises that retry).
- */
-testRecoil(
-  'async selector runs the minimum number of times required',
-  async () => {
-    const [asyncDep1, resolveAsyncDep1] = asyncSelector();
-    const [asyncDep2, resolveAsyncDep2] = asyncSelector();
-
-    let numTimesRan = 0;
-
-    const selectorWithAsyncDeps = selector({
-      key: 'selectorRunsMinTimes',
-      get: async ({get}) => {
-        numTimesRan++;
-        return get(asyncDep1) + get(asyncDep2);
-      },
-    });
-
-    const container = renderElements(
-      <ReadsAtom atom={selectorWithAsyncDeps} />,
-    );
-
-    expect(numTimesRan).toBe(1);
-
-    act(() => resolveAsyncDep1('a'));
-
-    await flushPromisesAndTimers();
-
-    expect(numTimesRan).toBe(2);
-
-    act(() => resolveAsyncDep2('b'));
-
-    await flushPromisesAndTimers();
-
-    expect(numTimesRan).toBe(3);
-
-    await flushPromisesAndTimers();
-
-    expect(container.textContent).toEqual('"ab"');
-  },
-);
-
-testRecoil(
-  'async selector with changing dependencies finishes execution using original state',
-  async () => {
-    const [asyncDep, resolveAsyncDep] = asyncSelector();
-    const anAtom = atom({key: 'atomChangingDeps', default: 3});
-
-    const anAsyncSelector = selector({
-      key: 'selectorWithChangingDeps',
+    const catchingSelector = selector({
+      key: 'selector/catching selector',
       get: ({get}) => {
-        const atomValueBefore = get(anAtom);
-
-        get(asyncDep);
-
-        const atomValueAfter = get(anAtom);
-
-        expect(atomValueBefore).toBe(atomValueAfter);
-
-        return atomValueBefore + atomValueAfter;
+        try {
+          return get(throwingSel);
+        } catch (e) {
+          expect(e).toBe('MY ERROR');
+          return 'CAUGHT';
+        }
       },
     });
 
-    let loadableSoFar;
-    let setAtom;
-
-    const MyComponent = () => {
-      const setAtomLocal = useSetRecoilState(anAtom);
-      const asyncSelLoadable = useRecoilValueLoadable(anAsyncSelector);
-
-      setAtom = setAtomLocal;
-      loadableSoFar = asyncSelLoadable;
-
-      return asyncSelLoadable.state;
-    };
-
-    renderElements(<MyComponent />);
-
-    const loadableBeforeChangingAnything = nullthrows(loadableSoFar);
-    expect(loadableBeforeChangingAnything.contents).toBeInstanceOf(Promise);
-
-    act(() => setAtom(10));
-
-    const loadableAfterChangingAtom = nullthrows(loadableSoFar);
-    expect(loadableAfterChangingAtom.contents).toBeInstanceOf(Promise);
-    expect(loadableBeforeChangingAnything.contents).not.toBe(
-      loadableAfterChangingAtom.contents,
-    );
-
-    act(() => resolveAsyncDep(''));
-
-    await flushPromisesAndTimers();
-
-    await Promise.all([
-      expect(loadableBeforeChangingAnything.toPromise()).resolves.toBe(3 + 3),
-      expect(loadableAfterChangingAtom.toPromise()).resolves.toBe(10 + 10),
-    ]);
-  },
-);
-
-testRecoil('selector - dynamic getRecoilValue()', async () => {
-  const sel2 = selector({
-    key: 'MySelector2',
-    get: async () => 'READY',
+    expect(getValue(catchingSelector)).toEqual('CAUGHT');
   });
 
-  const sel1 = selector({
-    key: 'MySelector',
-    get: async ({get}) => {
-      await Promise.resolve();
-      return get(sel2);
-    },
+  testRecoil('selector - catching loads', () => {
+    const loadingSel = resolvingAsyncSelector('READY');
+    expect(getValue(loadingSel) instanceof Promise).toBe(true);
+
+    const blockedSelector = selector({
+      key: 'selector/blocked selector',
+      get: ({get}) => get(loadingSel),
+    });
+    expect(getValue(blockedSelector) instanceof Promise).toBe(true);
+
+    const bypassSelector = selector({
+      key: 'selector/bypassing selector',
+      get: ({get}) => {
+        try {
+          return get(loadingSel);
+        } catch (promise) {
+          expect(promise instanceof Promise).toBe(true);
+          return 'BYPASS';
+        }
+      },
+    });
+    expect(getValue(bypassSelector)).toBe('BYPASS');
+    act(() => jest.runAllTimers());
+    expect(getValue(bypassSelector)).toEqual('READY');
   });
-
-  const el = renderElements(<ReadsAtom atom={sel1} />);
-  expect(el.textContent).toEqual('loading');
-
-  await act(() => getValue(sel1));
-  act(() => jest.runAllTimers());
-
-  expect(el.textContent).toEqual('"READY"');
 });
 
-testRecoil(
-  'distinct loading dependencies are treated as distinct',
-  async () => {
-    const upstreamAtom = atom({
-      key: 'distinct loading dependencies/upstreamAtom',
-      default: 0,
-    });
-    const upstreamAsyncSelector = selector({
-      key: 'distinct loading dependencies/upstreamAsyncSelector',
-      get: ({get}) => Promise.resolve(get(upstreamAtom)),
-    });
-    const directSelector = selector({
-      key: 'distinct loading dependencies/directSelector',
-      get: ({get}) => get(upstreamAsyncSelector),
-    });
-
-    expect(getValue(directSelector) instanceof Promise).toBe(true);
-
-    act(() => jest.runAllTimers());
-    expect(getValue(directSelector)).toEqual(0);
-
-    setValue(upstreamAtom, 1);
-    expect(getValue(directSelector) instanceof Promise).toBe(true);
-
-    act(() => jest.runAllTimers());
-    expect(getValue(directSelector)).toEqual(1);
-  },
-);
-
-testRecoil(
-  'Selector deps are saved when a component mounts due to a non-recoil change at the same time that a selector is first read',
-  () => {
-    // Regression test for an issue where selector dependencies were not saved
-    // in this circumstance. In this situation dependencies are discovered for
-    // a selector when reading from a non-latest graph. This tests that these deps
-    // are carried forward instead of being forgotten.
-    let show, setShow, setAnotherAtom;
-    function Parent() {
-      [show, setShow] = useState(false);
-      setAnotherAtom = useSetRecoilState(anotherAtom);
-      if (show) {
-        return <SelectorUser />;
-      } else {
-        return null;
-      }
-    }
-
-    const anAtom = atom<number>({key: 'anAtom', default: 0});
-    const anotherAtom = atom<number>({key: 'anotherAtom', default: 0});
-
-    const aSelector = selector({
-      key: 'aSelector',
-      get: ({get}) => {
-        return get(anAtom);
-      },
-    });
-
-    function SelectorUser() {
-      const setter = useSetRecoilState(anAtom);
-      useEffect(() => {
-        setter(1);
-      });
-      return useRecoilValue(aSelector);
-    }
-
-    const c = renderElements(<Parent />);
-
-    expect(c.textContent).toEqual('');
-
-    act(() => {
-      setShow(true);
-      setAnotherAtom(1);
-    });
-
-    expect(c.textContent).toEqual('1');
-  },
-);
-
-describe('Async selector resolution notifies all stores that read pending', () => {
-  // Regression tests for #534: selectors used to only notify whichever store
-  // originally caused a promise to be returned, not any stores that also read
-  // the selector in that pending state.
-  testRecoil('Selectors read in a snapshot notify all stores', async () => {
-    // This version of the test uses the store inside of a Snapshot as its second store.
-    const switchAtom = atom({
-      key: 'notifiesAllStores/snapshots/switch',
-      default: false,
-    });
+describe('Dependencies', () => {
+  // Test that Recoil will throw an error with a useful debug message instead of
+  // infinite recurssion when there is a circular dependency
+  testRecoil('Detect circular dependencies', () => {
     const selectorA = selector({
-      key: 'notifiesAllStores/snapshots/a',
-      get: () => 'foo',
+      key: 'circular/A',
+      get: ({get}) => get(selectorC),
     });
-    let resolve = _ => {
-      throw new Error('error in test');
-    };
     const selectorB = selector({
-      key: 'notifiesAllStores/snapshots/b',
-      get: async () =>
-        new Promise(r => {
-          resolve = r;
-        }),
+      key: 'circular/B',
+      get: ({get}) => get(selectorA),
     });
+    const selectorC = selector({
+      key: 'circular/C',
+      get: ({get}) => get(selectorB),
+    });
+    const devStatus = window.__DEV__;
+    window.__DEV__ = true;
+    expect(getValue(selectorC)).toBeInstanceOf(Error);
+    expect(getError(selectorC).message).toEqual(
+      expect.stringContaining('circular/A'),
+    );
+    window.__DEV__ = devStatus;
+  });
 
-    let doIt;
-
-    function TestComponent() {
-      const shouldQuery = useRecoilValue(switchAtom);
-      const query = useRecoilValueLoadable(shouldQuery ? selectorB : selectorA);
-
-      doIt = useRecoilCallback(({snapshot, set}) => () => {
-        /**
-         * this is required as we need the selector accessed below to outlive
-         * the end of this callback so that the async resolution notifies the
-         * store of the resolution and a re-render is triggered. Otherwise, the
-         * selector will be cleaned up at the end of the callback, meaning the
-         * resolution of the selector will not result in a re-render.
-         */
-        snapshot.retain();
-        snapshot.getLoadable(selectorB); // cause query to be triggered in context of snapshot store
-        set(switchAtom, true); // cause us to then read from the pending selector
+  testRecoil(
+    'distinct loading dependencies are treated as distinct',
+    async () => {
+      const upstreamAtom = atom({
+        key: 'distinct loading dependencies/upstreamAtom',
+        default: 0,
+      });
+      const upstreamAsyncSelector = selector({
+        key: 'distinct loading dependencies/upstreamAsyncSelector',
+        get: ({get}) => Promise.resolve(get(upstreamAtom)),
+      });
+      const directSelector = selector({
+        key: 'distinct loading dependencies/directSelector',
+        get: ({get}) => get(upstreamAsyncSelector),
       });
 
-      return query.state === 'hasValue' ? query.contents : 'loading';
-    }
+      expect(getValue(directSelector) instanceof Promise).toBe(true);
 
-    const c = renderElements(<TestComponent />);
-    expect(c.textContent).toEqual('foo');
+      act(() => jest.runAllTimers());
+      expect(getValue(directSelector)).toEqual(0);
 
-    act(doIt);
-    expect(c.textContent).toEqual('loading');
+      setValue(upstreamAtom, 1);
+      expect(getValue(directSelector) instanceof Promise).toBe(true);
 
-    act(() => resolve('bar'));
-    await act(flushPromisesAndTimers);
-    await act(flushPromisesAndTimers);
-    expect(c.textContent).toEqual('bar');
-  });
+      act(() => jest.runAllTimers());
+      expect(getValue(directSelector)).toEqual(1);
+    },
+  );
 
-  testRecoil('Selectors read in a another root notify all roots', async () => {
-    // This version of the test uses another RecoilRoot as its second store
-    const switchAtom = atom({
-      key: 'notifiesAllStores/twoRoots/switch',
-      default: false,
-    });
+  testRecoil(
+    'selector - kite pattern runs only necessary selectors',
+    async () => {
+      const aNode = atom({
+        key: 'aNode',
+        default: true,
+      });
 
-    const selectorA = selector({
-      key: 'notifiesAllStores/twoRoots/a',
-      get: () => 'SELECTOR A',
-    });
+      let bNodeRunCount = 0;
+      const bNode = selector({
+        key: 'bNode',
+        get: ({get}) => {
+          bNodeRunCount++;
+          const a = get(aNode);
+          return String(a);
+        },
+      });
 
-    let resolve = _ => {
-      throw new Error('error in test');
-    };
-    const selectorB = selector({
-      key: 'notifiesAllStores/twoRoots/b',
-      get: async () =>
-        new Promise(r => {
-          resolve = r;
-        }),
-    });
+      let cNodeRunCount = 0;
+      const cNode = selector({
+        key: 'cNode',
+        get: ({get}) => {
+          cNodeRunCount++;
+          const a = get(aNode);
+          return String(Number(a));
+        },
+      });
 
-    function TestComponent({
-      setSwitch,
-    }: {
-      setSwitch: ((boolean) => void) => void,
-    }) {
-      const [shouldQuery, setShouldQuery] = useRecoilState(switchAtom);
-      const query = useRecoilValueLoadable(shouldQuery ? selectorB : selectorA);
-      setSwitch(setShouldQuery);
-      return query.state === 'hasValue' ? query.contents : 'loading';
-    }
+      let dNodeRunCount = 0;
+      const dNode = selector({
+        key: 'dNode',
+        get: ({get}) => {
+          dNodeRunCount++;
+          const value = get(aNode) ? get(bNode) : get(cNode);
+          return value.toUpperCase();
+        },
+      });
 
-    let setRootASelector;
-    const rootA = renderElements(
-      <TestComponent
-        setSwitch={setSelector => {
-          setRootASelector = setSelector;
-        }}
-      />,
-    );
-    let setRootBSelector;
-    const rootB = renderElements(
-      <TestComponent
-        setSwitch={setSelector => {
-          setRootBSelector = setSelector;
-        }}
-      />,
-    );
+      let dNodeValue = getValue(dNode);
+      expect(dNodeValue).toEqual('TRUE');
+      expect(bNodeRunCount).toEqual(1);
+      expect(cNodeRunCount).toEqual(0);
+      expect(dNodeRunCount).toEqual(1);
 
-    expect(rootA.textContent).toEqual('SELECTOR A');
-    expect(rootB.textContent).toEqual('SELECTOR A');
+      setValue(aNode, false);
+      dNodeValue = getValue(dNode);
+      expect(dNodeValue).toEqual('0');
+      expect(bNodeRunCount).toEqual(1);
+      expect(cNodeRunCount).toEqual(1);
+      expect(dNodeRunCount).toEqual(2);
+    },
+  );
 
-    act(() => setRootASelector(true)); // cause rootA to read the selector
-    expect(rootA.textContent).toEqual('loading');
-    expect(rootB.textContent).toEqual('SELECTOR A');
+  testRecoil(
+    'selector does not re-run to completion when one of its async deps resolves to a previously cached value',
+    async () => {
+      const testSnapshot = freshSnapshot();
+      testSnapshot.retain();
 
-    act(() => setRootBSelector(true)); // cause rootB to read the selector
-    expect(rootA.textContent).toEqual('loading');
-    expect(rootB.textContent).toEqual('loading');
+      const atomA = atom({
+        key: 'atomc-rerun-opt-test',
+        default: -3,
+      });
 
-    act(() => resolve('SELECTOR B'));
+      const selectorB = selector({
+        key: 'selb-rerun-opt-test',
+        get: async ({get}) => {
+          await Promise.resolve();
 
-    await flushPromisesAndTimers();
+          return Math.abs(get(atomA));
+        },
+      });
 
-    expect(rootA.textContent).toEqual('SELECTOR B');
-    expect(rootB.textContent).toEqual('SELECTOR B');
-  });
+      let numTimesCStartedToRun = 0;
+      let numTimesCRanToCompletion = 0;
+
+      const selectorC = selector({
+        key: 'sela-rerun-opt-test',
+        get: ({get}) => {
+          numTimesCStartedToRun++;
+
+          const ret = get(selectorB);
+
+          /**
+           * The placement of numTimesCRan is important as this optimization
+           * prevents the execution of selectorC _after_ the point where the
+           * selector execution hits a known path of dependencies. In other words,
+           * the lines prior to the get(selectorB) will run twice, but the lines
+           * following get(selectorB) should only run once given that we are
+           * setting up this test so that selectorB resolves to a previously seen
+           * value the second time that it runs.
+           */
+          numTimesCRanToCompletion++;
+
+          return ret;
+        },
+      });
+
+      testSnapshot.getLoadable(selectorC);
+
+      /**
+       * Run selector chain so that selectorC is cached with a dep of selectorB
+       * set to "3"
+       */
+      await flushPromisesAndTimers();
+
+      const loadableA = testSnapshot.getLoadable(selectorC);
+
+      expect(loadableA.contents).toBe(3);
+      expect(numTimesCRanToCompletion).toBe(1);
+
+      /**
+       * It's expected that C started to run twice so far (the first is the first
+       * time that the selector was called and suspended, the second was when B
+       * resolved and C re-ran because of the async dep resolution)
+       */
+      expect(numTimesCStartedToRun).toBe(2);
+
+      const mappedSnapshot = testSnapshot.map(({set}) => {
+        set(atomA, 3);
+      });
+
+      mappedSnapshot.getLoadable(selectorC);
+
+      /**
+       * Run selector chain so that selectorB recalculates as a result of atomA
+       * being changed to "3"
+       */
+      mappedSnapshot.retain();
+      await flushPromisesAndTimers();
+
+      const loadableB = mappedSnapshot.getLoadable(selectorC);
+
+      expect(loadableB.contents).toBe(3);
+
+      /**
+       * If selectors are correctly optimized, selectorC will not re-run because
+       * selectorB resolved to "3", which is a value that selectorC has previously
+       * cached for its selectorB dependency.
+       */
+      expect(numTimesCRanToCompletion).toBe(1);
+
+      /**
+       * TODO:
+       * in the ideal case this should be:
+       *
+       * expect(numTimesCStartedToRun).toBe(2);
+       */
+      expect(numTimesCStartedToRun).toBe(3);
+    },
+  );
+
+  testRecoil(
+    'async dep that changes from loading to value triggers re-execution',
+    async () => {
+      const baseAtom = atom({
+        key: 'baseAtom',
+        default: 0,
+      });
+
+      const asyncSel = selector({
+        key: 'asyncSel',
+        get: ({get}) => {
+          const atomVal = get(baseAtom);
+
+          if (atomVal === 0) {
+            return new Promise(() => {});
+          }
+
+          return atomVal;
+        },
+      });
+
+      const selWithAsyncDep = selector({
+        key: 'selWithAsyncDep',
+        get: ({get}) => {
+          return get(asyncSel);
+        },
+      });
+
+      const snapshot = freshSnapshot();
+      snapshot.retain();
+
+      const loadingValLoadable = snapshot.getLoadable(selWithAsyncDep);
+
+      expect(loadingValLoadable.state).toBe('loading');
+
+      const mappedSnapshot = snapshot.map(({set}) => {
+        set(baseAtom, 10);
+      });
+
+      const newAtomVal = mappedSnapshot.getLoadable(baseAtom);
+
+      expect(newAtomVal.valueMaybe()).toBe(10);
+
+      const valLoadable = mappedSnapshot.getLoadable(selWithAsyncDep);
+
+      expect(valLoadable.valueMaybe()).toBe(10);
+    },
+  );
 });
-
-testRecoil(
-  'selector - kite pattern runs only necessary selectors',
-  async () => {
-    const aNode = atom({
-      key: 'aNode',
-      default: true,
-    });
-
-    let bNodeRunCount = 0;
-    const bNode = selector({
-      key: 'bNode',
-      get: ({get}) => {
-        bNodeRunCount++;
-        const a = get(aNode);
-        return String(a);
-      },
-    });
-
-    let cNodeRunCount = 0;
-    const cNode = selector({
-      key: 'cNode',
-      get: ({get}) => {
-        cNodeRunCount++;
-        const a = get(aNode);
-        return String(Number(a));
-      },
-    });
-
-    let dNodeRunCount = 0;
-    const dNode = selector({
-      key: 'dNode',
-      get: ({get}) => {
-        dNodeRunCount++;
-        const value = get(aNode) ? get(bNode) : get(cNode);
-        return value.toUpperCase();
-      },
-    });
-
-    let dNodeValue = getValue(dNode);
-    expect(dNodeValue).toEqual('TRUE');
-    expect(bNodeRunCount).toEqual(1);
-    expect(cNodeRunCount).toEqual(0);
-    expect(dNodeRunCount).toEqual(1);
-
-    setValue(aNode, false);
-    dNodeValue = getValue(dNode);
-    expect(dNodeValue).toEqual('0');
-    expect(bNodeRunCount).toEqual(1);
-    expect(cNodeRunCount).toEqual(1);
-    expect(dNodeRunCount).toEqual(2);
-  },
-);
 
 testRecoil('async set not supported', async () => {
   const myAtom = atom({
@@ -1262,129 +546,131 @@ testRecoil('async set not supported', async () => {
   await expect(resetAttempt).rejects.toThrowError();
 });
 
-testRecoil(
-  'selectors with user-thrown loadable promises execute to completion as expected',
-  async () => {
-    const [asyncDep, resolveAsyncDep] = asyncSelector<string, void>();
+describe('User-thrown promises', () => {
+  testRecoil(
+    'selectors with user-thrown loadable promises execute to completion as expected',
+    async () => {
+      const [asyncDep, resolveAsyncDep] = asyncSelector<string, void>();
 
-    const selWithUserThrownPromise = selector({
-      key: 'selWithUserThrownPromise',
-      get: ({get}) => {
-        const loadable = get(noWait(asyncDep));
+      const selWithUserThrownPromise = selector({
+        key: 'selWithUserThrownPromise',
+        get: ({get}) => {
+          const loadable = get(noWait(asyncDep));
 
-        if (loadable.state === 'loading') {
-          throw loadable.toPromise();
-        }
+          if (loadable.state === 'loading') {
+            throw loadable.toPromise();
+          }
 
-        return loadable.valueOrThrow();
-      },
-    });
+          return loadable.valueOrThrow();
+        },
+      });
 
-    const loadable = getLoadable(selWithUserThrownPromise);
-    const promise = loadable.toPromise();
+      const loadable = getLoadable(selWithUserThrownPromise);
+      const promise = loadable.toPromise();
 
-    expect(loadable.state).toBe('loading');
+      expect(loadable.state).toBe('loading');
 
-    resolveAsyncDep('RESOLVED');
+      resolveAsyncDep('RESOLVED');
 
-    await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
 
-    const val: mixed = await promise;
+      const val: mixed = await promise;
 
-    expect(val).toBe('RESOLVED');
-  },
-);
+      expect(val).toBe('RESOLVED');
+    },
+  );
 
-testRecoil(
-  'selectors with user-thrown loadable promises execute to completion as expected',
-  async () => {
-    const myAtomA = atom({
-      key: 'myatoma selectors user-thrown promise',
-      default: 'A',
-    });
+  testRecoil(
+    'selectors with user-thrown loadable promises execute to completion as expected',
+    async () => {
+      const myAtomA = atom({
+        key: 'myatoma selectors user-thrown promise',
+        default: 'A',
+      });
 
-    const myAtomB = atom({
-      key: 'myatomb selectors user-thrown promise',
-      default: 'B',
-    });
+      const myAtomB = atom({
+        key: 'myatomb selectors user-thrown promise',
+        default: 'B',
+      });
 
-    let isResolved = false;
-    let resolve = () => {};
+      let isResolved = false;
+      let resolve = () => {};
 
-    const myPromise = new Promise(localResolve => {
-      resolve = () => {
-        isResolved = true;
-        localResolve();
-      };
-    });
+      const myPromise = new Promise(localResolve => {
+        resolve = () => {
+          isResolved = true;
+          localResolve();
+        };
+      });
 
-    const selWithUserThrownPromise = selector({
-      key: 'selWithUserThrownPromise',
-      get: ({get}) => {
-        const a = get(myAtomA);
+      const selWithUserThrownPromise = selector({
+        key: 'selWithUserThrownPromise',
+        get: ({get}) => {
+          const a = get(myAtomA);
 
-        if (!isResolved) {
-          throw myPromise;
-        }
+          if (!isResolved) {
+            throw myPromise;
+          }
 
-        const b = get(myAtomB);
+          const b = get(myAtomB);
 
-        return `${a}${b}`;
-      },
-    });
+          return `${a}${b}`;
+        },
+      });
 
-    const loadable = getLoadable(selWithUserThrownPromise);
-    const promise = loadable.toPromise();
+      const loadable = getLoadable(selWithUserThrownPromise);
+      const promise = loadable.toPromise();
 
-    expect(loadable.state).toBe('loading');
+      expect(loadable.state).toBe('loading');
 
-    resolve();
+      resolve();
 
-    await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
 
-    const val: mixed = await promise;
+      const val: mixed = await promise;
 
-    expect(val).toBe('AB');
-  },
-);
+      expect(val).toBe('AB');
+    },
+  );
 
-testRecoil(
-  'selectors with nested user-thrown loadable promises execute to completion as expected',
-  async () => {
-    const [asyncDep, resolveAsyncDep] = asyncSelector<string, void>();
+  testRecoil(
+    'selectors with nested user-thrown loadable promises execute to completion as expected',
+    async () => {
+      const [asyncDep, resolveAsyncDep] = asyncSelector<string, void>();
 
-    const selWithUserThrownPromise = selector({
-      key: 'selWithUserThrownPromise',
-      get: ({get}) => {
-        const loadable = get(noWait(asyncDep));
+      const selWithUserThrownPromise = selector({
+        key: 'selWithUserThrownPromise',
+        get: ({get}) => {
+          const loadable = get(noWait(asyncDep));
 
-        if (loadable.state === 'loading') {
-          throw loadable.toPromise();
-        }
+          if (loadable.state === 'loading') {
+            throw loadable.toPromise();
+          }
 
-        return loadable.valueOrThrow();
-      },
-    });
+          return loadable.valueOrThrow();
+        },
+      });
 
-    const selThatDependsOnSelWithUserThrownPromise = selector({
-      key: 'selThatDependsOnSelWithUserThrownPromise',
-      get: ({get}) => get(selWithUserThrownPromise),
-    });
+      const selThatDependsOnSelWithUserThrownPromise = selector({
+        key: 'selThatDependsOnSelWithUserThrownPromise',
+        get: ({get}) => get(selWithUserThrownPromise),
+      });
 
-    const loadable = getLoadable(selThatDependsOnSelWithUserThrownPromise);
-    const promise = loadable.toPromise();
+      const loadable = getLoadable(selThatDependsOnSelWithUserThrownPromise);
+      const promise = loadable.toPromise();
 
-    expect(loadable.state).toBe('loading');
+      expect(loadable.state).toBe('loading');
 
-    resolveAsyncDep('RESOLVED');
+      resolveAsyncDep('RESOLVED');
 
-    await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
 
-    const val: mixed = await promise;
+      const val: mixed = await promise;
 
-    expect(val).toBe('RESOLVED');
-  },
-);
+      expect(val).toBe('RESOLVED');
+    },
+  );
+});
 
 testRecoil('selectors cannot mutate values in get() or set()', () => {
   const devStatus = window.__DEV__;
@@ -1442,154 +728,6 @@ testRecoil('selectors cannot mutate values in get() or set()', () => {
 
   window.__DEV__ = devStatus;
 });
-
-testRecoil(
-  'selector does not re-run to completion when one of its async deps resolves to a previously cached value',
-  async () => {
-    const testSnapshot = freshSnapshot();
-    testSnapshot.retain();
-
-    const atomA = atom({
-      key: 'atomc-rerun-opt-test',
-      default: -3,
-    });
-
-    const selectorB = selector({
-      key: 'selb-rerun-opt-test',
-      get: async ({get}) => {
-        await Promise.resolve();
-
-        return Math.abs(get(atomA));
-      },
-    });
-
-    let numTimesCStartedToRun = 0;
-    let numTimesCRanToCompletion = 0;
-
-    const selectorC = selector({
-      key: 'sela-rerun-opt-test',
-      get: ({get}) => {
-        numTimesCStartedToRun++;
-
-        const ret = get(selectorB);
-
-        /**
-         * The placement of numTimesCRan is important as this optimization
-         * prevents the execution of selectorC _after_ the point where the
-         * selector execution hits a known path of dependencies. In other words,
-         * the lines prior to the get(selectorB) will run twice, but the lines
-         * following get(selectorB) should only run once given that we are
-         * setting up this test so that selectorB resolves to a previously seen
-         * value the second time that it runs.
-         */
-        numTimesCRanToCompletion++;
-
-        return ret;
-      },
-    });
-
-    testSnapshot.getLoadable(selectorC);
-
-    /**
-     * Run selector chain so that selectorC is cached with a dep of selectorB
-     * set to "3"
-     */
-    await flushPromisesAndTimers();
-
-    const loadableA = testSnapshot.getLoadable(selectorC);
-
-    expect(loadableA.contents).toBe(3);
-    expect(numTimesCRanToCompletion).toBe(1);
-
-    /**
-     * It's expected that C started to run twice so far (the first is the first
-     * time that the selector was called and suspended, the second was when B
-     * resolved and C re-ran because of the async dep resolution)
-     */
-    expect(numTimesCStartedToRun).toBe(2);
-
-    const mappedSnapshot = testSnapshot.map(({set}) => {
-      set(atomA, 3);
-    });
-
-    mappedSnapshot.getLoadable(selectorC);
-
-    /**
-     * Run selector chain so that selectorB recalculates as a result of atomA
-     * being changed to "3"
-     */
-    mappedSnapshot.retain();
-    await flushPromisesAndTimers();
-
-    const loadableB = mappedSnapshot.getLoadable(selectorC);
-
-    expect(loadableB.contents).toBe(3);
-
-    /**
-     * If selectors are correctly optimized, selectorC will not re-run because
-     * selectorB resolved to "3", which is a value that selectorC has previously
-     * cached for its selectorB dependency.
-     */
-    expect(numTimesCRanToCompletion).toBe(1);
-
-    /**
-     * TODO:
-     * in the ideal case this should be:
-     *
-     * expect(numTimesCStartedToRun).toBe(2);
-     */
-    expect(numTimesCStartedToRun).toBe(3);
-  },
-);
-
-testRecoil(
-  'async dep that changes from loading to value triggers re-execution',
-  async () => {
-    const baseAtom = atom({
-      key: 'baseAtom',
-      default: 0,
-    });
-
-    const asyncSel = selector({
-      key: 'asyncSel',
-      get: ({get}) => {
-        const atomVal = get(baseAtom);
-
-        if (atomVal === 0) {
-          return new Promise(() => {});
-        }
-
-        return atomVal;
-      },
-    });
-
-    const selWithAsyncDep = selector({
-      key: 'selWithAsyncDep',
-      get: ({get}) => {
-        return get(asyncSel);
-      },
-    });
-
-    const snapshot = freshSnapshot();
-    snapshot.retain();
-
-    const loadingValLoadable = snapshot.getLoadable(selWithAsyncDep);
-
-    expect(loadingValLoadable.state).toBe('loading');
-
-    const mappedSnapshot = snapshot.map(({set}) => {
-      set(baseAtom, 10);
-    });
-
-    const newAtomVal = mappedSnapshot.getLoadable(baseAtom);
-
-    expect(newAtomVal.valueMaybe()).toBe(10);
-
-    const valLoadable = mappedSnapshot.getLoadable(selWithAsyncDep);
-
-    expect(valLoadable.valueMaybe()).toBe(10);
-  },
-);
 
 describe('getCallback', () => {
   testRecoil('Selector getCallback', async () => {
@@ -1791,35 +929,6 @@ describe('getCallback', () => {
     ).resolves.toEqual(123);
   });
 });
-
-testRecoil(
-  "Releasing snapshot doesn't invalidate pending selector",
-  async () => {
-    const [mySelector, resolveSelector] = asyncSelector();
-
-    // Initialize selector with snapshot first so it is initialized for both
-    // snapshot and root and has separate cleanup handlers for both.
-    function Component() {
-      const callback = useRecoilCallback(({snapshot}) => () => {
-        snapshot.getLoadable(mySelector);
-      });
-      callback(); // First initialize with snapshot
-      return useRecoilValue(mySelector); // Second initialize with RecoilRoot
-    }
-
-    const c = renderElements(<Component />);
-
-    // Wait to allow the snapshot in the callback to release and call the
-    // selector node cleanup functions.
-    await flushPromisesAndTimers();
-
-    expect(c.textContent).toBe('loading');
-
-    act(() => resolveSelector('RESOLVE'));
-    await flushPromisesAndTimers();
-    expect(c.textContent).toBe('RESOLVE');
-  },
-);
 
 testRecoil('Selector values are frozen', async () => {
   const devStatus = window.__DEV__;

--- a/packages/recoil/recoil_values/__tests__/Recoil_selectorHooks-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selectorHooks-test.js
@@ -1,0 +1,1850 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+/* eslint-disable fb-www/react-no-useless-fragment */
+'use strict';
+
+import type {
+  RecoilState,
+  RecoilValue,
+  RecoilValueReadOnly,
+} from '../../core/Recoil_RecoilValue';
+import type {PersistenceSettings} from '../../recoil_values/Recoil_atom';
+
+const {
+  getRecoilTestFn,
+} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
+
+let React,
+  useEffect,
+  useState,
+  Profiler,
+  act,
+  batchUpdates,
+  atom,
+  constSelector,
+  errorSelector,
+  selector,
+  ReadsAtom,
+  asyncSelector,
+  loadingAsyncSelector,
+  resolvingAsyncSelector,
+  errorThrowingAsyncSelector,
+  flushPromisesAndTimers,
+  renderElements,
+  renderElementsWithSuspenseCount,
+  useRecoilState,
+  useRecoilValue,
+  useRecoilValueLoadable,
+  useSetRecoilState,
+  useResetRecoilState,
+  useRecoilCallback,
+  reactMode,
+  invariant,
+  nullthrows;
+
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({useEffect, useState, Profiler} = require('react'));
+  ({act} = require('ReactTestUtils'));
+
+  ({batchUpdates} = require('../../core/Recoil_Batching'));
+  atom = require('../../recoil_values/Recoil_atom');
+  constSelector = require('../../recoil_values/Recoil_constSelector');
+  errorSelector = require('../../recoil_values/Recoil_errorSelector');
+  selector = require('../../recoil_values/Recoil_selector');
+  ({
+    ReadsAtom,
+    asyncSelector,
+    loadingAsyncSelector,
+    resolvingAsyncSelector,
+    errorThrowingAsyncSelector,
+    flushPromisesAndTimers,
+    renderElements,
+    renderElementsWithSuspenseCount,
+  } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
+  ({reactMode} = require('../../core/Recoil_ReactMode'));
+  ({
+    useRecoilState,
+    useRecoilValue,
+    useRecoilValueLoadable,
+    useSetRecoilState,
+    useResetRecoilState,
+  } = require('../../hooks/Recoil_Hooks'));
+  ({useRecoilCallback} = require('../../hooks/Recoil_useRecoilCallback'));
+
+  invariant = require('recoil-shared/util/Recoil_invariant');
+  nullthrows = require('recoil-shared/util/Recoil_nullthrows');
+});
+
+let nextID = 0;
+
+function counterAtom(persistence?: PersistenceSettings<number>) {
+  return atom({
+    key: `atom${nextID++}`,
+    default: 0,
+    persistence_UNSTABLE: persistence,
+  });
+}
+
+function booleanAtom(persistence?: PersistenceSettings<boolean>) {
+  return atom<boolean>({
+    key: `atom${nextID++}`,
+    default: false,
+    persistence_UNSTABLE: persistence,
+  });
+}
+
+function plusOneSelector(dep: RecoilValue<number>) {
+  const fn = jest.fn(x => x + 1);
+  const sel = selector({
+    key: `selector${nextID++}`,
+    get: ({get}) => fn(get(dep)),
+  });
+  return [sel, fn];
+}
+
+function plusOneAsyncSelector(
+  dep: RecoilValue<number>,
+): [RecoilValueReadOnly<number>, (number) => void] {
+  let nextTimeoutAmount = 100;
+  const fn = jest.fn(x => {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve(x + 1);
+      }, nextTimeoutAmount);
+    });
+  });
+  const sel = selector({
+    key: `selector${nextID++}`,
+    get: ({get}) => fn(get(dep)),
+  });
+  return [
+    sel,
+    x => {
+      nextTimeoutAmount = x;
+    },
+  ];
+}
+
+function additionSelector(
+  depA: RecoilValue<number>,
+  depB: RecoilValue<number>,
+) {
+  const fn = jest.fn((a, b) => a + b);
+  const sel = selector({
+    key: `selector${nextID++}`,
+    get: ({get}) => fn(get(depA), get(depB)),
+  });
+  return [sel, fn];
+}
+
+// flowlint-next-line unclear-type:off
+function asyncSelectorThatPushesPromisesOntoArray(dep: RecoilValue<any>) {
+  const promises = [];
+  const sel = selector({
+    key: `selector${nextID++}`,
+    get: ({get}) => {
+      get(dep);
+      let resolve = _ => invariant(false, 'bug in test code'); // make flow happy with initialization
+      let reject = _ => invariant(false, 'bug in test code');
+      const p = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      promises.push([resolve, reject]);
+      return p;
+    },
+  });
+  return [sel, promises];
+}
+
+function componentThatWritesAtom<T>(
+  recoilState: RecoilState<T>,
+  // flowlint-next-line unclear-type:off
+): [any, ((T => T) | T) => void] {
+  let updateValue;
+  const Component = jest.fn(() => {
+    updateValue = useSetRecoilState(recoilState);
+    return null;
+  });
+  // flowlint-next-line unclear-type:off
+  return [(Component: any), x => updateValue(x)];
+}
+
+function componentThatReadsAtomWithCommitCount(recoilState) {
+  const commit = jest.fn(() => {});
+  function ReadAtom() {
+    return (
+      <Profiler id="test" onRender={commit}>
+        {useRecoilValue(recoilState)}
+      </Profiler>
+    );
+  }
+  return [ReadAtom, commit];
+}
+
+function componentThatToggles(a, b) {
+  const toggle = {current: () => invariant(false, 'bug in test code')};
+  const Toggle = () => {
+    const [value, setValue] = useState(false);
+    toggle.current = () => setValue(v => !v);
+    return value ? b : a;
+  };
+  return [Toggle, toggle];
+}
+
+function advanceTimersBy(ms) {
+  // Jest does the right thing for runAllTimers but not advanceTimersByTime:
+  act(() => {
+    jest.runAllTicks();
+    jest.runAllImmediates();
+    jest.advanceTimersByTime(ms);
+    jest.runAllImmediates(); // order seems backwards but matches jest.runAllTimers().
+    jest.runAllTicks();
+  });
+}
+
+function baseRenderCount(gks): number {
+  return reactMode().mode === 'LEGACY' &&
+    !gks.includes('recoil_suppress_rerender_in_callback')
+    ? 1
+    : 0;
+}
+
+testRecoil('static selector', () => {
+  const staticSel = constSelector('HELLO');
+  const c = renderElements(<ReadsAtom atom={staticSel} />);
+  expect(c.textContent).toEqual('"HELLO"');
+});
+
+describe('Updates', () => {
+  testRecoil('Selectors are updated when upstream atoms change', () => {
+    const anAtom = counterAtom();
+    const [aSelector, _] = plusOneSelector(anAtom);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={aSelector} />
+      </>,
+    );
+    expect(container.textContent).toEqual('1');
+    act(() => updateValue(1));
+    expect(container.textContent).toEqual('2');
+  });
+
+  testRecoil('Selectors can depend on other selectors', () => {
+    const anAtom = counterAtom();
+    const [selectorA, _] = plusOneSelector(anAtom);
+    const [selectorB, __] = plusOneSelector(selectorA);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={selectorB} />
+      </>,
+    );
+    expect(container.textContent).toEqual('2');
+    act(() => updateValue(1));
+    expect(container.textContent).toEqual('3');
+  });
+
+  testRecoil('Selectors can depend on async selectors', async () => {
+    jest.useFakeTimers();
+    const anAtom = counterAtom();
+    const [selectorA, _] = plusOneAsyncSelector(anAtom);
+    const [selectorB, __] = plusOneSelector(selectorA);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={selectorB} />
+      </>,
+    );
+    expect(container.textContent).toEqual('loading');
+
+    act(() => jest.runAllTimers());
+    await flushPromisesAndTimers();
+    expect(container.textContent).toEqual('2');
+
+    act(() => updateValue(1));
+
+    expect(container.textContent).toEqual('loading');
+
+    act(() => jest.runAllTimers());
+    await flushPromisesAndTimers();
+    expect(container.textContent).toEqual('3');
+  });
+
+  testRecoil('Async selectors can depend on async selectors', async () => {
+    jest.useFakeTimers();
+    const anAtom = counterAtom();
+    const [selectorA, _] = plusOneAsyncSelector(anAtom);
+    const [selectorB, __] = plusOneAsyncSelector(selectorA);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={selectorB} />
+      </>,
+    );
+
+    if (reactMode().mode !== 'LEGACY') {
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('2');
+
+      act(() => updateValue(1));
+      expect(container.textContent).toEqual('loading');
+
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('3');
+    } else {
+      // we need to test the useRecoilValueLoadable_LEGACY method
+
+      expect(container.textContent).toEqual('loading');
+
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('2');
+
+      act(() => updateValue(1));
+      expect(container.textContent).toEqual('loading');
+
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('3');
+    }
+  });
+
+  testRecoil('Dep of upstream selector can change while pending', async () => {
+    const anAtom = counterAtom();
+    const [upstreamSel, upstreamResolvers] =
+      asyncSelectorThatPushesPromisesOntoArray(anAtom);
+    const [downstreamSel, downstreamResolvers] =
+      asyncSelectorThatPushesPromisesOntoArray(upstreamSel);
+
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={downstreamSel} />
+      </>,
+    );
+
+    // Initially, upstream has returned a promise so there is one upstream resolver.
+    // Downstream is waiting on upstream so it hasn't returned anything yet.
+    expect(container.textContent).toEqual('loading');
+    expect(upstreamResolvers.length).toEqual(1);
+    expect(downstreamResolvers.length).toEqual(0);
+
+    // Resolve upstream; downstream should now have returned a new promise:
+    upstreamResolvers[0][0](123);
+    await flushPromisesAndTimers();
+    expect(downstreamResolvers.length).toEqual(1);
+
+    // Update atom to a new value while downstream is pending:
+    act(() => updateValue(1));
+    await flushPromisesAndTimers();
+
+    // Upstream returns a new promise for the new atom value.
+    // Downstream is once again waiting on upstream so it hasn't returned a new
+    // promise for the new value.
+    expect(upstreamResolvers.length).toEqual(2);
+    expect(downstreamResolvers.length).toEqual(1);
+
+    // Resolve the new upstream promise:
+    upstreamResolvers[1][0](123);
+    await flushPromisesAndTimers();
+
+    // Downstream can now return its new promise:
+    expect(downstreamResolvers.length).toEqual(2);
+
+    // If we resolve downstream's new promise we should see the result:
+    downstreamResolvers[1][0](123);
+    await flushPromisesAndTimers();
+    expect(container.textContent).toEqual('123');
+  });
+
+  testRecoil('Errors are propogated through selectors', () => {
+    const errorThrower = errorSelector('ERROR');
+    const [downstreamSelector] = plusOneSelector(errorThrower);
+    const container = renderElements(
+      <>
+        <ReadsAtom atom={downstreamSelector} />
+      </>,
+    );
+    expect(container.textContent).toEqual('error');
+  });
+
+  testRecoil(
+    'Rejected promises are propogated through selectors (immediate rejection)',
+    async () => {
+      const anAtom = counterAtom();
+      const errorThrower = errorThrowingAsyncSelector('ERROR', anAtom);
+      const [downstreamSelector] = plusOneAsyncSelector(errorThrower);
+      const container = renderElements(
+        <>
+          <ReadsAtom atom={downstreamSelector} />
+        </>,
+      );
+      expect(container.textContent).toEqual('loading');
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('error');
+    },
+  );
+
+  testRecoil(
+    'Rejected promises are propogated through selectors (later rejection)',
+    async () => {
+      const anAtom = counterAtom();
+      const [errorThrower, _resolve, reject] = asyncSelector(anAtom);
+      const [downstreamSelector] = plusOneAsyncSelector(errorThrower);
+      const container = renderElements(
+        <>
+          <ReadsAtom atom={downstreamSelector} />
+        </>,
+      );
+      expect(container.textContent).toEqual('loading');
+      act(() => reject(new Error()));
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('error');
+    },
+  );
+});
+
+testRecoil('Selectors can be invertible', () => {
+  const anAtom = counterAtom();
+  const aSelector = selector({
+    key: 'invertible1',
+    get: ({get}) => get(anAtom),
+    set: ({set}, newValue) => set(anAtom, newValue),
+  });
+
+  const [Component, updateValue] = componentThatWritesAtom(aSelector);
+  const container = renderElements(
+    <>
+      <Component />
+      <ReadsAtom atom={anAtom} />
+    </>,
+  );
+
+  expect(container.textContent).toEqual('0');
+  act(() => updateValue(1));
+  expect(container.textContent).toEqual('1');
+});
+
+describe('Dynamic Dependencies', () => {
+  testRecoil('Selector dependencies can change over time', () => {
+    const atomA = counterAtom();
+    const atomB = counterAtom();
+    const aSelector = selector({
+      key: 'depsChange',
+      get: ({get}) => {
+        const a = get(atomA);
+        if (a === 1337) {
+          const b = get(atomB);
+          return b;
+        } else {
+          return a;
+        }
+      },
+    });
+
+    const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
+    const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
+
+    const container = renderElements(
+      <>
+        <ComponentA />
+        <ComponentB />
+        <ReadsAtom atom={aSelector} />
+      </>,
+    );
+
+    expect(container.textContent).toEqual('0');
+    act(() => updateValueA(1337));
+    expect(container.textContent).toEqual('0');
+    act(() => updateValueB(1));
+
+    expect(container.textContent).toEqual('1');
+    act(() => updateValueA(2));
+    expect(container.textContent).toEqual('2');
+  });
+
+  testRecoil('Selectors can gain and lose depnedencies', ({gks}) => {
+    const BASE_CALLS = baseRenderCount(gks);
+
+    const switchAtom = booleanAtom();
+    const inputAtom = counterAtom();
+
+    // Depends on inputAtom only when switchAtom is true:
+    const aSelector = selector<number>({
+      key: 'gainsDeps',
+      get: ({get}) => {
+        if (get(switchAtom)) {
+          return get(inputAtom);
+        } else {
+          return Infinity;
+        }
+      },
+    });
+
+    const [ComponentA, setSwitch] = componentThatWritesAtom(switchAtom);
+    const [ComponentB, setInput] = componentThatWritesAtom(inputAtom);
+    const [ComponentC, commit] =
+      componentThatReadsAtomWithCommitCount(aSelector);
+    const container = renderElements(
+      <>
+        <ComponentA />
+        <ComponentB />
+        <ComponentC />
+      </>,
+    );
+
+    expect(container.textContent).toEqual('Infinity');
+    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+
+    // Input is not a dep yet, so this has no effect:
+    act(() => setInput(1));
+    expect(container.textContent).toEqual('Infinity');
+    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+
+    // Flip switch:
+    act(() => setSwitch(true));
+    expect(container.textContent).toEqual('1');
+    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
+
+    // Now changing input causes a re-render:
+    act(() => setInput(2));
+    expect(container.textContent).toEqual('2');
+    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 3);
+
+    // Now that we've added the dep, we can remove it...
+    act(() => setSwitch(false));
+    expect(container.textContent).toEqual('Infinity');
+    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 4);
+
+    // ... and again changing input will not cause a re-render:
+    act(() => setInput(3));
+    expect(container.textContent).toEqual('Infinity');
+    expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 4);
+  });
+
+  testRecoil('Selector depedencies are updated transactionally', () => {
+    const atomA = counterAtom();
+    const atomB = counterAtom();
+    const atomC = counterAtom();
+
+    const [observedSelector, selectorFn] = plusOneSelector(atomC);
+
+    const aSelector = selector({
+      key: 'transactionally',
+      get: ({get}) => {
+        const a = get(atomA);
+        const b = get(atomB);
+        return a !== 0 && b === 0
+          ? get(observedSelector) // We want to test this never happens
+          : null;
+      },
+    });
+
+    const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
+    const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
+    const [ComponentC, updateValueC] = componentThatWritesAtom(atomC);
+    renderElements(
+      <>
+        <ComponentA />
+        <ComponentB />
+        <ComponentC />
+        <ReadsAtom atom={aSelector} />
+      </>,
+    );
+
+    act(() => {
+      batchUpdates(() => {
+        updateValueA(1);
+        updateValueB(1);
+      });
+    });
+
+    // observedSelector wasn't evaluated:
+    expect(selectorFn).toHaveBeenCalledTimes(0);
+
+    // nor were any subscriptions created for it:
+    act(() => {
+      updateValueC(1);
+    });
+    expect(selectorFn).toHaveBeenCalledTimes(0);
+  });
+
+  testRecoil(
+    'selector is able to track dependencies discovered asynchronously',
+    async () => {
+      const anAtom = atom({
+        key: 'atomTrackedAsync',
+        default: 'Async Dep Value',
+      });
+
+      const selectorWithAsyncDeps = selector({
+        key: 'selectorTrackDepsIncrementally',
+        get: async ({get}) => {
+          await Promise.resolve(); // needed to simulate discovering a dependency asynchronously
+
+          return get(anAtom);
+        },
+      });
+
+      let setAtom;
+
+      function Component() {
+        [, setAtom] = useRecoilState(anAtom);
+        const selVal = useRecoilValue(selectorWithAsyncDeps);
+
+        return selVal;
+      }
+
+      const container = renderElements(<Component />);
+
+      expect(container.textContent).toEqual('loading');
+
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers(); // HACK: not sure why but this is needed in OSS
+      expect(container.textContent).toEqual('Async Dep Value');
+
+      act(() => setAtom('CHANGED Async Dep'));
+      expect(container.textContent).toEqual('loading');
+
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('CHANGED Async Dep');
+    },
+  );
+
+  /**
+   * This test is an extension of the 'selector is able to track dependencies
+   * discovered asynchronously' test: in addition to testing that a selector
+   * responds to changes in dependencies that were discovered asynchronously, the
+   * selector should run through the entire selector in response to those changes.
+   */
+  testRecoil(
+    'selector should rerun entire selector when a dep changes',
+    async () => {
+      const resolvingSel1 = resolvingAsyncSelector(1);
+      const resolvingSel2 = resolvingAsyncSelector(2);
+      const anAtom3 = atom({key: 'atomTrackedAsync3', default: 3});
+
+      const selectorWithAsyncDeps = selector({
+        key: 'selectorNotCacheIncDeps',
+        get: async ({get}) => {
+          const val1 = get(resolvingSel1);
+
+          await Promise.resolve();
+
+          const val2 = get(resolvingSel2);
+
+          await Promise.resolve();
+
+          const val3 = get(anAtom3);
+
+          return val1 + val2 + val3;
+        },
+      });
+
+      let setAtom;
+
+      function Component() {
+        [, setAtom] = useRecoilState(anAtom3);
+        const selVal = useRecoilValue(selectorWithAsyncDeps);
+
+        return selVal;
+      }
+
+      const container = renderElements(<Component />);
+
+      expect(container.textContent).toEqual('loading');
+
+      await flushPromisesAndTimers();
+
+      // HACK: not sure why but these are needed in OSS
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+
+      expect(container.textContent).toEqual('6');
+
+      act(() => setAtom(4));
+
+      expect(container.textContent).toEqual('loading');
+
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+
+      expect(container.textContent).toEqual('7');
+    },
+  );
+
+  testRecoil(
+    'async selector with changing dependencies finishes execution using original state',
+    async () => {
+      const [asyncDep, resolveAsyncDep] = asyncSelector();
+      const anAtom = atom({key: 'atomChangingDeps', default: 3});
+
+      const anAsyncSelector = selector({
+        key: 'selectorWithChangingDeps',
+        get: ({get}) => {
+          const atomValueBefore = get(anAtom);
+
+          get(asyncDep);
+
+          const atomValueAfter = get(anAtom);
+
+          expect(atomValueBefore).toBe(atomValueAfter);
+
+          return atomValueBefore + atomValueAfter;
+        },
+      });
+
+      let loadableSoFar;
+      let setAtom;
+
+      const MyComponent = () => {
+        const setAtomLocal = useSetRecoilState(anAtom);
+        const asyncSelLoadable = useRecoilValueLoadable(anAsyncSelector);
+
+        setAtom = setAtomLocal;
+        loadableSoFar = asyncSelLoadable;
+
+        return asyncSelLoadable.state;
+      };
+
+      renderElements(<MyComponent />);
+
+      const loadableBeforeChangingAnything = nullthrows(loadableSoFar);
+      expect(loadableBeforeChangingAnything.contents).toBeInstanceOf(Promise);
+
+      act(() => setAtom(10));
+
+      const loadableAfterChangingAtom = nullthrows(loadableSoFar);
+      expect(loadableAfterChangingAtom.contents).toBeInstanceOf(Promise);
+      expect(loadableBeforeChangingAnything.contents).not.toBe(
+        loadableAfterChangingAtom.contents,
+      );
+
+      act(() => resolveAsyncDep(''));
+
+      await flushPromisesAndTimers();
+
+      await Promise.all([
+        expect(loadableBeforeChangingAnything.toPromise()).resolves.toBe(3 + 3),
+        expect(loadableAfterChangingAtom.toPromise()).resolves.toBe(10 + 10),
+      ]);
+    },
+  );
+
+  testRecoil(
+    'Selector deps are saved when a component mounts due to a non-recoil change at the same time that a selector is first read',
+    () => {
+      // Regression test for an issue where selector dependencies were not saved
+      // in this circumstance. In this situation dependencies are discovered for
+      // a selector when reading from a non-latest graph. This tests that these deps
+      // are carried forward instead of being forgotten.
+      let show, setShow, setAnotherAtom;
+      function Parent() {
+        [show, setShow] = useState(false);
+        setAnotherAtom = useSetRecoilState(anotherAtom);
+        if (show) {
+          return <SelectorUser />;
+        } else {
+          return null;
+        }
+      }
+
+      const anAtom = atom<number>({key: 'anAtom', default: 0});
+      const anotherAtom = atom<number>({key: 'anotherAtom', default: 0});
+
+      const aSelector = selector({
+        key: 'aSelector',
+        get: ({get}) => {
+          return get(anAtom);
+        },
+      });
+
+      function SelectorUser() {
+        const setter = useSetRecoilState(anAtom);
+        useEffect(() => {
+          setter(1);
+        });
+        return useRecoilValue(aSelector);
+      }
+
+      const c = renderElements(<Parent />);
+
+      expect(c.textContent).toEqual('');
+
+      act(() => {
+        setShow(true);
+        setAnotherAtom(1);
+      });
+
+      expect(c.textContent).toEqual('1');
+    },
+  );
+});
+
+describe('Catching Deps', () => {
+  testRecoil('selector catching exceptions', () => {
+    const throwingSel = errorSelector('MY ERROR');
+    const c1 = renderElements(<ReadsAtom atom={throwingSel} />);
+    expect(c1.textContent).toEqual('error');
+
+    const catchingSelector = selector({
+      key: 'useRecoilState/catching selector',
+      get: ({get}) => {
+        try {
+          return get(throwingSel);
+        } catch (e) {
+          expect(e instanceof Error).toBe(true);
+          expect(e.message).toContain('MY ERROR');
+          return 'CAUGHT';
+        }
+      },
+    });
+    const c2 = renderElements(<ReadsAtom atom={catchingSelector} />);
+    expect(c2.textContent).toEqual('"CAUGHT"');
+  });
+
+  testRecoil('selector catching exceptions (non Errors)', () => {
+    const throwingSel = selector({
+      key: '__error/non Error thrown',
+      get: () => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'MY ERROR';
+      },
+    });
+
+    const c1 = renderElements(<ReadsAtom atom={throwingSel} />);
+    expect(c1.textContent).toEqual('error');
+
+    const catchingSelector = selector({
+      key: 'useRecoilState/catching selector',
+      get: ({get}) => {
+        try {
+          return get(throwingSel);
+        } catch (e) {
+          expect(e).toBe('MY ERROR');
+          return 'CAUGHT';
+        }
+      },
+    });
+
+    const c2 = renderElements(<ReadsAtom atom={catchingSelector} />);
+    expect(c2.textContent).toEqual('"CAUGHT"');
+  });
+
+  testRecoil('selector catching loads', async () => {
+    const resolvingSel = resolvingAsyncSelector('READY');
+    const bypassSelector = selector({
+      key: 'useRecoilState/bypassing selector',
+      get: ({get}) => {
+        try {
+          const value = get(resolvingSel);
+          expect(value).toBe('READY');
+          return value;
+        } catch (promise) {
+          expect(promise instanceof Promise).toBe(true);
+          return 'BYPASS';
+        }
+      },
+    });
+
+    // On first read the dependency is not yet available, but the
+    // selector catches and bypasses it.
+    const c3 = renderElements(<ReadsAtom atom={bypassSelector} />);
+    expect(c3.textContent).toEqual('"BYPASS"');
+
+    // When the dependency does resolve, the selector re-evaluates
+    // with the new data.
+    act(() => jest.runAllTimers());
+    expect(c3.textContent).toEqual('"READY"');
+  });
+
+  testRecoil('selector catching all of 2 loads', async () => {
+    const [resolvingSel1, res1] = asyncSelector();
+    const [resolvingSel2, res2] = asyncSelector();
+
+    const bypassSelector = selector({
+      key: 'useRecoilState/bypassing selector all',
+      get: ({get}) => {
+        let ready = 0;
+        try {
+          const value1 = get(resolvingSel1);
+          expect(value1).toBe('READY1');
+          ready++;
+          const value2 = get(resolvingSel2);
+          expect(value2).toBe('READY2');
+          ready++;
+          return ready;
+        } catch (promise) {
+          expect(promise instanceof Promise).toBe(true);
+          return ready;
+        }
+      },
+    });
+
+    // On first read the dependency is not yet available, but the
+    // selector catches and bypasses it.
+    const c3 = renderElements(<ReadsAtom atom={bypassSelector} />);
+    expect(c3.textContent).toEqual('0');
+
+    // After the first resolution, we're still waiting on the second
+    res1('READY1');
+    act(() => jest.runAllTimers());
+    expect(c3.textContent).toEqual('1');
+
+    // When both are available, we are done!
+    res2('READY2');
+    act(() => jest.runAllTimers());
+    expect(c3.textContent).toEqual('2');
+  });
+
+  testRecoil('selector catching any of 2 loads', async () => {
+    const resolvingSel1 = resolvingAsyncSelector('READY');
+    const resolvingSel2 = resolvingAsyncSelector('READY');
+    const bypassSelector = selector({
+      key: 'useRecoilState/bypassing selector any',
+      get: ({get}) => {
+        let ready = 0;
+        for (const resolvingSel of [resolvingSel1, resolvingSel2]) {
+          try {
+            const value = get(resolvingSel);
+            expect(value).toBe('READY');
+            ready++;
+          } catch (promise) {
+            expect(promise instanceof Promise).toBe(true);
+            ready = ready;
+          }
+        }
+        return ready;
+      },
+    });
+
+    // On first read the dependency is not yet available, but the
+    // selector catches and bypasses it.
+    const c3 = renderElements(<ReadsAtom atom={bypassSelector} />);
+    expect(c3.textContent).toEqual('0');
+
+    // Because both dependencies are tried, they should both resolve
+    // in parallel after one event loop.
+    act(() => jest.runAllTimers());
+    expect(c3.textContent).toEqual('2');
+  });
+
+  // Test the ability to catch a promise for a pending dependency that we can
+  // then handle by returning an async promise.
+  testRecoil(
+    'selector catching promise and resolving asynchronously',
+    async () => {
+      const [originalDep, resolveOriginal] = asyncSelector();
+      const [bypassDep, resolveBypass] = asyncSelector();
+      const catchPromiseSelector = selector({
+        key: 'useRecoilState/catch then async',
+        get: ({get}) => {
+          try {
+            return get(originalDep);
+          } catch (promise) {
+            expect(promise instanceof Promise).toBe(true);
+            return bypassDep;
+          }
+        },
+      });
+      const c = renderElements(<ReadsAtom atom={catchPromiseSelector} />);
+
+      expect(c.textContent).toEqual('loading');
+      act(() => jest.runAllTimers());
+      expect(c.textContent).toEqual('loading');
+      resolveBypass('BYPASS');
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(c.textContent).toEqual('"BYPASS"');
+      resolveOriginal('READY');
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(c.textContent).toEqual('"READY"');
+    },
+  );
+
+  // This tests ability to catch a pending result as a promise and
+  // that the promise resolves to the dependency's value and it is handled
+  // as an asynchronous selector
+  testRecoil('selector catching promise 2', async () => {
+    let dependencyPromiseTest;
+    const resolvingSel = resolvingAsyncSelector('READY');
+    const catchPromiseSelector = selector({
+      key: 'useRecoilState/catch then async 2',
+      get: ({get}) => {
+        try {
+          return get(resolvingSel);
+        } catch (promise) {
+          expect(promise instanceof Promise).toBe(true);
+          // eslint-disable-next-line jest/valid-expect
+          dependencyPromiseTest = expect(promise).resolves.toBe('READY');
+
+          return promise.then(pending => {
+            const result = pending.value;
+            expect(result).toBe('READY');
+            return result.value + ' NOW';
+          });
+        }
+      },
+    });
+    const c = renderElements(<ReadsAtom atom={catchPromiseSelector} />);
+
+    expect(c.textContent).toEqual('loading');
+
+    await flushPromisesAndTimers();
+
+    // NOTE!!!
+    // The output here may be "READY NOW" if we optimize the selector to
+    // cache the result of the async evaluation when the dependency is available
+    // in the cache key with the dependency being available.  Currently it does not
+    // So, when the dependency is ready and the component re-renders it will
+    // re-evaluate.  At that point the dependency is now READY and thus we only
+    // get READY and not READY NOW.
+    // expect(c.textContent).toEqual('"READY NOW"');
+    expect(c.textContent).toEqual('"READY"');
+
+    // Test that the promise for the dependency that we got actually resolved
+    // to the dependency's value.
+    await dependencyPromiseTest;
+  });
+});
+
+describe('Async Selectors', () => {
+  testRecoil('Resolving async selector', async () => {
+    const resolvingSel = resolvingAsyncSelector('READY');
+
+    // On first read it is blocked on the async selector
+    const c1 = renderElements(<ReadsAtom atom={resolvingSel} />);
+    expect(c1.textContent).toEqual('loading');
+
+    // When that resolves the data is ready
+    act(() => jest.runAllTimers());
+    await flushPromisesAndTimers();
+    expect(c1.textContent).toEqual('"READY"');
+  });
+
+  testRecoil('Blocked on dependency', async () => {
+    const resolvingSel = resolvingAsyncSelector('READY');
+    const blockedSelector = selector({
+      key: 'useRecoilState/blocked selector',
+      get: ({get}) => get(resolvingSel),
+    });
+
+    // On first read, the selectors dependency is still loading
+    const c2 = renderElements(<ReadsAtom atom={blockedSelector} />);
+    expect(c2.textContent).toEqual('loading');
+
+    // When the dependency resolves, the data is ready
+    act(() => jest.runAllTimers());
+    await flushPromisesAndTimers();
+    expect(c2.textContent).toEqual('"READY"');
+  });
+
+  testRecoil('Basic async selector test', async () => {
+    jest.useFakeTimers();
+    const anAtom = counterAtom();
+    const [aSelector, _] = plusOneAsyncSelector(anAtom);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={aSelector} />
+      </>,
+    );
+    // Begins in loading state, then shows initial value:
+    expect(container.textContent).toEqual('loading');
+    act(() => jest.runAllTimers());
+    await flushPromisesAndTimers();
+    expect(container.textContent).toEqual('1');
+    // Changing dependency makes it go back to loading, then to show new value:
+    act(() => updateValue(1));
+    expect(container.textContent).toEqual('loading');
+    act(() => jest.runAllTimers());
+    expect(container.textContent).toEqual('2');
+    // Returning to a seen value does not cause the loading state:
+    act(() => updateValue(0));
+    expect(container.textContent).toEqual('1');
+  });
+
+  testRecoil('async dependency', async () => {
+    const sel2 = selector({
+      key: 'MySelector2',
+      get: async () => 'READY',
+    });
+
+    const sel1 = selector({
+      key: 'MySelector',
+      get: async ({get}) => {
+        await Promise.resolve();
+        return get(sel2);
+      },
+    });
+
+    const el = renderElements(<ReadsAtom atom={sel1} />);
+    expect(el.textContent).toEqual('loading');
+
+    await flushPromisesAndTimers();
+    expect(el.textContent).toEqual('"READY"');
+  });
+
+  testRecoil('Ability to not use Suspense', () => {
+    jest.useFakeTimers();
+    const anAtom = counterAtom();
+    const [aSelector, _] = plusOneAsyncSelector(anAtom);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+
+    function ReadsAtomWithoutSuspense({state}) {
+      const loadable = useRecoilValueLoadable(state);
+      if (loadable.state === 'loading') {
+        return 'loading not with suspense';
+      } else if (loadable.state === 'hasValue') {
+        return loadable.contents;
+      } else {
+        throw loadable.contents;
+      }
+    }
+
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtomWithoutSuspense state={aSelector} />
+      </>,
+    );
+    // Begins in loading state, then shows initial value:
+    expect(container.textContent).toEqual('loading not with suspense');
+    act(() => jest.runAllTimers());
+    expect(container.textContent).toEqual('1');
+    // Changing dependency makes it go back to loading, then to show new value:
+    act(() => updateValue(1));
+    expect(container.textContent).toEqual('loading not with suspense');
+    act(() => jest.runAllTimers());
+    expect(container.textContent).toEqual('2');
+    // Returning to a seen value does not cause the loading state:
+    act(() => updateValue(0));
+    expect(container.textContent).toEqual('1');
+  });
+
+  testRecoil(
+    'Ability to not use Suspense - with value instead of loadable',
+    () => {
+      jest.useFakeTimers();
+      const anAtom = counterAtom();
+      const [aSelector, _] = plusOneAsyncSelector(anAtom);
+      const [Component, updateValue] = componentThatWritesAtom(anAtom);
+
+      function ReadsAtomWithoutSuspense({state}) {
+        return (
+          useRecoilValueLoadable(state).valueMaybe() ??
+          'loading not with suspense'
+        );
+      }
+
+      const container = renderElements(
+        <>
+          <Component />
+          <ReadsAtomWithoutSuspense state={aSelector} />
+        </>,
+      );
+      // Begins in loading state, then shows initial value:
+      expect(container.textContent).toEqual('loading not with suspense');
+      act(() => jest.runAllTimers());
+      expect(container.textContent).toEqual('1');
+      // Changing dependency makes it go back to loading, then to show new value:
+      act(() => updateValue(1));
+      expect(container.textContent).toEqual('loading not with suspense');
+      act(() => jest.runAllTimers());
+      expect(container.textContent).toEqual('2');
+      // Returning to a seen value does not cause the loading state:
+      act(() => updateValue(0));
+      expect(container.textContent).toEqual('1');
+    },
+  );
+
+  testRecoil(
+    'Selector can alternate between synchronous and asynchronous',
+    async () => {
+      jest.useFakeTimers();
+      const anAtom = counterAtom();
+      const aSelector = selector({
+        key: 'alternatingSelector',
+        get: ({get}) => {
+          const x = get(anAtom);
+          if (x === 1337) {
+            return new Promise(() => {});
+          }
+          if (x % 2 === 0) {
+            return x;
+          } else {
+            return new Promise(resolve => {
+              setTimeout(() => resolve(x), 100);
+            });
+          }
+        },
+      });
+      const [Component, updateValue] = componentThatWritesAtom(anAtom);
+      const container = renderElements(
+        <>
+          <Component />
+          <ReadsAtom atom={aSelector} />
+        </>,
+      );
+
+      // Transition from sync to async:
+      expect(container.textContent).toEqual('0');
+      act(() => updateValue(1));
+      expect(container.textContent).toEqual('loading');
+      advanceTimersBy(101);
+      expect(container.textContent).toEqual('1');
+
+      // Transition from async to sync (with async being in hasValue state):
+      act(() => updateValue(2));
+      expect(container.textContent).toEqual('2');
+
+      // Transition from async to sync (with async being in loading state):
+      act(() => updateValue(1337));
+      expect(container.textContent).toEqual('loading');
+      act(() => updateValue(4));
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('4');
+
+      // Transition from sync to async with still unresolved promise from before:
+      act(() => updateValue(5));
+      expect(container.textContent).toEqual('loading');
+      advanceTimersBy(101);
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('5');
+    },
+  );
+
+  testRecoil(
+    'Async selectors do not re-query when re-subscribed from having no subscribers',
+    async () => {
+      const anAtom = counterAtom();
+      const [sel, resolvers] = asyncSelectorThatPushesPromisesOntoArray(anAtom);
+      const [Component, updateValue] = componentThatWritesAtom(anAtom);
+      const [Toggle, toggle] = componentThatToggles(
+        <ReadsAtom atom={sel} />,
+        null,
+      );
+      const container = renderElements(
+        <>
+          <Component />
+          <Toggle />
+        </>,
+      );
+      expect(container.textContent).toEqual('loading');
+      expect(resolvers.length).toBe(1);
+      act(() => updateValue(2));
+      await flushPromisesAndTimers();
+      expect(resolvers.length).toBe(2);
+      resolvers[1][0]('hello');
+      await flushPromisesAndTimers();
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('"hello"');
+
+      // Cause sel to have no subscribers:
+      act(() => toggle.current());
+      expect(container.textContent).toEqual('');
+
+      // Once it's used again, it should not issue another request:
+      act(() => toggle.current());
+      expect(resolvers.length).toBe(2);
+      expect(container.textContent).toEqual('"hello"');
+    },
+  );
+
+  testRecoil('Can move out of suspense by changing deps', async () => {
+    const anAtom = counterAtom();
+    const [aSelector, resolvers] =
+      asyncSelectorThatPushesPromisesOntoArray(anAtom);
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={aSelector} />
+      </>,
+    );
+    // While still waiting for first request, let a second faster request happen:
+    expect(container.textContent).toEqual('loading');
+    expect(resolvers.length).toEqual(1);
+    act(() => updateValue(1));
+    await flushPromisesAndTimers();
+    expect(resolvers.length).toEqual(2);
+    expect(container.textContent).toEqual('loading');
+    // When the faster second request resolves, we should see its result:
+    resolvers[1][0]('hello');
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    expect(container.textContent).toEqual('"hello"');
+  });
+
+  testRecoil('Can use an already-resolved promise', async () => {
+    jest.useFakeTimers();
+    const anAtom = counterAtom();
+    const [Component, updateValue] = componentThatWritesAtom(anAtom);
+    const sel = selector({
+      key: `selector${nextID++}`,
+      get: ({get}) => {
+        const x = get(anAtom);
+        return Promise.resolve(x + 1);
+      },
+    });
+    const container = renderElements(
+      <>
+        <Component />
+        <ReadsAtom atom={sel} />
+      </>,
+    );
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    expect(container.textContent).toEqual('1');
+    act(() => updateValue(1));
+    await flushPromisesAndTimers();
+    await flushPromisesAndTimers();
+    expect(container.textContent).toEqual('2');
+  });
+
+  testRecoil(
+    'Wakeup from Suspense to previous value',
+    async ({gks, strictMode, concurrentMode}) => {
+      const BASE_CALLS = baseRenderCount(gks);
+      const sm = strictMode && concurrentMode ? 2 : 1;
+
+      const myAtom = atom({
+        key: `atom${nextID++}`,
+        default: {value: 0},
+      });
+      const mySelector = selector({
+        key: `selector${nextID++}`,
+        get: ({get}) => get(myAtom).value,
+      });
+
+      const [Component, updateValue] = componentThatWritesAtom(myAtom);
+      const [ReadComp, commit] =
+        componentThatReadsAtomWithCommitCount(mySelector);
+      const [container, suspense] = renderElementsWithSuspenseCount(
+        <>
+          <Component />
+          <ReadComp />
+        </>,
+      );
+
+      // Render initial state "0"
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('0');
+      expect(suspense).toHaveBeenCalledTimes(0 * sm);
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+
+      // Set selector to a pending state should cause component to suspend
+      act(() => updateValue({value: new Promise(() => {})}));
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('loading');
+      expect(suspense).toHaveBeenCalledTimes(1 * sm);
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+
+      // Setting selector back to the previous state before it was pending should
+      // wake it up and render in previous state
+      act(() => updateValue({value: 0}));
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('0');
+      expect(suspense).toHaveBeenCalledTimes(1 * sm);
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
+
+      // Setting selector to a new state "1" should update and re-render
+      act(() => updateValue({value: 1}));
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('1');
+      expect(suspense).toHaveBeenCalledTimes(1 * sm);
+      expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 3);
+
+      // Setting selector to the same value "1" should avoid a re-render
+      act(() => updateValue({value: 1}));
+      act(() => jest.runAllTimers());
+      await flushPromisesAndTimers();
+      expect(container.textContent).toEqual('1');
+      expect(suspense).toHaveBeenCalledTimes(1 * sm);
+      expect(commit).toHaveBeenCalledTimes(
+        BASE_CALLS +
+          3 +
+          ((reactMode().mode === 'LEGACY' ||
+            reactMode().mode === 'MUTABLE_SOURCE') &&
+          !gks.includes('recoil_suppress_rerender_in_callback')
+            ? 1
+            : 0),
+      );
+    },
+  );
+
+  describe('Async selector resolution notifies all stores that read pending', () => {
+    // Regression tests for #534: selectors used to only notify whichever store
+    // originally caused a promise to be returned, not any stores that also read
+    // the selector in that pending state.
+    testRecoil('Selectors read in a snapshot notify all stores', async () => {
+      // This version of the test uses the store inside of a Snapshot as its second store.
+      const switchAtom = atom({
+        key: 'notifiesAllStores/snapshots/switch',
+        default: false,
+      });
+      const selectorA = selector({
+        key: 'notifiesAllStores/snapshots/a',
+        get: () => 'foo',
+      });
+      let resolve = _ => {
+        throw new Error('error in test');
+      };
+      const selectorB = selector({
+        key: 'notifiesAllStores/snapshots/b',
+        get: async () =>
+          new Promise(r => {
+            resolve = r;
+          }),
+      });
+
+      let doIt;
+
+      function TestComponent() {
+        const shouldQuery = useRecoilValue(switchAtom);
+        const query = useRecoilValueLoadable(
+          shouldQuery ? selectorB : selectorA,
+        );
+
+        doIt = useRecoilCallback(({snapshot, set}) => () => {
+          /**
+           * this is required as we need the selector accessed below to outlive
+           * the end of this callback so that the async resolution notifies the
+           * store of the resolution and a re-render is triggered. Otherwise, the
+           * selector will be cleaned up at the end of the callback, meaning the
+           * resolution of the selector will not result in a re-render.
+           */
+          snapshot.retain();
+          snapshot.getLoadable(selectorB); // cause query to be triggered in context of snapshot store
+          set(switchAtom, true); // cause us to then read from the pending selector
+        });
+
+        return query.state === 'hasValue' ? query.contents : 'loading';
+      }
+
+      const c = renderElements(<TestComponent />);
+      expect(c.textContent).toEqual('foo');
+
+      act(doIt);
+      expect(c.textContent).toEqual('loading');
+
+      act(() => resolve('bar'));
+      await act(flushPromisesAndTimers);
+      await act(flushPromisesAndTimers);
+      expect(c.textContent).toEqual('bar');
+    });
+
+    testRecoil(
+      'Selectors read in a another root notify all roots',
+      async () => {
+        // This version of the test uses another RecoilRoot as its second store
+        const switchAtom = atom({
+          key: 'notifiesAllStores/twoRoots/switch',
+          default: false,
+        });
+
+        const selectorA = selector({
+          key: 'notifiesAllStores/twoRoots/a',
+          get: () => 'SELECTOR A',
+        });
+
+        let resolve = _ => {
+          throw new Error('error in test');
+        };
+        const selectorB = selector({
+          key: 'notifiesAllStores/twoRoots/b',
+          get: async () =>
+            new Promise(r => {
+              resolve = r;
+            }),
+        });
+
+        function TestComponent({
+          setSwitch,
+        }: {
+          setSwitch: ((boolean) => void) => void,
+        }) {
+          const [shouldQuery, setShouldQuery] = useRecoilState(switchAtom);
+          const query = useRecoilValueLoadable(
+            shouldQuery ? selectorB : selectorA,
+          );
+          setSwitch(setShouldQuery);
+          return query.state === 'hasValue' ? query.contents : 'loading';
+        }
+
+        let setRootASelector;
+        const rootA = renderElements(
+          <TestComponent
+            setSwitch={setSelector => {
+              setRootASelector = setSelector;
+            }}
+          />,
+        );
+        let setRootBSelector;
+        const rootB = renderElements(
+          <TestComponent
+            setSwitch={setSelector => {
+              setRootBSelector = setSelector;
+            }}
+          />,
+        );
+
+        expect(rootA.textContent).toEqual('SELECTOR A');
+        expect(rootB.textContent).toEqual('SELECTOR A');
+
+        act(() => setRootASelector(true)); // cause rootA to read the selector
+        expect(rootA.textContent).toEqual('loading');
+        expect(rootB.textContent).toEqual('SELECTOR A');
+
+        act(() => setRootBSelector(true)); // cause rootB to read the selector
+        expect(rootA.textContent).toEqual('loading');
+        expect(rootB.textContent).toEqual('loading');
+
+        act(() => resolve('SELECTOR B'));
+
+        await flushPromisesAndTimers();
+
+        expect(rootA.textContent).toEqual('SELECTOR B');
+        expect(rootB.textContent).toEqual('SELECTOR B');
+      },
+    );
+  });
+});
+
+// Test the following scenario:
+// 0. Recoil state version 1 with A=FOO and B=BAR
+// 1. Component renders with A for a value of FOO
+// 2. Component renders with B for a value of BAR
+// 3. Recoil state updated to version 2 with A=FOO and B=FOO
+//
+// Step 2 may be problematic if we attempt to suppress re-renders and don't
+// properly keep track of previous component values when the mutable source changes.
+testRecoil('Updating with changed selector', ({gks}) => {
+  if (!gks.includes('recoil_suppress_rerender_in_callback')) {
+    return;
+  }
+
+  const atomA = atom({
+    key: 'selector change rerender / atomA',
+    default: {value: 'FOO'},
+  });
+  const atomB = atom({
+    key: 'selector change rerender / atomB',
+    default: {value: 'BAR'},
+  });
+  const selectorA = selector({
+    key: 'selector change rerender / selectorA',
+    get: ({get}) => get(atomA).value,
+  });
+  const selectorB = selector({
+    key: 'selector change rerender / selectorB',
+    get: ({get}) => get(atomB).value,
+  });
+
+  let setSide;
+  let setB;
+  function SelectorComponent() {
+    const [side, setSideState] = useState('A');
+    setSide = setSideState;
+
+    setB = useRecoilCallback(({snapshot, gotoSnapshot}) => value => {
+      gotoSnapshot(
+        snapshot.map(({set}) => {
+          set(atomB, {value});
+        }),
+      );
+    });
+
+    return useRecoilValue(side === 'A' ? selectorA : selectorB);
+  }
+  const c = renderElements(<SelectorComponent />);
+
+  expect(c.textContent).toEqual('FOO');
+
+  // When we change the selector we are looking up it will render other atom's value
+  act(() => setSide('B'));
+  expect(c.textContent).toEqual('BAR');
+
+  // When we change Recoil state the component should re-render with new value.
+  // True even if we keep track of previous renders values to suppress re-renders when they don't change.
+  // If we don't keep track properly when the atom changes, this may break.
+  act(() => setB('FOO'));
+  expect(c.textContent).toEqual('FOO');
+
+  // When we swap back to atomA it now has the same value as atomB.
+  act(() => setSide('A'));
+  expect(c.textContent).toEqual('FOO');
+});
+
+testRecoil('Change component prop to suspend and wake', () => {
+  const awakeSelector = constSelector('WAKE');
+  const suspendedSelector = loadingAsyncSelector();
+
+  function TestComponent({side}) {
+    return (
+      useRecoilValue(side === 'AWAKE' ? awakeSelector : suspendedSelector) ??
+      'LOADING'
+    );
+  }
+
+  let setSide;
+  const SelectorComponent = function () {
+    const [side, setSideState] = useState('AWAKE');
+    setSide = setSideState;
+    return <TestComponent side={side} />;
+  };
+  const c = renderElements(<SelectorComponent />);
+
+  expect(c.textContent).toEqual('WAKE');
+
+  act(() => setSide('SLEEP'));
+  expect(c.textContent).toEqual('loading');
+
+  act(() => setSide('AWAKE'));
+  expect(c.textContent).toEqual('WAKE');
+});
+
+testRecoil(
+  "Releasing snapshot doesn't invalidate pending selector",
+  async () => {
+    const [mySelector, resolveSelector] = asyncSelector();
+
+    // Initialize selector with snapshot first so it is initialized for both
+    // snapshot and root and has separate cleanup handlers for both.
+    function Component() {
+      const callback = useRecoilCallback(({snapshot}) => () => {
+        snapshot.getLoadable(mySelector);
+      });
+      callback(); // First initialize with snapshot
+      return useRecoilValue(mySelector); // Second initialize with RecoilRoot
+    }
+
+    const c = renderElements(<Component />);
+
+    // Wait to allow the snapshot in the callback to release and call the
+    // selector node cleanup functions.
+    await flushPromisesAndTimers();
+
+    expect(c.textContent).toBe('loading');
+
+    act(() => resolveSelector('RESOLVE'));
+    await flushPromisesAndTimers();
+    expect(c.textContent).toBe('RESOLVE');
+  },
+);
+
+describe('Counts', () => {
+  describe('Evaluation', () => {
+    testRecoil('Selector functions are evaluated just once', () => {
+      const anAtom = counterAtom();
+      const [aSelector, selectorFn] = plusOneSelector(anAtom);
+      const [Component, updateValue] = componentThatWritesAtom(anAtom);
+      renderElements(
+        <>
+          <Component />
+          <ReadsAtom atom={aSelector} />
+        </>,
+      );
+      expect(selectorFn).toHaveBeenCalledTimes(1);
+      act(() => updateValue(1));
+      expect(selectorFn).toHaveBeenCalledTimes(2);
+    });
+
+    testRecoil(
+      'Selector functions are evaluated just once even if multiple upstreams change',
+      () => {
+        const atomA = counterAtom();
+        const atomB = counterAtom();
+        const [aSelector, selectorFn] = additionSelector(atomA, atomB);
+        const [ComponentA, updateValueA] = componentThatWritesAtom(atomA);
+        const [ComponentB, updateValueB] = componentThatWritesAtom(atomB);
+        renderElements(
+          <>
+            <ComponentA />
+            <ComponentB />
+            <ReadsAtom atom={aSelector} />
+          </>,
+        );
+        expect(selectorFn).toHaveBeenCalledTimes(1);
+        act(() => {
+          batchUpdates(() => {
+            updateValueA(1);
+            updateValueB(1);
+          });
+        });
+        expect(selectorFn).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    /**
+     * This test ensures that we are not running the selector's get() an unnecessary
+     * number of times in response to async selectors resolving (i.e. by retrying
+     * more times than we have to or creating numerous promises that retry).
+     */
+    testRecoil(
+      'async selector runs the minimum number of times required',
+      async () => {
+        const [asyncDep1, resolveAsyncDep1] = asyncSelector();
+        const [asyncDep2, resolveAsyncDep2] = asyncSelector();
+
+        let numTimesRan = 0;
+
+        const selectorWithAsyncDeps = selector({
+          key: 'selectorRunsMinTimes',
+          get: async ({get}) => {
+            numTimesRan++;
+            return get(asyncDep1) + get(asyncDep2);
+          },
+        });
+
+        const container = renderElements(
+          <ReadsAtom atom={selectorWithAsyncDeps} />,
+        );
+
+        expect(numTimesRan).toBe(1);
+
+        act(() => resolveAsyncDep1('a'));
+        await flushPromisesAndTimers();
+        expect(numTimesRan).toBe(2);
+
+        act(() => resolveAsyncDep2('b'));
+        await flushPromisesAndTimers();
+        expect(numTimesRan).toBe(3);
+
+        await flushPromisesAndTimers();
+        expect(container.textContent).toEqual('"ab"');
+      },
+    );
+  });
+
+  describe('Render', () => {
+    testRecoil("Updating with same value doesn't rerender", ({gks}) => {
+      if (!gks.includes('recoil_suppress_rerender_in_callback')) {
+        return;
+      }
+
+      const myAtom = atom({
+        key: 'selector same value rerender / atom',
+        default: {value: 'DEFAULT'},
+      });
+      const mySelector = selector({
+        key: 'selector - same value rerender',
+        get: ({get}) => get(myAtom).value,
+      });
+
+      let setAtom;
+      let resetAtom;
+      let renders = 0;
+      function SelectorComponent() {
+        const value = useRecoilValue(mySelector);
+        const setAtomValue = useSetRecoilState(myAtom);
+        const resetAtomValue = useResetRecoilState(myAtom);
+        setAtom = x => setAtomValue({value: x});
+        resetAtom = resetAtomValue;
+        return value;
+      }
+      expect(renders).toEqual(0);
+      const c = renderElements(
+        <Profiler
+          id="test"
+          onRender={() => {
+            renders++;
+          }}>
+          <SelectorComponent />
+        </Profiler>,
+      );
+
+      // Initial render happens one time in www and 2 times in oss.
+      // resetting the counter to 1 after the initial render to make them
+      // the same in both repos. 2 renders probably need to be looked into.
+      renders = 1;
+
+      expect(c.textContent).toEqual('DEFAULT');
+
+      act(() => setAtom('SET'));
+      expect(c.textContent).toEqual('SET');
+      expect(renders).toEqual(2);
+
+      act(() => setAtom('SET'));
+      expect(c.textContent).toEqual('SET');
+      expect(renders).toEqual(2);
+
+      act(() => setAtom('CHANGE'));
+      expect(c.textContent).toEqual('CHANGE');
+      expect(renders).toEqual(3);
+
+      act(resetAtom);
+      expect(c.textContent).toEqual('DEFAULT');
+      expect(renders).toEqual(4);
+
+      act(resetAtom);
+      expect(c.textContent).toEqual('DEFAULT');
+      expect(renders).toEqual(4);
+    });
+
+    testRecoil(
+      'Resolution of suspense causes render just once',
+      async ({gks, strictMode, concurrentMode}) => {
+        const BASE_CALLS = baseRenderCount(gks);
+        const sm = strictMode && concurrentMode ? 2 : 1;
+
+        jest.useFakeTimers();
+        const anAtom = counterAtom();
+        const [aSelector, _] = plusOneAsyncSelector(anAtom);
+        const [Component, updateValue] = componentThatWritesAtom(anAtom);
+        const [ReadComp, commit] =
+          componentThatReadsAtomWithCommitCount(aSelector);
+        const [__, suspense] = renderElementsWithSuspenseCount(
+          <>
+            <Component />
+            <ReadComp />
+          </>,
+        );
+
+        // Begins in loading state, then shows initial value:
+        act(() => jest.runAllTimers());
+        await flushPromisesAndTimers();
+        expect(suspense).toHaveBeenCalledTimes(1 * sm);
+        expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 1);
+        // Changing dependency makes it go back to loading, then to show new value:
+        act(() => updateValue(1));
+        act(() => jest.runAllTimers());
+        await flushPromisesAndTimers();
+        expect(suspense).toHaveBeenCalledTimes(2 * sm);
+        expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 2);
+        // Returning to a seen value does not cause the loading state:
+        act(() => updateValue(0));
+        await flushPromisesAndTimers();
+        expect(suspense).toHaveBeenCalledTimes(2 * sm);
+        expect(commit).toHaveBeenCalledTimes(BASE_CALLS + 3);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Summary: Cleanup unit tests by organizing them a bit more.  Also, a couple files were getting rather large and sometimes overruning the 10s threshold with all of the GK and React environment combinations.  This splits out the common hook tests from the selector-specific ones and splits the selector tests between tests of just selectors with mock store and selectors via hooks.

Differential Revision: D33735180

