### PR TITLE
Add note about retaining a snapshot in async selector jest tests

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -196,6 +196,15 @@ test('Test multipliedState', () => {
 });
 ```
 
+### Jest unit testing async selectors
+
+When testing an **async selector**, it is necessary to `retain()` the snapshot to avoid early cancelation of the selector.
+
+```jsx
+const initialSnapshot = snapshot_UNSTABLE();
+initialSnapshot.retain();
+```
+
 ### Clearing all selector caches
 
 ```jsx


### PR DESCRIPTION
I wasn't sure if it's necessary to create a complete second example since they're _mostly_ equal in code. Right now it only references the already existing documentation but if you prefer an example with a new headline just let me know, I originally prepared one:

```js
export const numberState = atom({
  key: "number",
  default: selector({
    key: "number/Default",
    get: async () => {
      // await some numbers
    }
  })
});

test('Test async numberState default', async () => {
  const initialSnapshot = snapshot_UNSTABLE();
  initialSnapshot.retain();
  await expect(initialSnapshot.getLoadable(numberState).promiseOrThrow()).resolves.toBe(0);
});
```

This could also link to the existing docs for a more complete picture of retain/release handling

Closes #1590 