### PR TITLE
Adding ELI5 video to the home page

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -86,6 +86,43 @@ function Feature({
   );
 }
 
+function VideosContainer() {
+  return (
+    <div className="container text--center margin-bottom--lg margin-top--lg">
+      <div className="row">
+        <div className="col">
+          <h2>Brief Introduction into Recoil</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube-nocookie.com/embed/U9XStcquQyY"
+              title="Explain Like I'm 5: Recoil"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+        <div className="col">
+          <h2>Deep Dive into Recoil</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube-nocookie.com/embed/_ISAA_Jt9kI"
+              title="Recoil: State Management for Today's React - Dave McCabe aka @mcc_abe at @ReactEurope 2020"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
@@ -117,6 +154,7 @@ function Home() {
         </div>
       </header>
       <main>
+      <VideosContainer />
         {features && features.length && (
           <section className={styles.features}>
             <div className="container">
@@ -128,24 +166,6 @@ function Home() {
             </div>
           </section>
         )}
-        <section className={styles.features}>
-          <div className="container">
-            <div className="row">
-              <div className="container">
-                <div className="row" style={{ justifyContent: 'center' }}>
-                  <iframe
-                    width="560"
-                    height="315"
-                    src="https://www.youtube-nocookie.com/embed/_ISAA_Jt9kI"
-                    frameBorder="0"
-                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-                    allowFullScreen
-                  />{' '}
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
       </main>
     </Layout>
   );


### PR DESCRIPTION
## Summary

Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
![image](https://user-images.githubusercontent.com/12485205/154751079-f6c177e9-78d4-4623-a8d0-9ed64cb5e115.png)
