### PR TITLE
useRecoilCallback() snapshot gets the latest state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Change Log
 
 ## UPCOMING
-
-- Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
-- Better error reporting when selectors provide inconsistent results (#1696)
-
 **_Add new changes here as they land_**
 
 - `shouldNotBeFrozen` now works in JS environment without `Window` interface. (#1571)
+- Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
+- Better error reporting when selectors provide inconsistent results (#1696)
+
+### Breaking Changes
+
+- `useRecoilCallback()` now provides a snapshot for the latest state instead of the latest rendered state, which had bugs (#1610, #1604)
 
 ## 0.6.1 (2022-01-29)
 

--- a/packages/recoil/core/Recoil_RecoilValueInterface.js
+++ b/packages/recoil/core/Recoil_RecoilValueInterface.js
@@ -35,6 +35,7 @@ const {
   RecoilValueReadOnly,
   isRecoilValue,
 } = require('./Recoil_RecoilValue');
+const {invalidateMemoizedSnapshot} = require('./Recoil_SnapshotCache');
 const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
@@ -195,6 +196,7 @@ function applyActionsToStore(store, actions) {
       applyAction(store, newState, action);
     }
     invalidateDownstreams(store, newState);
+    invalidateMemoizedSnapshot();
     return newState;
   });
 }
@@ -369,5 +371,4 @@ module.exports = {
   invalidateDownstreams,
   copyTreeState,
   refreshRecoilValue,
-  invalidateDownstreams_FOR_TESTING: invalidateDownstreams,
 };

--- a/packages/recoil/core/Recoil_SnapshotCache.js
+++ b/packages/recoil/core/Recoil_SnapshotCache.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+let _invalidateMemoizedSnapshot: ?() => void = null;
+
+function setInvalidateMemoizedSnapshot(invalidate: () => void): void {
+  _invalidateMemoizedSnapshot = invalidate;
+}
+
+function invalidateMemoizedSnapshot(): void {
+  _invalidateMemoizedSnapshot?.();
+}
+
+module.exports = {
+  setInvalidateMemoizedSnapshot,
+  invalidateMemoizedSnapshot,
+};

--- a/packages/recoil/hooks/Recoil_SnapshotHooks.js
+++ b/packages/recoil/hooks/Recoil_SnapshotHooks.js
@@ -158,7 +158,7 @@ function useRecoilTransactionObserver(
   useTransactionSubscription(
     useCallback(
       store => {
-        const snapshot = cloneSnapshot(store, 'current');
+        const snapshot = cloneSnapshot(store, 'latest');
         const previousSnapshot = cloneSnapshot(store, 'previous');
         callback({
           snapshot,

--- a/packages/recoil/hooks/Recoil_useRecoilCallback.js
+++ b/packages/recoil/hooks/Recoil_useRecoilCallback.js
@@ -12,6 +12,7 @@
 
 import type {TransactionInterface} from '../core/Recoil_AtomicUpdates';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
+import type {Snapshot} from '../core/Recoil_Snapshot';
 import type {Store} from '../core/Recoil_State';
 
 const {atomicUpdater} = require('../core/Recoil_AtomicUpdates');
@@ -22,7 +23,7 @@ const {
   refreshRecoilValue,
   setRecoilValue,
 } = require('../core/Recoil_RecoilValueInterface');
-const {Snapshot, cloneSnapshot} = require('../core/Recoil_Snapshot');
+const {cloneSnapshot} = require('../core/Recoil_Snapshot');
 const {gotoSnapshot} = require('./Recoil_SnapshotHooks');
 const {useCallback} = require('react');
 const err = require('recoil-shared/util/Recoil_err');

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -33,7 +33,7 @@ const {
   sendEndOfBatchNotifications_FOR_TESTING,
 } = require('../../recoil/core/Recoil_RecoilRoot');
 const {
-  invalidateDownstreams_FOR_TESTING,
+  invalidateDownstreams,
 } = require('../../recoil/core/Recoil_RecoilValueInterface');
 const {makeEmptyStoreState} = require('../../recoil/core/Recoil_State');
 const invariant = require('../util/Recoil_invariant');
@@ -65,7 +65,7 @@ function makeStore(): Store {
       const currentStoreState = store.getState();
       // FIXME: does not increment state version number
       currentStoreState.currentTree = replacer(currentStoreState.currentTree); // no batching so nextTree is never active
-      invalidateDownstreams_FOR_TESTING(store, currentStoreState.currentTree);
+      invalidateDownstreams(store, currentStoreState.currentTree);
       const {reactMode} = require('../../recoil/core/Recoil_ReactMode');
       if (reactMode().early) {
         notifyComponents_FOR_TESTING(


### PR DESCRIPTION
Summary:
NOTE: This is a breaking change, but the previous approach had a bug.

Previously, `useRecoilCallback()` would attempt to provide a `Snapshot` based on the state that was currently rendered.  However, there were some bugs where this was not the case.  For example, a callback called from an effect handler may or may not have had the latest rendered state based on the timing of the setter.

The new approach `useRecoilCallback()` will always try to get a snapshot with the latest state.  This should also be more intuitive for users.

Addresses #1604

Differential Revision: D34236485

