### PR TITLE
Fix postInstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Recoil - A state management library for React",
   "main": "cjs/recoil.js",
   "module": "es/recoil.js",
@@ -17,7 +17,6 @@
   "license": "MIT",
   "scripts": {
     "prepare": "install-peers",
-    "postinstall": "cd ./node_modules/gen-flow-files && yarn install && yarn build",
     "build": "rollup -c && node scripts/postbuild.js",
     "test": "jest packages/*",
     "format": "prettier --write \"./**/*.{js,md,json}\"",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -23,7 +23,10 @@ console.log('Copying index.d.ts for TypeScript support...');
 fs.copyFile('./typescript/index.d.ts', './index.d.ts', logErrors);
 
 console.log('Generating Flow type files...');
-exec('npx gen-flow-files packages/recoil --out-dir cjs', err => {
-  logErrors(err);
-  fs.rename('cjs/Recoil_index.js.flow', 'cjs/recoil.js.flow', logErrors);
-});
+exec(
+  'cd ./node_modules/gen-flow-files && yarn install && yarn build && cd ../.. && npx gen-flow-files packages/recoil --out-dir cjs',
+  err => {
+    logErrors(err);
+    fs.rename('cjs/Recoil_index.js.flow', 'cjs/recoil.js.flow', logErrors);
+  },
+);


### PR DESCRIPTION
Summary: D32366885 (https://github.com/facebookexperimental/recoil/commit/97cb9783400f18c22797e822af998fbf1cfca244) added a `postInstall` script for building the temporary patched package we use for `gen-flow-files`.  However, this was added as a production install script when the `devDependencies` are not available.  It should only be used at build time so move to `postbuild.js` script.

Differential Revision: D33871387

