### PR TITLE
Optimize Selector Tree Cache

### DIFF
--- a/packages/recoil/caches/Recoil_TreeCache.js
+++ b/packages/recoil/caches/Recoil_TreeCache.js
@@ -21,7 +21,6 @@ import type {
 } from './Recoil_TreeCacheImplementationType';
 
 const err = require('recoil-shared/util/Recoil_err');
-const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
 export type Options<T> = {
@@ -31,6 +30,11 @@ export type Options<T> = {
 };
 
 class ChangedPathError extends Error {}
+
+const CHANGED_PATH_ERROR_MESSAGE =
+  'Invalid cache values.  This happens when selectors do not return ' +
+  'consistent values for the same input dependency values.  That may be ' +
+  'caused when using Fast Refresh to change a selector implementation.';
 
 class TreeCache<T = mixed> {
   _numLeafs: number;
@@ -66,79 +70,166 @@ class TreeCache<T = mixed> {
     getNodeValue: NodeValueGet,
     handlers?: GetHandlers<T>,
   ): ?TreeCacheLeaf<T> {
-    return findLeaf<T>(
-      this.root(),
-      nodeKey => this._mapNodeValue(getNodeValue(nodeKey)),
-      {
-        onNodeVisit: node => {
-          handlers?.onNodeVisit(node);
+    if (this._root == null) {
+      return undefined;
+    }
 
-          if (node.type === 'leaf') {
-            this._onHit(node);
-          }
-        },
-      },
-    );
+    // Iterate down the tree based on the current node values until we hit a leaf
+    let node = this._root;
+    while (node) {
+      handlers?.onNodeVisit(node);
+      if (node.type === 'leaf') {
+        this._onHit(node);
+        return node;
+      }
+      const nodeValue = this._mapNodeValue(getNodeValue(node.nodeKey));
+      node = node.branches.get(nodeValue);
+    }
+    return undefined;
   }
 
   set(route: NodeCacheRoute, value: T, handlers?: SetHandlers<T>): void {
-    let leafNode: TreeCacheLeaf<T>;
-    const retryableSet = () => {
-      this._root = addLeaf(
-        this.root(),
-        route.map(([nodeKey, nodeValue]) => [
+    const addLeaf = () => {
+      // Iterate down the tree following the provided route
+      let node: ?TreeCacheBranch<T>;
+      let branchKey;
+      for (const [nodeKey, nodeValue] of route) {
+        // If the previous root was a leaf while we not have a get() it means
+        // the selector has inconsistent values or implementation changed.
+        const root = this._root;
+        if (root?.type === 'leaf') {
+          recoverableViolation(
+            CHANGED_PATH_ERROR_MESSAGE + '  Resetting cache.',
+            'recoil',
+          );
+          throw new ChangedPathError();
+        }
+
+        // node now refers to the next node down the tree
+        const parent = node;
+        node = parent ? parent.branches.get(branchKey) : root;
+        node = node ?? {
+          type: 'branch',
           nodeKey,
-          this._mapNodeValue(nodeValue),
-        ]),
-        null,
+          parent,
+          branches: new Map(),
+          branchKey,
+        };
+
+        // Confirm node is consistent if it was an existing node
+        if (node.type !== 'branch' || node.nodeKey !== nodeKey) {
+          recoverableViolation(
+            CHANGED_PATH_ERROR_MESSAGE + '  Resetting cache.',
+            'recoil',
+          );
+          throw new ChangedPathError();
+        }
+
+        // Add the node to the tree
+        node.parent?.branches.set(branchKey, node);
+        handlers?.onNodeVisit?.(node);
+
+        // Prepare for next iteration and install root if it is new.
+        branchKey = this._mapNodeValue(nodeValue);
+        this._root = this._root ?? node;
+      }
+
+      // If there is an existing leaf down our route confirm it is consistent
+      const oldLeaf: ?TreeCacheNode<T> = node
+        ? node?.branches.get(branchKey)
+        : this._root;
+      if (
+        oldLeaf != null &&
+        (oldLeaf.type !== 'leaf' || oldLeaf.branchKey !== branchKey)
+      ) {
+        if (__DEV__) {
+          throw err(CHANGED_PATH_ERROR_MESSAGE);
+        }
+        recoverableViolation(
+          CHANGED_PATH_ERROR_MESSAGE + '  Resetting cache.',
+          'recoil',
+        );
+        throw new ChangedPathError();
+      }
+
+      // Create a new or replacement leaf.
+      const leafNode = {
+        type: 'leaf',
         value,
-        null,
-        {
-          onNodeVisit: node => {
-            handlers?.onNodeVisit(node);
-            if (node.type === 'leaf') {
-              leafNode = node;
-            }
-          },
-        },
-      );
+        parent: node,
+        branchKey,
+      };
+
+      // Install the leaf and call handlers
+      node?.branches.set(branchKey, leafNode);
+      this._root = this._root ?? leafNode;
+      this._numLeafs++;
+      this._onSet(leafNode);
+      handlers?.onNodeVisit?.(leafNode);
     };
+
     try {
-      retryableSet();
+      addLeaf();
     } catch (error) {
+      // If the cache was stale or observed inconsistent values, then clear
+      // it and rebuild with the new values.
       if (error instanceof ChangedPathError) {
-        // If the cache was stale or observed inconsistent values, then clear
-        // it and rebuild with the new values.
         this.clear();
-        retryableSet();
+        addLeaf();
       } else {
         throw error;
       }
     }
-
-    this._numLeafs++;
-    this._onSet(nullthrows(leafNode, 'Error adding to selector cache'));
   }
 
-  delete(node: TreeCacheNode<T>): boolean {
+  // Returns true if leaf was actually deleted from the tree
+  delete(leaf: TreeCacheLeaf<T>): boolean {
     const root = this.root();
     if (!root) {
       return false;
     }
 
-    const existsInTree = pruneNodeFromTree(root, node);
-    if (!existsInTree) {
-      return false;
-    }
-
-    if (node === root || (root.type === 'branch' && !root.branches.size)) {
+    if (leaf === root) {
       this._root = null;
       this._numLeafs = 0;
-
       return true;
     }
 
-    this._numLeafs -= countDownstreamLeaves(node);
+    // Iterate up from the leaf deleteing it from it's parent's branches.
+    let node = leaf.parent;
+    let branchKey = leaf.branchKey;
+    while (node) {
+      node.branches.delete(branchKey);
+      // Stop iterating if we hit the root.
+      if (node === root) {
+        if (node.branches.size === 0) {
+          this._root = null;
+          this._numLeafs = 0;
+        } else {
+          this._numLeafs--;
+        }
+        return true;
+      }
+
+      // Stop iterating if there are other branches since we don't need to
+      // remove any more nodes.
+      if (node.branches.size > 0) {
+        break;
+      }
+
+      // Iterate up to our parent
+      branchKey = node?.branchKey;
+      node = node.parent;
+    }
+
+    // Confirm that the leaf we are deleting is actually attached to our tree
+    for (; node !== root; node = node.parent) {
+      if (node == null) {
+        return false;
+      }
+    }
+
+    this._numLeafs--;
     return true;
   }
 
@@ -147,137 +238,5 @@ class TreeCache<T = mixed> {
     this._root = null;
   }
 }
-
-const findLeaf = <T>(
-  root: ?TreeCacheNode<T>,
-  getNodeValue: NodeValueGet,
-  handlers?: GetHandlers<T>,
-): ?TreeCacheLeaf<T> => {
-  if (root == null) {
-    return undefined;
-  }
-
-  handlers?.onNodeVisit?.(root);
-
-  if (root.type === 'leaf') {
-    return root;
-  }
-
-  const nodeValue = getNodeValue(root.nodeKey);
-  return findLeaf(root.branches.get(nodeValue), getNodeValue, handlers);
-};
-
-// Returns the current or replaced root node.
-const addLeaf = <T>(
-  root: ?TreeCacheNode<T>,
-  route: NodeCacheRoute,
-  parent: ?TreeCacheBranch<T>,
-  value: T,
-  branchKey: ?mixed,
-  handlers?: SetHandlers<T>,
-): TreeCacheNode<T> => {
-  let node;
-
-  // New cache route, make new nodes
-  if (root == null) {
-    if (route.length === 0) {
-      node = {type: 'leaf', value, parent, branchKey};
-    } else {
-      const [[nodeKey, nodeValue], ...rest] = route;
-      node = {
-        type: 'branch',
-        nodeKey,
-        parent,
-        branches: new Map(),
-        branchKey,
-      };
-
-      node.branches.set(
-        nodeValue,
-        addLeaf(null, rest, node, value, nodeValue, handlers),
-      );
-    }
-
-    // Follow an existing cache route
-  } else {
-    node = root;
-
-    const changedPathError =
-      'Invalid cache values.  This happens when selectors do not return ' +
-      'consistent values for the same input dependency values.  That may be ' +
-      'caused when using Fast Refresh to change a selector implementation.';
-
-    if (route.length) {
-      const [[nodeKey, nodeValue], ...rest] = route;
-
-      if (node.type !== 'branch' || node.nodeKey !== nodeKey) {
-        recoverableViolation(changedPathError + '  Resetting cache.', 'recoil');
-        throw new ChangedPathError();
-      }
-
-      node.branches.set(
-        nodeValue,
-        addLeaf(
-          node.branches.get(nodeValue),
-          rest,
-          node,
-          value,
-          nodeValue,
-          handlers,
-        ),
-      );
-    } else {
-      if (node.type !== 'leaf' || node.branchKey !== branchKey) {
-        if (__DEV__) {
-          throw err(changedPathError);
-        }
-        recoverableViolation(changedPathError + '  Resetting cache.', 'recoil');
-        throw new ChangedPathError();
-      }
-    }
-  }
-
-  handlers?.onNodeVisit?.(node);
-  return node;
-};
-
-// Returns true if node was deleted from the tree
-const pruneNodeFromTree = <T>(
-  root: TreeCacheNode<T>,
-  node: TreeCacheNode<T>,
-): boolean => {
-  const {parent} = node;
-  if (!parent) {
-    return root === node;
-  }
-
-  parent.branches.delete(node.branchKey);
-
-  return pruneUpstreamBranches(root, parent);
-};
-
-const pruneUpstreamBranches = <T>(
-  root: TreeCacheNode<T>,
-  branchNode: TreeCacheBranch<T>,
-): boolean => {
-  const {parent} = branchNode;
-  if (!parent) {
-    return root === branchNode;
-  }
-
-  if (branchNode.branches.size === 0) {
-    parent.branches.delete(branchNode.branchKey);
-  }
-
-  return pruneUpstreamBranches(root, parent);
-};
-
-const countDownstreamLeaves = <T>(node: TreeCacheNode<T>): number =>
-  node.type === 'leaf'
-    ? 1
-    : Array.from(node.branches.values()).reduce(
-        (sum, currNode) => sum + countDownstreamLeaves(currNode),
-        0,
-      );
 
 module.exports = {TreeCache};

--- a/packages/recoil/caches/Recoil_TreeCacheImplementationType.js
+++ b/packages/recoil/caches/Recoil_TreeCacheImplementationType.js
@@ -19,7 +19,7 @@ export type TreeCacheNode<T> = TreeCacheLeaf<T> | TreeCacheBranch<T>;
 export type TreeCacheLeaf<T> = {
   type: 'leaf',
   value: T,
-  branchKey?: ?mixed,
+  branchKey?: mixed,
   parent: ?TreeCacheBranch<T>,
 };
 
@@ -27,7 +27,7 @@ export type TreeCacheBranch<T> = {
   type: 'branch',
   nodeKey: NodeKey,
   branches: Map<mixed, TreeCacheNode<T>>,
-  branchKey?: ?mixed,
+  branchKey?: mixed,
   parent: ?TreeCacheBranch<T>,
 };
 
@@ -64,7 +64,7 @@ export type SetHandlers<T> = {
 export interface TreeCacheImplementation<T> {
   +get: (NodeValueGet, handlers?: GetHandlers<T>) => ?T;
   +set: (NodeCacheRoute, T, handlers?: SetHandlers<T>) => void;
-  +delete: (TreeCacheNode<T>) => boolean;
+  +delete: (TreeCacheLeaf<T>) => boolean;
   +clear: () => void;
   +root: () => ?TreeCacheNode<T>;
   +size: () => number;

--- a/packages/recoil/caches/__tests__/Recoil_TreeCache-test.js
+++ b/packages/recoil/caches/__tests__/Recoil_TreeCache-test.js
@@ -77,13 +77,14 @@ describe('TreeCache', () => {
 
     const [route2, loadable2] = [
       [
-        ['a', 3],
+        ['a', 2],
         ['b', 4],
+        ['c', 5],
       ],
       loadableWithValue('value2'),
     ];
 
-    const [route3, loadable3] = [[['a', 4]], loadableWithValue('value3')];
+    const [route3, loadable3] = [[['a', 6]], loadableWithValue('value3')];
 
     cache.set(route1, loadable1);
     cache.set(route2, loadable2);
@@ -112,23 +113,19 @@ describe('TreeCache', () => {
     expect(cache.size()).toBe(3);
 
     const deleted1 = cache.delete(leaf1Node);
-
     expect(deleted1).toBe(true);
     expect(cache.size()).toBe(2);
 
     const deleted2 = cache.delete(leaf2Node);
-
     expect(deleted2).toBe(true);
     expect(cache.size()).toBe(1);
 
     const deleted3 = cache.delete(leaf3Node);
-
     expect(deleted3).toBe(true);
     expect(cache.size()).toBe(0);
     expect(cache.root()).toBeNull();
 
     const deletedAgain = cache.delete(leaf1Node);
-
     expect(deletedAgain).toBe(false);
   });
 
@@ -241,5 +238,24 @@ describe('TreeCache', () => {
     ]);
 
     expect(resultWithKeyCopy).toBe(loadable1);
+  });
+
+  // Test ability to scale cache to large number of entries.
+  // Use more dependencies than the JavaScript callstack depth limit to ensure
+  // we are not using a recursive algorithm.
+  testRecoil('Scalability', () => {
+    const cache = new TreeCache();
+
+    const route = Array.from(Array(10000).keys()).map(i => [
+      String(i),
+      String(i),
+    ]);
+
+    cache.set(route, 'VALUE');
+
+    expect(cache.get(x => x)).toBe('VALUE');
+
+    const leafNode = cache.getLeafNode(x => x);
+    expect(cache.delete(nullthrows(leafNode))).toBe(true);
   });
 });


### PR DESCRIPTION
Summary: Optimize the selector tree cache to use an iterative vs a recursive algorithm.  This hurts readability, but is important to allow more selector dependencies than the JavaScript callstack depth limit.

Differential Revision: D34633750

