### PR TITLE
Unwrap Loadables and allow atoms/selector to have Promise/Loadable/Atom values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Breaking Changes
 
+- Selector's `get()` and Atom's `default` can now accept a `Loadable` to put the node in that state.
+  If you wish to store a `Loadable`, `Promise`, or `RecoilValue` directly you can wrap it with `selector.value()` or `atom.value()`. (#1640)
 - `useRecoilCallback()` now provides a snapshot for the latest state instead of the latest rendered state, which had bugs (#1610, #1604)
 
 ## 0.6.1 (2022-01-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - The `default` value is now optional for `atom()` and `atomFamily()`.  If not provided the atom will initialize to a pending state. (#1639)
 - Significant optimization for selector evaluations.  2x improvement with 100 dependencies, 4x with 1,000, and 40x with 10,000. (#1515, #914)
+- Automatically retain snapshots for the duration of async callbacks. (#1632)
 - `shouldNotBeFrozen` now works in JS environment without `Window` interface. (#1571)
 - Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
 - Better error reporting when selectors provide inconsistent results (#1696)

--- a/packages/recoil/adt/Recoil_Wrapper.js
+++ b/packages/recoil/adt/Recoil_Wrapper.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+recoil
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+class WrappedValue<T> {
+  value: T;
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+
+module.exports = {
+  WrappedValue,
+};

--- a/packages/recoil/recoil_values/Recoil_WaitFor.js
+++ b/packages/recoil/recoil_values/Recoil_WaitFor.js
@@ -21,6 +21,7 @@ const {
   loadableWithPromise,
   loadableWithValue,
 } = require('../adt/Recoil_Loadable');
+const selector = require('./Recoil_selector');
 const selectorFamily = require('./Recoil_selectorFamily');
 const isPromise = require('recoil-shared/util/Recoil_isPromise');
 
@@ -306,11 +307,13 @@ const noWait: (
     dependency =>
     ({get}) => {
       try {
-        return loadableWithValue(get(dependency));
+        return selector.value(loadableWithValue(get(dependency)));
       } catch (exception) {
-        return isPromise(exception)
-          ? loadableWithPromise(exception)
-          : loadableWithError(exception);
+        return selector.value(
+          isPromise(exception)
+            ? loadableWithPromise(exception)
+            : loadableWithError(exception),
+        );
       }
     },
   dangerouslyAllowMutability: true,

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+import type {Loadable} from '../adt/Recoil_Loadable';
+import type {WrappedValue} from '../adt/Recoil_Wrapper';
 import type {CachePolicyWithoutEviction} from '../caches/Recoil_CachePolicy';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
 import type {RetainedBy} from '../core/Recoil_RetainedBy';
@@ -58,6 +60,8 @@ export type AtomFamilyOptions<T, P: Parameter> =
       default:
         | RecoilValue<T>
         | Promise<T>
+        | Loadable<T>
+        | WrappedValue<T>
         | T
         | (P => T | RecoilValue<T> | Promise<T>),
     }>
@@ -111,11 +115,13 @@ function atomFamily<T, P: Parameter>(
     const optionsDefault:
       | RecoilValue<T>
       | Promise<T>
+      | Loadable<T>
+      | WrappedValue<T>
       | T
       | (P => T | RecoilValue<T> | Promise<T>) =
       'default' in options
         ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
-          // $FlowFixMe[incompatible-type]
+          // $FlowIssue[incompatible-type] No way to refine in Flow that property is not defined
           options.default
         : new Promise(() => {});
 

--- a/packages/recoil/recoil_values/Recoil_selectorFamily.js
+++ b/packages/recoil/recoil_values/Recoil_selectorFamily.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+import type {Loadable} from '../adt/Recoil_Loadable';
+import type {WrappedValue} from '../adt/Recoil_Wrapper';
 import type {
   CachePolicy,
   CachePolicyWithoutEviction,
@@ -59,7 +61,7 @@ export type ReadOnlySelectorFamilyOptions<T, P: Parameter> = $ReadOnly<{
   get: P => ({
     get: GetRecoilValue,
     getCallback: GetCallback<T>,
-  }) => Promise<T> | RecoilValue<T> | T,
+  }) => Promise<T> | Loadable<T> | WrappedValue<T> | RecoilValue<T> | T,
 }>;
 
 export type ReadWriteSelectorFamilyOptions<T, P: Parameter> = $ReadOnly<{

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -398,7 +398,13 @@ const testGKs =
   };
 
 const WWW_GKS_TO_TEST = QUICK_TEST
-  ? [['recoil_hamt_2020', 'recoil_sync_external_store']]
+  ? [
+      [
+        'recoil_hamt_2020',
+        'recoil_sync_external_store',
+        'recoil_memory_managament_2020',
+      ],
+    ]
   : [
       // OSS for React <18:
       ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -77,6 +77,11 @@
   reset: ResetRecoilState;
  }
 
+ declare const WrappedValue_OPAQUE: unique symbol;
+ export interface WrappedValue<T> {
+   readonly [WrappedValue_OPAQUE]: true;
+ }
+
  // Effect is called the first time a node is used with a <RecoilRoot>
  export type AtomEffect<T> = (param: {
   node: RecoilState<T>,
@@ -112,7 +117,7 @@
    dangerouslyAllowMutability?: boolean;
  }
  interface AtomOptionsWithDefault<T> extends AtomOptionsWithoutDefault<T> {
-   default: RecoilValue<T> | Promise<T> | T;
+   default: RecoilValue<T> | Promise<T> | Loadable<T> | WrappedValue<T> | T;
  }
  export type AtomOptions<T> = AtomOptionsWithoutDefault<T> | AtomOptionsWithDefault<T>;
 
@@ -120,6 +125,9 @@
   * Creates an atom, which represents a piece of writeable state
   */
  export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
+ export namespace atom {
+  function value<T>(value: T): WrappedValue<T>;
+ }
 
  export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
  export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
@@ -175,7 +183,7 @@
     get: (opts: {
       get: GetRecoilValue,
       getCallback: GetCallback,
-    }) => Promise<T> | RecoilValue<T> | T;
+    }) => Promise<T> | RecoilValue<T> | Loadable<T> | WrappedValue<T> | T;
     dangerouslyAllowMutability?: boolean;
     cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
  }
@@ -196,6 +204,9 @@
   */
  export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<T>;
  export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
+ export namespace selector {
+  function value<T>(value: T): WrappedValue<T>;
+ }
 
  // hooks.d.ts
 
@@ -386,20 +397,25 @@
   | ReadonlyArray<SerializableParam>
   | Readonly<{[key: string]: SerializableParam}>;
 
- interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
+interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
   key: NodeKey;
   dangerouslyAllowMutability?: boolean;
   effects?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   effects_UNSTABLE?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
- }
- interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam>
-   extends AtomFamilyOptionsWithoutDefault<T, P> {
-  default: RecoilValue<T> | Promise<T> | T | ((param: P) => T | RecoilValue<T> | Promise<T>);
- }
- export type AtomFamilyOptions<T, P extends SerializableParam> =
-   | AtomFamilyOptionsWithDefault<T, P>
-   | AtomFamilyOptionsWithoutDefault<T, P>;
+  }
+  interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam> extends AtomFamilyOptionsWithoutDefault<T, P> {
+  default:
+    | RecoilValue<T>
+    | Promise<T>
+    | Loadable<T>
+    | WrappedValue<T>
+    | T
+    | ((param: P) => T | RecoilValue<T> | Promise<T>);
+  }
+  export type AtomFamilyOptions<T, P extends SerializableParam> =
+    | AtomFamilyOptionsWithDefault<T, P>
+    | AtomFamilyOptionsWithoutDefault<T, P>;
 
  /**
   * Returns a function which returns a memoized atom for each unique parameter value.
@@ -413,7 +429,7 @@
   get: (param: P) => (opts: {
     get: GetRecoilValue,
     getCallback: GetCallback,
-  }) => Promise<T> | RecoilValue<T> | T;
+  }) => Promise<T> | RecoilValue<T> | Loadable<T> | WrappedValue<T> | T;
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
   cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
   dangerouslyAllowMutability?: boolean;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -13,7 +13,7 @@
   constSelector, DefaultValue,
   errorSelector, isRecoilValue,
   noWait, readOnlySelector, RecoilBridge, RecoilRoot,
-  RecoilState, RecoilValueReadOnly,
+  RecoilValue, RecoilState, RecoilValueReadOnly,
   selector,
   selectorFamily,
   Snapshot,
@@ -46,21 +46,44 @@ const myAtom: RecoilState<number> = atom({
   default: 5,
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const myAtomWithoutDefault: RecoilState<number> = atom<number>({
   key: 'MyAtomWithoutDefault',
 });
 
+{
+  const atom1: RecoilState<number> = atom<number>({
+    key: 'Key',
+    default: RecoilLoadable.of(123),
+  });
+
+  const atom2: RecoilState<number> = atom({
+    key: 'Key',
+    default: atom.value(123),
+  });
+}
+
 // selector
-const mySelector1 = selector({
+const mySelector1: RecoilValue<number> = selector({
   key: 'MySelector1',
   get: () => 5,
 });
 
-const mySelector2 = selector({
+const mySelector2: RecoilValue<string> = selector({
   key: 'MySelector2',
   get: () => '',
 });
+
+{
+  const mySelector3: RecoilValue<number> = selector({
+    key: 'MySelector3',
+    get: () => RecoilLoadable.of(123),
+  });
+
+  const mySelector4: RecoilValue<number> = selector({
+    key: 'MySelector3',
+    get: () => selector.value(123),
+  });
+}
 
 // $ExpectError
 selector({


### PR DESCRIPTION
Summary:
Add the ability for Atom defaults and Selector `get()` to return a `Loadable` object and take the state of the loadable.  This allows them to more cleanly accept error states, mapped loadables, etc.

```
const myAtom = atom({
  key: 'Key',
  default: RecoilLoadable.error('ERROR'),
});
```

For storing `Promsie`, `Loadable`, or `RecoilValue` objects direclty as values in atoms and selectors you can now wrap them with `atom.value()` or `selector.value()`

```
const mySelector = selector({
  key: 'Key',
  get: ({get}) => {
    return selector.value(Promise.resolve('Promise as a value'));
  },
});
```

While `RecoilLoaable.of()` allows you to nest `Promise`s, you cannot nest other combinations.  I actually implemented that to work, but it confuses Flow and makes it harder to automatically infer atom/selector types without requiring more user annotations.

Differential Revision: D34497205

