### PR TITLE
Add 'onSetValue' method to effect params for reactive cross-state updates

### DIFF
--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -302,6 +302,11 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         if (recoilValue.key === key) {
           throw new Error('use onSet to subscribe to mutations to self');
         }
+        if (!duringInit) {
+          throw new Error(
+            'onSetValue must be used at the top of the effect scope',
+          );
+        }
         const {release} = store.subscribeToTransactions(store => {
           const {currentTree} = store.getState();
           const currentValueLoadable = getRecoilValueAsLoadable(

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -300,12 +300,10 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         observer: (value: S) => void,
       ): void {
         if (recoilValue.key === key) {
-          throw new Error('use onSet to subscribe to mutations to self');
+          throw err('use onSet to subscribe to mutations to self');
         }
         if (!duringInit) {
-          throw new Error(
-            'onSetValue must be used at the top of the effect scope',
-          );
+          throw err('onSetValue must be used at the top of the effect scope');
         }
         const {release} = store.subscribeToTransactions(store => {
           const {currentTree} = store.getState();
@@ -389,6 +387,9 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
 
       const onSet =
         effect => (handler: (T, T | DefaultValue, boolean) => void) => {
+          if (!duringInit) {
+            throw err('onSet must be used at the top of the effect scope');
+          }
           const {release} = store.subscribeToTransactions(currentStore => {
             // eslint-disable-next-line prefer-const
             let {currentTree, previousTree} = currentStore.getState();

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -297,6 +297,9 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         recoilValue: RecoilValue<S>,
         observer: (value: S) => void,
       ): void {
+        if (recoilValue.key === key) {
+          throw new Error('use onSet to subscribe to mutations to self');
+        }
         const {release} = store.subscribeToTransactions(store => {
           const {currentTree} = store.getState();
           const currentValueLoadable = getRecoilValueAsLoadable(

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -298,9 +298,16 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         observer: (value: S) => void,
       ): void {
         const {release} = store.subscribeToTransactions(store => {
-          const loadable = getRecoilValueAsLoadable(store, recoilValue);
-          const value = loadable.getValue();
-          observer(value);
+          const {currentTree} = store.getState();
+          const currentValueLoadable = getRecoilValueAsLoadable(
+            store,
+            recoilValue,
+            currentTree,
+          );
+          if (currentValueLoadable.state === 'hasValue') {
+            const value = currentValueLoadable.getValue();
+            observer(value);
+          }
         }, recoilValue.key);
 
         cleanupEffectsByStore.set(store, [

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -134,8 +134,10 @@ export type AtomEffect<T> = ({
     (newValue: T, oldValue: T | DefaultValue, isReset: boolean) => void,
   ) => void,
 
+  // Subscribe to changes in other recoil values
+  onSetValue: <S>(RecoilValue<S>, (value: S) => void) => void,
+
   // Accessors to read other atoms/selectors
-  observe: <S>(RecoilValue<S>, (value: S) => void) => void,
   getPromise: <S>(RecoilValue<S>) => Promise<S>,
   getLoadable: <S>(RecoilValue<S>) => Loadable<S>,
   getInfo_UNSTABLE: <S>(RecoilValue<S>) => RecoilValueInfo<S>,
@@ -293,7 +295,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         return getLoadable(recoilValue).toPromise();
       }
 
-      function observe<S>(
+      function onSetValue<S>(
         recoilValue: RecoilValue<S>,
         observer: (value: S) => void,
       ): void {
@@ -435,7 +437,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
             setSelf: setSelf(effect),
             resetSelf: resetSelf(effect),
             onSet: onSet(effect),
-            observe,
+            onSetValue,
             getPromise,
             getLoadable,
             getInfo_UNSTABLE,

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -305,18 +305,28 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         if (!duringInit) {
           throw err('onSetValue must be used at the top of the effect scope');
         }
-        const {release} = store.subscribeToTransactions(store => {
-          const {currentTree} = store.getState();
-          const currentValueLoadable = getRecoilValueAsLoadable(
-            store,
-            recoilValue,
-            currentTree,
-          );
-          if (currentValueLoadable.state === 'hasValue') {
-            const value = currentValueLoadable.getValue();
-            observer(value);
-          }
-        }, recoilValue.key);
+        const {release} = store.subscribeToTransactions(
+          store => {
+            const {currentTree} = store.getState();
+            const currentValueLoadable = getRecoilValueAsLoadable(
+              store,
+              recoilValue,
+              currentTree,
+            );
+            if (currentValueLoadable.state === 'hasValue') {
+              const value = currentValueLoadable.getValue();
+              observer(value);
+            }
+          },
+          // Note: we probably want this key to be used to filter events, but this is
+          // preventing us from getting events on when selectors update. I'm guessing this is a
+          // bug in the store?
+          //
+          // By not filtering on the key, this event stream will be overly chatty and reset() on
+          // an atom subscribing to an upstream will break
+          //
+          // recoilValue.key
+        );
 
         cleanupEffectsByStore.set(store, [
           ...(cleanupEffectsByStore.get(store) ?? []),

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -911,6 +911,37 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('"DEFAULT_A""DEFAULT_B"');
   });
 
+  testRecoil('observe', () => {
+    const atomA = atom({
+      key: 'observe test a',
+      default: 100,
+    });
+    const atomB = atom({
+      key: 'observe test b',
+      default: 99,
+      effects: [
+        ({observe, setSelf}) => {
+          return observe(atomA, value => {
+            setSelf(value + 1);
+          });
+        },
+      ],
+    });
+
+    const [AtomA, setA, resetA] = componentThatReadsAndWritesAtom(atomA);
+    const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
+    const c = renderElements(
+      <>
+        <AtomA />
+        <AtomB />
+      </>,
+    );
+
+    expect(c.textContent).toEqual('10099');
+    act(() => setA(100));
+    expect(c.textContent).toEqual('100101');
+  });
+
   testRecoil('Cleanup Handlers - when root unmounted', () => {
     const refCountsA = [0, 0];
     const refCountsB = [0, 0];

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -911,17 +911,17 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('"DEFAULT_A""DEFAULT_B"');
   });
 
-  testRecoil('observe - can observe updates', () => {
+  testRecoil('onSetVa;lue - can observe updates', () => {
     const atomA = atom({
-      key: 'observe test a',
+      key: 'onSetValue test a',
       default: 100,
     });
     const atomB = atom({
-      key: 'observe test b',
+      key: 'onSetValue test b',
       default: 99,
       effects: [
-        ({observe, setSelf}) => {
-          observe(atomA, value => {
+        ({onSetValue, setSelf}) => {
+          onSetValue(atomA, value => {
             setSelf(value + 1);
           });
         },
@@ -955,13 +955,13 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('10099');
   });
 
-  testRecoil('observe - cannot subscribe to self', () => {
+  testRecoil('onSetVa;lue - cannot subscribe to self', () => {
     const atomA = atom({
-      key: 'observe test a',
+      key: 'onSetValue test a',
       default: 100,
       effects: [
-        ({observe, setSelf}) => {
-          observe(atomA, value => {});
+        ({onSetValue, setSelf}) => {
+          onSetValue(atomA, value => {});
         },
       ],
     });

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -1244,7 +1244,6 @@ describe('Effects', () => {
       effects: [
         ({onSetValue, onSet}) => {
           onSetValue(atomA, () => {
-            console.log('ONSETVALUE');
             onSet(value => {
               setSelf(value * 100);
             });

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -940,6 +940,8 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('10099');
     act(() => setA(100));
     expect(c.textContent).toEqual('100101');
+    act(() => setA(101));
+    expect(c.textContent).toEqual('101102');
   });
 
   testRecoil('Cleanup Handlers - when root unmounted', () => {

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -921,7 +921,7 @@ describe('Effects', () => {
       default: 99,
       effects: [
         ({observe, setSelf}) => {
-          return observe(atomA, value => {
+          observe(atomA, value => {
             setSelf(value + 1);
           });
         },

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -98,6 +98,9 @@
     param: (newValue: T, oldValue: T | DefaultValue, isReset: boolean) => void,
   ) => void,
 
+  // Subscribe to changes in other recoil values
+  onSetValue: <S>(recoilValue: RecoilValue<S>, observer: (newValue: S) => void) => void,
+
   // Accessors to read other atoms/selectors
   getPromise: <S>(recoilValue: RecoilValue<S>) => Promise<S>,
   getLoadable: <S>(recoilValue: RecoilValue<S>) => Loadable<S>,


### PR DESCRIPTION
This PR adds an 'onSetValue' method to the arguments object passed to effect functions. This will allow atoms to subscribe to state changes in other atoms and reactively respond. This is useful for situations where atoms are dependent, but are not derivative from each other (where a selector would be useful).

Caveat: I'm not super familiar with Flow or the Recoil internals, so I'd be glad to shift anything around to match your teams' coding patterns

Fixes #1611 