### PR TITLE
Avoid releasing retainables if there are pending writes

### DIFF
--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -209,7 +209,7 @@ function endBatch(store: Store) {
 
     // Ignore commits that are not because of Recoil transactions -- namely,
     // because something above RecoilRoot re-rendered:
-    if (nextTree === null) {
+    if (nextTree == null) {
       return;
     }
 
@@ -232,7 +232,11 @@ function endBatch(store: Store) {
     storeState.previousTree = null;
 
     if (gkx('recoil_memory_managament_2020')) {
-      releaseScheduledRetainablesNow(store);
+      // Only release retainables if there were no writes during the end of the
+      // batch.  This avoids releasing something we might be about to use.
+      if (nextTree == null) {
+        releaseScheduledRetainablesNow(store);
+      }
     }
   } finally {
     storeState.commitDepth--;


### PR DESCRIPTION
Summary:
Avoid releasing retainables at the end of the batch if there were writes while processing them.  This could happen, for example, if there are effects which monitor changes and then also write state.

This error is currently superfulous for the open source release where garbage collection is enabled but not used.

Addresses #1582

Differential Revision: D33965759

