### PR TITLE
Retain snapshots for async callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - The `default` value is now optional for `atom()` and `atomFamily()`.  If not provided the atom will initialize to a pending state. (#1639)
 - Significant optimization for selector evaluations.  2x improvement with 100 dependencies, 4x with 1,000, and 40x with 10,000. (#1515, #914)
+- Automatically retain snapshots for the duration of async callbacks. (#1632)
 - `shouldNotBeFrozen` now works in JS environment without `Window` interface. (#1571)
 - Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
 - Better error reporting when selectors provide inconsistent results (#1696)

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -398,7 +398,13 @@ const testGKs =
   };
 
 const WWW_GKS_TO_TEST = QUICK_TEST
-  ? [['recoil_hamt_2020', 'recoil_sync_external_store']]
+  ? [
+      [
+        'recoil_hamt_2020',
+        'recoil_sync_external_store',
+        'recoil_memory_managament_2020',
+      ],
+    ]
   : [
       // OSS for React <18:
       ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering


### PR DESCRIPTION
Summary:
Automatically retains snapshots from `useRecoilCallback()` for the duration of async callbacks until the promise is resolved.  This should help avoid potential user errors without needing to manually remember to `retain()` and release in a `finally` clause.

Before:
```
const callback = useRecoilCallback(({snapshot}) => async () => {
  const release = snapshot.retain();
  try {
    ... await
    ... use snapshot
  } finally {
    release();
  }
});
```

After:
```
const callback = useRecoilCallback(({snapshot}) => async () => {
  ... await
  ... use snapshot
});
```

Manually retaining is still required if trying to persist the the Snapshot beyond the lifetime of the async callback or if it is used in async callbacks not dependent to a returned promise.

Differential Revision: D34405832

