### PR TITLE
Better error reporting / workaround for inconsistent selector values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UPCOMING
 
 - Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
+- Better error reporting when selectors provide inconsistent results (#1696)
 
 **_Add new changes here as they land_**
 


### PR DESCRIPTION
Summary:
Better detect and clarify error message when selectors do not provide consistent values based on input dependency values.

In development mode this will throw an error.  In production it will log and report to console, then try to reset the selector cache and trundle on.

This workaround is not sufficient to avoid issues and the user should resolve the selector behavior.

Differential Revision: D34100576

