### PR TITLE
Suppress console message with Fast Refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 **_Add new changes here as they land_**
 
 - The `default` value is now optional for `atom()` and `atomFamily()`.  If not provided the atom will initialize to a pending state. (#1639)
+- Significant optimization for selector evaluations.  2x improvement with 100 dependencies, 4x with 1,000, and 40x with 10,000. (#1515, #914)
 - `shouldNotBeFrozen` now works in JS environment without `Window` interface. (#1571)
 - Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
 - Better error reporting when selectors provide inconsistent results (#1696)
@@ -35,6 +36,7 @@
 - Add `.isRetained()` method for Snapshots and check if snapshot is already released when using `.retain()` (#1546)
 
 ### Other Fixes and Optimizations
+
 - Reduce overhead of snapshot cloning
   - Only clone the current snapshot for callbacks if the callback actually uses it. (#1501)
   - Cache the cloned snapshots from callbacks unless there was a state change. (#1533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Avoid spurious console errors from effects when calling `setSelf()` from `onSet()` handlers. (#1589)
 - Better error reporting when selectors provide inconsistent results (#1696)
 - Add `getStoreID()` method to `Snapshot` (#1612)
+- Optimize selector caches to support thousands of dependencies. (#1651)
 
 ### Breaking Changes
 

--- a/packages/recoil/caches/Recoil_TreeCache.js
+++ b/packages/recoil/caches/Recoil_TreeCache.js
@@ -20,6 +20,7 @@ import type {
   TreeCacheNode,
 } from './Recoil_TreeCacheImplementationType';
 
+const {isFastRefreshEnabled} = require('../core/Recoil_ReactMode');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
 export type Options<T> = {
@@ -30,11 +31,17 @@ export type Options<T> = {
 
 class ChangedPathError extends Error {}
 
-const CHANGED_PATH_ERROR_MESSAGE =
-  'Invalid cache values.  This happens when selectors do not return ' +
-  'consistent values for the same input dependency values.  That may be ' +
-  'caused when using Fast Refresh to change a selector implementation.  ' +
-  'Resetting cache.';
+function invalidCacheError() {
+  const CHANGED_PATH_ERROR_MESSAGE =
+    'Invalid cache values.  This happens when selectors do not return ' +
+    'consistent values for the same input dependency values.  That may be ' +
+    'caused when using Fast Refresh to change a selector implementation.  ' +
+    'Resetting cache.';
+  if (!isFastRefreshEnabled()) {
+    recoverableViolation(CHANGED_PATH_ERROR_MESSAGE, 'recoil');
+  }
+  throw new ChangedPathError();
+}
 
 class TreeCache<T = mixed> {
   _numLeafs: number;
@@ -55,8 +62,6 @@ class TreeCache<T = mixed> {
   size(): number {
     return this._numLeafs;
   }
-
-  // TODO: nodeCount(): number
 
   root(): TreeCacheNode<T> | null {
     return this._root;
@@ -100,8 +105,7 @@ class TreeCache<T = mixed> {
         // the selector has inconsistent values or implementation changed.
         const root = this._root;
         if (root?.type === 'leaf') {
-          recoverableViolation(CHANGED_PATH_ERROR_MESSAGE, 'recoil');
-          throw new ChangedPathError();
+          throw invalidCacheError();
         }
 
         // node now refers to the next node down in the tree
@@ -117,8 +121,7 @@ class TreeCache<T = mixed> {
 
         // If we found an existing node, confirm it has a consistent value
         if (node.type !== 'branch' || node.nodeKey !== nodeKey) {
-          recoverableViolation(CHANGED_PATH_ERROR_MESSAGE, 'recoil');
-          throw new ChangedPathError();
+          throw invalidCacheError();
         }
 
         // Add the branch node to the tree
@@ -140,8 +143,7 @@ class TreeCache<T = mixed> {
         oldLeaf != null &&
         (oldLeaf.type !== 'leaf' || oldLeaf.branchKey !== branchKey)
       ) {
-        recoverableViolation(CHANGED_PATH_ERROR_MESSAGE, 'recoil');
-        throw new ChangedPathError();
+        throw invalidCacheError();
       }
 
       // Create a new or replacement leaf.

--- a/packages/recoil/caches/Recoil_TreeCache.js
+++ b/packages/recoil/caches/Recoil_TreeCache.js
@@ -20,8 +20,6 @@ import type {
   TreeCacheNode,
 } from './Recoil_TreeCacheImplementationType';
 
-const err = require('recoil-shared/util/Recoil_err');
-const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
 export type Options<T> = {
@@ -31,6 +29,12 @@ export type Options<T> = {
 };
 
 class ChangedPathError extends Error {}
+
+const CHANGED_PATH_ERROR_MESSAGE =
+  'Invalid cache values.  This happens when selectors do not return ' +
+  'consistent values for the same input dependency values.  That may be ' +
+  'caused when using Fast Refresh to change a selector implementation.  ' +
+  'Resetting cache.';
 
 class TreeCache<T = mixed> {
   _numLeafs: number;
@@ -66,79 +70,158 @@ class TreeCache<T = mixed> {
     getNodeValue: NodeValueGet,
     handlers?: GetHandlers<T>,
   ): ?TreeCacheLeaf<T> {
-    return findLeaf<T>(
-      this.root(),
-      nodeKey => this._mapNodeValue(getNodeValue(nodeKey)),
-      {
-        onNodeVisit: node => {
-          handlers?.onNodeVisit(node);
+    if (this._root == null) {
+      return undefined;
+    }
 
-          if (node.type === 'leaf') {
-            this._onHit(node);
-          }
-        },
-      },
-    );
+    // Iterate down the tree based on the current node values until we hit a leaf
+    let node = this._root;
+    while (node) {
+      handlers?.onNodeVisit(node);
+      if (node.type === 'leaf') {
+        this._onHit(node);
+        return node;
+      }
+      const nodeValue = this._mapNodeValue(getNodeValue(node.nodeKey));
+      node = node.branches.get(nodeValue);
+    }
+    return undefined;
   }
 
   set(route: NodeCacheRoute, value: T, handlers?: SetHandlers<T>): void {
-    let leafNode: TreeCacheLeaf<T>;
-    const retryableSet = () => {
-      this._root = addLeaf(
-        this.root(),
-        route.map(([nodeKey, nodeValue]) => [
+    const addLeaf = () => {
+      // First, setup the branch nodes for the route:
+
+      // Iterate down the tree to find or add branch nodes following the route
+      let node: ?TreeCacheBranch<T>;
+      let branchKey;
+      for (const [nodeKey, nodeValue] of route) {
+        // If the previous root was a leaf, while we not have a get(), it means
+        // the selector has inconsistent values or implementation changed.
+        const root = this._root;
+        if (root?.type === 'leaf') {
+          recoverableViolation(CHANGED_PATH_ERROR_MESSAGE, 'recoil');
+          throw new ChangedPathError();
+        }
+
+        // node now refers to the next node down in the tree
+        const parent = node;
+        node = parent ? parent.branches.get(branchKey) : root;
+        node = node ?? {
+          type: 'branch',
           nodeKey,
-          this._mapNodeValue(nodeValue),
-        ]),
-        null,
+          parent,
+          branches: new Map(),
+          branchKey,
+        };
+
+        // If we found an existing node, confirm it has a consistent value
+        if (node.type !== 'branch' || node.nodeKey !== nodeKey) {
+          recoverableViolation(CHANGED_PATH_ERROR_MESSAGE, 'recoil');
+          throw new ChangedPathError();
+        }
+
+        // Add the branch node to the tree
+        parent?.branches.set(branchKey, node);
+        handlers?.onNodeVisit?.(node);
+
+        // Prepare for next iteration and install root if it is new.
+        branchKey = this._mapNodeValue(nodeValue);
+        this._root = this._root ?? node;
+      }
+
+      // Second, setup the leaf node:
+
+      // If there is an existing leaf for this route confirm it is consistent
+      const oldLeaf: ?TreeCacheNode<T> = node
+        ? node?.branches.get(branchKey)
+        : this._root;
+      if (
+        oldLeaf != null &&
+        (oldLeaf.type !== 'leaf' || oldLeaf.branchKey !== branchKey)
+      ) {
+        recoverableViolation(CHANGED_PATH_ERROR_MESSAGE, 'recoil');
+        throw new ChangedPathError();
+      }
+
+      // Create a new or replacement leaf.
+      const leafNode = {
+        type: 'leaf',
         value,
-        null,
-        {
-          onNodeVisit: node => {
-            handlers?.onNodeVisit(node);
-            if (node.type === 'leaf') {
-              leafNode = node;
-            }
-          },
-        },
-      );
+        parent: node,
+        branchKey,
+      };
+
+      // Install the leaf and call handlers
+      node?.branches.set(branchKey, leafNode);
+      this._root = this._root ?? leafNode;
+      this._numLeafs++;
+      this._onSet(leafNode);
+      handlers?.onNodeVisit?.(leafNode);
     };
+
     try {
-      retryableSet();
+      addLeaf();
     } catch (error) {
+      // If the cache was stale or observed inconsistent values, such as with
+      // Fast Refresh, then clear it and rebuild with the new values.
       if (error instanceof ChangedPathError) {
-        // If the cache was stale or observed inconsistent values, then clear
-        // it and rebuild with the new values.
         this.clear();
-        retryableSet();
+        addLeaf();
       } else {
         throw error;
       }
     }
-
-    this._numLeafs++;
-    this._onSet(nullthrows(leafNode, 'Error adding to selector cache'));
   }
 
-  delete(node: TreeCacheNode<T>): boolean {
+  // Returns true if leaf was actually deleted from the tree
+  delete(leaf: TreeCacheLeaf<T>): boolean {
     const root = this.root();
     if (!root) {
       return false;
     }
 
-    const existsInTree = pruneNodeFromTree(root, node);
-    if (!existsInTree) {
-      return false;
-    }
-
-    if (node === root || (root.type === 'branch' && !root.branches.size)) {
+    if (leaf === root) {
       this._root = null;
       this._numLeafs = 0;
-
       return true;
     }
 
-    this._numLeafs -= countDownstreamLeaves(node);
+    // Iterate up from the leaf deleteing it from it's parent's branches.
+    let node = leaf.parent;
+    let branchKey = leaf.branchKey;
+    while (node) {
+      node.branches.delete(branchKey);
+      // Stop iterating if we hit the root.
+      if (node === root) {
+        if (node.branches.size === 0) {
+          this._root = null;
+          this._numLeafs = 0;
+        } else {
+          this._numLeafs--;
+        }
+        return true;
+      }
+
+      // Stop iterating if there are other branches since we don't need to
+      // remove any more nodes.
+      if (node.branches.size > 0) {
+        break;
+      }
+
+      // Iterate up to our parent
+      branchKey = node?.branchKey;
+      node = node.parent;
+    }
+
+    // Confirm that the leaf we are deleting is actually attached to our tree
+    for (; node !== root; node = node.parent) {
+      if (node == null) {
+        return false;
+      }
+    }
+
+    this._numLeafs--;
     return true;
   }
 
@@ -147,137 +230,5 @@ class TreeCache<T = mixed> {
     this._root = null;
   }
 }
-
-const findLeaf = <T>(
-  root: ?TreeCacheNode<T>,
-  getNodeValue: NodeValueGet,
-  handlers?: GetHandlers<T>,
-): ?TreeCacheLeaf<T> => {
-  if (root == null) {
-    return undefined;
-  }
-
-  handlers?.onNodeVisit?.(root);
-
-  if (root.type === 'leaf') {
-    return root;
-  }
-
-  const nodeValue = getNodeValue(root.nodeKey);
-  return findLeaf(root.branches.get(nodeValue), getNodeValue, handlers);
-};
-
-// Returns the current or replaced root node.
-const addLeaf = <T>(
-  root: ?TreeCacheNode<T>,
-  route: NodeCacheRoute,
-  parent: ?TreeCacheBranch<T>,
-  value: T,
-  branchKey: ?mixed,
-  handlers?: SetHandlers<T>,
-): TreeCacheNode<T> => {
-  let node;
-
-  // New cache route, make new nodes
-  if (root == null) {
-    if (route.length === 0) {
-      node = {type: 'leaf', value, parent, branchKey};
-    } else {
-      const [[nodeKey, nodeValue], ...rest] = route;
-      node = {
-        type: 'branch',
-        nodeKey,
-        parent,
-        branches: new Map(),
-        branchKey,
-      };
-
-      node.branches.set(
-        nodeValue,
-        addLeaf(null, rest, node, value, nodeValue, handlers),
-      );
-    }
-
-    // Follow an existing cache route
-  } else {
-    node = root;
-
-    const changedPathError =
-      'Invalid cache values.  This happens when selectors do not return ' +
-      'consistent values for the same input dependency values.  That may be ' +
-      'caused when using Fast Refresh to change a selector implementation.';
-
-    if (route.length) {
-      const [[nodeKey, nodeValue], ...rest] = route;
-
-      if (node.type !== 'branch' || node.nodeKey !== nodeKey) {
-        recoverableViolation(changedPathError + '  Resetting cache.', 'recoil');
-        throw new ChangedPathError();
-      }
-
-      node.branches.set(
-        nodeValue,
-        addLeaf(
-          node.branches.get(nodeValue),
-          rest,
-          node,
-          value,
-          nodeValue,
-          handlers,
-        ),
-      );
-    } else {
-      if (node.type !== 'leaf' || node.branchKey !== branchKey) {
-        if (__DEV__) {
-          throw err(changedPathError);
-        }
-        recoverableViolation(changedPathError + '  Resetting cache.', 'recoil');
-        throw new ChangedPathError();
-      }
-    }
-  }
-
-  handlers?.onNodeVisit?.(node);
-  return node;
-};
-
-// Returns true if node was deleted from the tree
-const pruneNodeFromTree = <T>(
-  root: TreeCacheNode<T>,
-  node: TreeCacheNode<T>,
-): boolean => {
-  const {parent} = node;
-  if (!parent) {
-    return root === node;
-  }
-
-  parent.branches.delete(node.branchKey);
-
-  return pruneUpstreamBranches(root, parent);
-};
-
-const pruneUpstreamBranches = <T>(
-  root: TreeCacheNode<T>,
-  branchNode: TreeCacheBranch<T>,
-): boolean => {
-  const {parent} = branchNode;
-  if (!parent) {
-    return root === branchNode;
-  }
-
-  if (branchNode.branches.size === 0) {
-    parent.branches.delete(branchNode.branchKey);
-  }
-
-  return pruneUpstreamBranches(root, parent);
-};
-
-const countDownstreamLeaves = <T>(node: TreeCacheNode<T>): number =>
-  node.type === 'leaf'
-    ? 1
-    : Array.from(node.branches.values()).reduce(
-        (sum, currNode) => sum + countDownstreamLeaves(currNode),
-        0,
-      );
 
 module.exports = {TreeCache};

--- a/packages/recoil/caches/Recoil_TreeCacheImplementationType.js
+++ b/packages/recoil/caches/Recoil_TreeCacheImplementationType.js
@@ -19,7 +19,7 @@ export type TreeCacheNode<T> = TreeCacheLeaf<T> | TreeCacheBranch<T>;
 export type TreeCacheLeaf<T> = {
   type: 'leaf',
   value: T,
-  branchKey?: ?mixed,
+  branchKey?: mixed,
   parent: ?TreeCacheBranch<T>,
 };
 
@@ -27,7 +27,7 @@ export type TreeCacheBranch<T> = {
   type: 'branch',
   nodeKey: NodeKey,
   branches: Map<mixed, TreeCacheNode<T>>,
-  branchKey?: ?mixed,
+  branchKey?: mixed,
   parent: ?TreeCacheBranch<T>,
 };
 
@@ -64,7 +64,7 @@ export type SetHandlers<T> = {
 export interface TreeCacheImplementation<T> {
   +get: (NodeValueGet, handlers?: GetHandlers<T>) => ?T;
   +set: (NodeCacheRoute, T, handlers?: SetHandlers<T>) => void;
-  +delete: (TreeCacheNode<T>) => boolean;
+  +delete: (TreeCacheLeaf<T>) => boolean;
   +clear: () => void;
   +root: () => ?TreeCacheNode<T>;
   +size: () => number;

--- a/packages/recoil/caches/__tests__/Recoil_TreeCache-test.js
+++ b/packages/recoil/caches/__tests__/Recoil_TreeCache-test.js
@@ -77,13 +77,14 @@ describe('TreeCache', () => {
 
     const [route2, loadable2] = [
       [
-        ['a', 3],
+        ['a', 2],
         ['b', 4],
+        ['c', 5],
       ],
       loadableWithValue('value2'),
     ];
 
-    const [route3, loadable3] = [[['a', 4]], loadableWithValue('value3')];
+    const [route3, loadable3] = [[['a', 6]], loadableWithValue('value3')];
 
     cache.set(route1, loadable1);
     cache.set(route2, loadable2);
@@ -112,23 +113,19 @@ describe('TreeCache', () => {
     expect(cache.size()).toBe(3);
 
     const deleted1 = cache.delete(leaf1Node);
-
     expect(deleted1).toBe(true);
     expect(cache.size()).toBe(2);
 
     const deleted2 = cache.delete(leaf2Node);
-
     expect(deleted2).toBe(true);
     expect(cache.size()).toBe(1);
 
     const deleted3 = cache.delete(leaf3Node);
-
     expect(deleted3).toBe(true);
     expect(cache.size()).toBe(0);
     expect(cache.root()).toBeNull();
 
     const deletedAgain = cache.delete(leaf1Node);
-
     expect(deletedAgain).toBe(false);
   });
 
@@ -241,5 +238,24 @@ describe('TreeCache', () => {
     ]);
 
     expect(resultWithKeyCopy).toBe(loadable1);
+  });
+
+  // Test ability to scale cache to large number of entries.
+  // Use more dependencies than the JavaScript callstack depth limit to ensure
+  // we are not using a recursive algorithm.
+  testRecoil('Scalability', () => {
+    const cache = new TreeCache();
+
+    const route = Array.from(Array(10000).keys()).map(i => [
+      String(i),
+      String(i),
+    ]);
+
+    cache.set(route, 'VALUE');
+
+    expect(cache.get(x => x)).toBe('VALUE');
+
+    const leafNode = cache.getLeafNode(x => x);
+    expect(cache.delete(nullthrows(leafNode))).toBe(true);
   });
 });

--- a/packages/recoil/core/Recoil_Node.js
+++ b/packages/recoil/core/Recoil_Node.js
@@ -15,6 +15,7 @@ import type {RecoilValue} from './Recoil_RecoilValue';
 import type {RetainedBy} from './Recoil_RetainedBy';
 import type {AtomWrites, NodeKey, Store, TreeState} from './Recoil_State';
 
+const {isFastRefreshEnabled} = require('./Recoil_ReactMode');
 const RecoilValueClasses = require('./Recoil_RecoilValue');
 const expectationViolation = require('recoil-shared/util/Recoil_expectationViolation');
 const gkx = require('recoil-shared/util/Recoil_gkx');
@@ -120,19 +121,16 @@ function registerNode<T>(node: Node<T>): RecoilValue<T> {
     const message = `Duplicate atom key "${node.key}". This is a FATAL ERROR in
       production. But it is safe to ignore this warning if it occurred because of
       hot module replacement.`;
-    // TODO Need to figure out if there is a standard/open-source equivalent to see if hot module replacement is happening:
-    // prettier-ignore
-    // @fb-only: if (__DEV__) {
-    // @fb-only: const isAcceptingUpdate = require('__debug').isAcceptingUpdate;
-    // prettier-ignore
-    // @fb-only: if (typeof isAcceptingUpdate !== 'function' || !isAcceptingUpdate()) {
-    // @fb-only: expectationViolation(message, 'recoil');
-    // @fb-only: }
-    // prettier-ignore
-    // @fb-only: } else {
-    // @fb-only: recoverableViolation(message, 'recoil');
-    // @fb-only: }
-    console.warn(message); // @oss-only
+
+    if (__DEV__) {
+      // TODO Figure this out for open-source
+      if (!isFastRefreshEnabled()) {
+        expectationViolation(message, 'recoil');
+      }
+    } else {
+      // @fb-only: recoverableViolation(message, 'recoil');
+      console.warn(message); // @oss-only
+    }
   }
   nodes.set(node.key, node);
 

--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @emails oncall+recoil
- * @flow strict
+ * @flow strict-local
  * @format
  */
 'use strict';
@@ -82,9 +82,17 @@ function reactMode(): {mode: ReactMode, early: boolean, concurrent: boolean} {
     : {mode: 'LEGACY', early: false, concurrent: false};
 }
 
+// TODO Need to figure out if there is a standard/open-source equivalent to see if hot module replacement is happening:
+function isFastRefreshEnabled(): boolean {
+  // @fb-only: const {isAcceptingUpdate} = require('__debug');
+  // @fb-only: return typeof isAcceptingUpdate === 'function' && isAcceptingUpdate();
+  return false; // @oss-only
+}
+
 module.exports = {
   createMutableSource,
   useMutableSource,
   useSyncExternalStore,
   reactMode,
+  isFastRefreshEnabled,
 };

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -649,18 +649,6 @@ function selector<T>(
     }
   }
 
-  function setNewDepInStore(
-    store: Store,
-    state: TreeState,
-    deps: Set<NodeKey>,
-    newDepKey: NodeKey,
-    executionId: ?ExecutionId,
-  ): void {
-    deps.add(newDepKey);
-
-    setDepsInStore(store, state, deps, executionId);
-  }
-
   function evaluateSelectorGetter(
     store: Store,
     state: TreeState,
@@ -694,13 +682,13 @@ function selector<T>(
      * deps for the current/latest state in the store)
      */
     const deps = new Set();
-
     setDepsInStore(store, state, deps, executionId);
 
     function getRecoilValue<S>(dep: RecoilValue<S>): S {
       const {key: depKey} = dep;
 
-      setNewDepInStore(store, state, deps, depKey, executionId);
+      deps.add(depKey);
+      setDepsInStore(store, state, deps, executionId);
 
       const depLoadable = getCachedNodeLoadable(store, state, depKey);
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -1043,14 +1043,25 @@ testRecoil('Report error with inconsistent values', () => {
 
   expect(getValue(mySelector)).toBe('DEFAULT');
 
+  const DEV = window.__DEV__;
+  let msg;
+  const consoleError = console.error;
+  // $FlowIssue[cannot-write]
+  console.error = (...args) => {
+    msg = args[0];
+    consoleError(...args);
+  };
+  window.__DEV__ = true;
+
   invalidInput = 'INVALID';
   setValue(depB, 'SET');
 
-  const DEV = window.__DEV__;
-  window.__DEV__ = true;
-  expect(() => getValue(mySelector)).toThrow('consistent values');
-  window.__DEV__ = false;
+  // Reset logic will still allow selector to work by resetting cache.
   expect(getValue(mySelector)).toBe('INVALID');
+  expect(msg).toEqual(expect.stringContaining('consistent values'));
+
+  // $FlowIssue[cannot-write]
+  console.error = consoleError;
   window.__DEV__ = DEV;
 });
 

--- a/packages/shared/polyfill/recoverableViolation.js
+++ b/packages/shared/polyfill/recoverableViolation.js
@@ -13,7 +13,7 @@
 
 function recoverableViolation(
   message: string,
-  projectName: 'recoil',
+  _projectName: 'recoil',
   {error}: {error?: Error} = {},
 ): null {
   if (__DEV__) {


### PR DESCRIPTION
Summary: With Fast Refresh the selector caches are expected to be invalid and reset.  So, to avoid filling up the debug console, might as well suppress these messages.

Differential Revision: D34703576

