### PR TITLE
Add `getStoreID()` to `Snapshot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
 - Better error reporting when selectors provide inconsistent results (#1696)
+- Add `getStoreID()` method to `Snapshot` (#)
 
 **_Add new changes here as they land_**
 

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -17,7 +17,7 @@ import type {
   ValueOrUpdater,
 } from '../recoil_values/Recoil_callbackTypes';
 import type {RecoilValueInfo} from './Recoil_FunctionalCore';
-import type {NodeKey} from './Recoil_Keys';
+import type {NodeKey, StoreID} from './Recoil_Keys';
 import type {RecoilState, RecoilValue} from './Recoil_RecoilValue';
 import type {StateID, Store, StoreState, TreeState} from './Recoil_State';
 
@@ -183,6 +183,11 @@ class Snapshot {
   getID(): SnapshotID {
     this.checkRefCount_INTERNAL();
     return this._store.getState().currentTree.stateID;
+  }
+
+  getStoreID(): StoreID {
+    this.checkRefCount_INTERNAL();
+    return this._store.storeID;
   }
 
   // We want to allow the methods to be destructured and used as accessors

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -556,7 +556,7 @@ describe('Atom effects', () => {
   testRecoil('Standalone snapshot', async ({gks}) => {
     let effectsRefCount = 0;
     const myAtom = atom({
-      key: 'snapshot effects',
+      key: 'snapshot effects standalone',
       default: 'DEFAULT',
       effects: [
         ({setSelf}) => {
@@ -587,7 +587,7 @@ describe('Atom effects', () => {
   testRecoil('RecoilRoot Snapshot', () => {
     let effectsRefCount = 0;
     const myAtom = atom({
-      key: 'snapshot effects',
+      key: 'snapshot effects RecoilRoot',
       default: 'DEFAULT',
       effects: [
         ({setSelf}) => {
@@ -626,5 +626,22 @@ describe('Atom effects', () => {
     act(() => setMount(false));
     expect(c.textContent).toBe('UNMOUNTED');
     expect(effectsRefCount).toBe(0);
+  });
+
+  testRecoil('getStoreID()', () => {
+    const myAtom = atom({
+      key: 'snapshot effects storeID',
+      default: 'DEFAULT',
+      effects: [
+        ({setSelf, storeID}) => {
+          setSelf(storeID);
+        },
+      ],
+    });
+
+    const testSnapshot = freshSnapshot();
+    expect(testSnapshot.getLoadable(myAtom).getValue()).toBe(
+      testSnapshot.getStoreID(),
+    );
   });
 });


### PR DESCRIPTION
Summary: Add `getStoreID()` to `Snapshot`.  This can be used to match-up with the `storeID` provided in Atom effects used in that snapshot.

Differential Revision: D34166775

