### PR TITLE
Enable transaction writing tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
   - Atom effects are cleaned up when initialized by a Snapshot which is released. (#1511, #1532)
   - Unsubscribe `onSet()` handlers in atom effects when atoms are cleaned up. (#1509)
   - Call `onSet()` when atoms are initialized with `<RecoilRoot initializeState={...} >` (#1519, #1511)
+  - Set `trigger` to `'set'` when initialized from a set in a Recoil transaction. (#1569)
 - Avoid extra re-renders in some cases when a component uses a different atom/selector. (#825)
 - `<RecoilRoot>` will only call `initializeState()` once during the initial render. (#1372)
 - Lazily compute the properties of `useGetRecoilValueInfo_UNSTABLE()` and `Snapshot#getInfo_UNSTABLE()` results (#1549)

--- a/packages/recoil/core/Recoil_AtomicUpdates.js
+++ b/packages/recoil/core/Recoil_AtomicUpdates.js
@@ -87,7 +87,7 @@ class TransactionInterfaceImpl {
       this._changes.set(recoilState.key, (valueOrUpdater: any)(current)); // flowlint-line unclear-type:off
     } else {
       // Initialize atom and run effects if not initialized yet
-      initializeNode(this._store, recoilState.key);
+      initializeNode(this._store, recoilState.key, 'set');
 
       this._changes.set(recoilState.key, valueOrUpdater);
     }

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -102,8 +102,8 @@ function initializeNodeIfNewToStore(
   });
 }
 
-function initializeNode(store: Store, key: NodeKey): void {
-  initializeNodeIfNewToStore(store, store.getState().currentTree, key, 'get');
+function initializeNode(store: Store, key: NodeKey, trigger: Trigger): void {
+  initializeNodeIfNewToStore(store, store.getState().currentTree, key, trigger);
 }
 
 function cleanUpNode(store: Store, key: NodeKey) {

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -502,7 +502,7 @@ function RecoilRoot_INTERNAL({
     // to re-initialize all known atoms after they were cleaned up.
     const store = storeRef.current;
     for (const atomKey of new Set(store.getState().knownAtoms)) {
-      initializeNode(store, atomKey);
+      initializeNode(store, atomKey, 'get');
     }
 
     return () => {

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -102,7 +102,7 @@ class Snapshot {
     // this snapshot gets counted towards the node's live stores count).
     // TODO Optimize this when cloning snapshots for callbacks
     for (const nodeKey of this._store.getState().knownAtoms) {
-      initializeNode(this._store, nodeKey);
+      initializeNode(this._store, nodeKey, 'get');
       updateRetainCount(this._store, nodeKey, 1);
     }
 


### PR DESCRIPTION
Summary:
Enable unit tests for `useRecoilTransaction()` tests that write state.  Test that subsequent reads in the same transaction obtain the latest value.

Also fix atom effects to use the `'set'` trigger when initiated from a `set()` in a transaction.

Differential Revision: D33677172

