### PR TITLE
Make default optional for atoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
+- The `default` value is now optional for `atom()` and `atomFamily()`.  If not provided the atom will initialize to a pending state. (#1639)
 - `shouldNotBeFrozen` now works in JS environment without `Window` interface. (#1571)
 - Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
 - Better error reporting when selectors provide inconsistent results (#1696)

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -94,6 +94,24 @@ function reset(recoilValue) {
   setRecoilValue(store, recoilValue, DEFAULT_VALUE);
 }
 
+testRecoil('Key is required when creating atoms', () => {
+  const devStatus = window.__DEV__;
+  window.__DEV__ = true;
+
+  // $FlowExpectedError[incompatible-call]
+  expect(() => atom({default: undefined})).toThrow();
+
+  window.__DEV__ = devStatus;
+});
+
+testRecoil('default is optional', () => {
+  const myAtom = atom({key: 'atom without default'});
+  expect(getRecoilStateLoadable(myAtom).state).toBe('loading');
+
+  act(() => set(myAtom, 'VALUE'));
+  expect(getValue(myAtom)).toBe('VALUE');
+});
+
 testRecoil('atom can read and write value', () => {
   const myAtom = atom<string>({
     key: 'atom with default',
@@ -1481,18 +1499,6 @@ testRecoil('object is frozen when stored in atom', async () => {
   });
   expect(Object.isFrozen(getValue(thawedAtom))).toBe(false);
   expect(Object.isFrozen(getValue(thawedAtom).nested)).toBe(false);
-
-  window.__DEV__ = devStatus;
-});
-
-testRecoil('Required options are provided when creating atoms', () => {
-  const devStatus = window.__DEV__;
-  window.__DEV__ = true;
-
-  // $FlowExpectedError[prop-missing]
-  expect(() => atom({default: undefined})).toThrow();
-  // $FlowExpectedError[prop-missing]
-  expect(() => atom({key: 'MISSING DEFAULT'})).toThrow();
 
   window.__DEV__ = devStatus;
 });

--- a/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -90,6 +90,10 @@ function get(recoilValue) {
   return getRecoilValueAsLoadable(store, recoilValue).contents;
 }
 
+function getLoadable(recoilValue) {
+  return getRecoilValueAsLoadable(store, recoilValue);
+}
+
 function set(recoilValue, value) {
   setRecoilValue(store, recoilValue, value);
 }
@@ -113,30 +117,40 @@ testRecoil('Works with non-overlapping sets', () => {
   expect(get(pAtom({y: 'y'}))).toBe('yValue');
 });
 
-testRecoil('Works with atom default', () => {
-  const fallbackAtom = atom({key: 'fallback', default: 0});
-  const hasFallback = atomFamily({
-    key: 'hasFallback',
-    default: fallbackAtom,
-  });
-  expect(get(hasFallback({k: 'x'}))).toBe(0);
-  set(fallbackAtom, 1);
-  expect(get(hasFallback({k: 'x'}))).toBe(1);
-  set(hasFallback({k: 'x'}), 2);
-  expect(get(hasFallback({k: 'x'}))).toBe(2);
-  expect(get(hasFallback({k: 'y'}))).toBe(1);
-});
+describe('Default', () => {
+  testRecoil('default is optional', () => {
+    const myAtom = atom({key: 'atom without default'});
+    expect(getLoadable(myAtom).state).toBe('loading');
 
-testRecoil('Works with parameterized default', () => {
-  const paramDefaultAtom = atomFamily({
-    key: 'parameterized default',
-    default: ({num}) => num,
+    act(() => set(myAtom, 'VALUE'));
+    expect(get(myAtom)).toBe('VALUE');
   });
-  expect(get(paramDefaultAtom({num: 1}))).toBe(1);
-  expect(get(paramDefaultAtom({num: 2}))).toBe(2);
-  set(paramDefaultAtom({num: 1}), 3);
-  expect(get(paramDefaultAtom({num: 1}))).toBe(3);
-  expect(get(paramDefaultAtom({num: 2}))).toBe(2);
+
+  testRecoil('Works with atom default', () => {
+    const fallbackAtom = atom({key: 'fallback', default: 0});
+    const hasFallback = atomFamily({
+      key: 'hasFallback',
+      default: fallbackAtom,
+    });
+    expect(get(hasFallback({k: 'x'}))).toBe(0);
+    set(fallbackAtom, 1);
+    expect(get(hasFallback({k: 'x'}))).toBe(1);
+    set(hasFallback({k: 'x'}), 2);
+    expect(get(hasFallback({k: 'x'}))).toBe(2);
+    expect(get(hasFallback({k: 'y'}))).toBe(1);
+  });
+
+  testRecoil('Works with parameterized default', () => {
+    const paramDefaultAtom = atomFamily({
+      key: 'parameterized default',
+      default: ({num}) => num,
+    });
+    expect(get(paramDefaultAtom({num: 1}))).toBe(1);
+    expect(get(paramDefaultAtom({num: 2}))).toBe(2);
+    set(paramDefaultAtom({num: 1}), 3);
+    expect(get(paramDefaultAtom({num: 1}))).toBe(3);
+    expect(get(paramDefaultAtom({num: 2}))).toBe(2);
+  });
 });
 
 testRecoil('Works with date as parameter', () => {

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -94,6 +94,20 @@ function resetValue(recoilState) {
   store.getState().currentTree.version++;
 }
 
+testRecoil('Required options are provided when creating selectors', () => {
+  const devStatus = window.__DEV__;
+  window.__DEV__ = true;
+
+  // $FlowExpectedError[incompatible-call]
+  expect(() => selector({get: () => {}})).toThrow();
+  // $FlowExpectedError[incompatible-call]
+  expect(() => selector({get: false})).toThrow();
+  // $FlowExpectedError[incompatible-call]
+  expect(() => selector({key: 'MISSING GET'})).toThrow();
+
+  window.__DEV__ = devStatus;
+});
+
 testRecoil('selector get', () => {
   const staticSel = constSelector('HELLO');
 
@@ -1041,20 +1055,6 @@ testRecoil('Selector values are frozen', async () => {
   expect(Object.isFrozen(getValue(fwdMixedSelector))).toBe(true);
   expect(Object.isFrozen(getValue(upstreamMixedSelector))).toBe(false);
   expect(Object.isFrozen(getValue(upstreamMixedSelector).nested)).toBe(false);
-
-  window.__DEV__ = devStatus;
-});
-
-testRecoil('Required options are provided when creating selectors', () => {
-  const devStatus = window.__DEV__;
-  window.__DEV__ = true;
-
-  // $FlowExpectedError[incompatible-call]
-  expect(() => selector({get: () => {}})).toThrow();
-  // $FlowExpectedError[incompatible-call]
-  expect(() => selector({get: false})).toThrow();
-  // $FlowExpectedError[incompatible-call]
-  expect(() => selector({key: 'MISSING GET'})).toThrow();
 
   window.__DEV__ = devStatus;
 });

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -105,13 +105,16 @@
  }) => void | (() => void);
 
  // atom.d.ts
- export interface AtomOptions<T> {
-  key: NodeKey;
-  default: RecoilValue<T> | Promise<T> | T;
-  effects?: ReadonlyArray<AtomEffect<T>>;
-  effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
-  dangerouslyAllowMutability?: boolean;
+ interface AtomOptionsWithoutDefault<T> {
+   key: NodeKey;
+   effects?: ReadonlyArray<AtomEffect<T>>;
+   effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
+   dangerouslyAllowMutability?: boolean;
  }
+ interface AtomOptionsWithDefault<T> extends AtomOptionsWithoutDefault<T> {
+   default: RecoilValue<T> | Promise<T> | T;
+ }
+ export type AtomOptions<T> = AtomOptionsWithoutDefault<T> | AtomOptionsWithDefault<T>;
 
  /**
   * Creates an atom, which represents a piece of writeable state
@@ -383,14 +386,20 @@
   | ReadonlyArray<SerializableParam>
   | Readonly<{[key: string]: SerializableParam}>;
 
- export interface AtomFamilyOptions<T, P extends SerializableParam> {
+ interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
   key: NodeKey;
   dangerouslyAllowMutability?: boolean;
-  default: RecoilValue<T> | Promise<T> | T | ((param: P) => T | RecoilValue<T> | Promise<T>);
   effects?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   effects_UNSTABLE?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
  }
+ interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam>
+   extends AtomFamilyOptionsWithoutDefault<T, P> {
+  default: RecoilValue<T> | Promise<T> | T | ((param: P) => T | RecoilValue<T> | Promise<T>);
+ }
+ export type AtomFamilyOptions<T, P extends SerializableParam> =
+   | AtomFamilyOptionsWithDefault<T, P>
+   | AtomFamilyOptionsWithoutDefault<T, P>;
 
  /**
   * Returns a function which returns a memoized atom for each unique parameter value.

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -41,9 +41,14 @@
 new DefaultValue();
 
 // atom
-const myAtom = atom({
+const myAtom: RecoilState<number> = atom({
   key: 'MyAtom',
   default: 5,
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const myAtomWithoutDefault: RecoilState<number> = atom<number>({
+  key: 'MyAtomWithoutDefault',
 });
 
 // selector
@@ -394,6 +399,10 @@ isRecoilValue(mySelector1);
   useRecoilValue(atm); // $ExpectType number
 
   myAtomFam(''); // $ExpectError
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const myAtomFamilyWithoutDefault: (number: number) => RecoilState<number> =
+    atomFamily<number, number>({key: 'MyAtomFamilyWithoutDefault'});
 }
 
 /**


### PR DESCRIPTION
Summary:
Make `default` an optional property for atoms.  If not provided the atom will initialize in a pending state until set.

This can be convenient to avoid having to make an atom with some nullable type or trying to come up with a default placeholder or using something cryptic like `default: new Promise(() => {}),`

Reviewed By: habond

Differential Revision: D34488397

