### PR TITLE
fix typo in comment "snapahot" to "snapshot"

### DIFF
--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -327,7 +327,7 @@ function freshSnapshot(initializeState?: MutableSnapshot => void): Snapshot {
   return initializeState != null ? snapshot.map(initializeState) : snapshot;
 }
 
-// Factory to clone a snapahot state
+// Factory to clone a snapshot state
 const [memoizedCloneSnapshot, invalidateMemoizedSnapshot] =
   memoizeOneWithArgsHashAndInvalidation(
     (store, version) => {


### PR DESCRIPTION
Summary: Fix typo

Reviewed By: habond

Differential Revision: D24593800

