### PR TITLE
Improve test guide

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -51,7 +51,7 @@ describe('The form state should', () => {
 
     render(
       <RecoilRoot>
-        <RecoilObserver node={nameAtom} onChange={onChange} />
+        <RecoilObserver node={nameState} onChange={onChange} />
         <Form />
       </RecoilRoot>,
     );
@@ -196,16 +196,22 @@ test('Test multipliedState', () => {
 });
 ```
 
-### Jest unit testing async selectors
+### Testing async selectors
 
 When testing an **async selector**, it is necessary to `retain()` the snapshot to avoid early cancelation of the selector.
 
 ```jsx
 const initialSnapshot = snapshot_UNSTABLE();
-initialSnapshot.retain();
+const release = initialSnapshot.retain();
+
+// your test
+
+release();
 ```
 
 ### Clearing all selector caches
+
+Cache is shared between tests, so you'll need to clear the cache after each test.
 
 ```jsx
 const clearSelectorCachesState = selector({
@@ -219,5 +225,6 @@ const clearSelectorCachesState = selector({
 
 const clearSelectorCaches = testingSnapshot.getLoadable(clearSelectorCachesState).getValue();
 
-clearSelectorCaches();
+// Assuming we're in a file added to Jest's setupFilesAfterEnv:
+afterEach(clearSelectorCaches);
 ```


### PR DESCRIPTION
- Fixes variable name passed to `RecoilObserver.node` to match the earlier example.
- Drop "Jest" from the async selector title as it's not specific to Jest
- Make clear `retain()` needs to be followed by `release()`.
- Explain why we need to clear cache.
- Show how to clear cache in `afterEach` for Jest