### PR TITLE
Test for dynamic dependencies with multiple stores

### DIFF
--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -649,18 +649,6 @@ function selector<T>(
     }
   }
 
-  function setNewDepInStore(
-    store: Store,
-    state: TreeState,
-    deps: Set<NodeKey>,
-    newDepKey: NodeKey,
-    executionId: ?ExecutionId,
-  ): void {
-    deps.add(newDepKey);
-
-    setDepsInStore(store, state, deps, executionId);
-  }
-
   function evaluateSelectorGetter(
     store: Store,
     state: TreeState,
@@ -694,13 +682,13 @@ function selector<T>(
      * deps for the current/latest state in the store)
      */
     const deps = new Set();
-
     setDepsInStore(store, state, deps, executionId);
 
     function getRecoilValue<S>(dep: RecoilValue<S>): S {
       const {key: depKey} = dep;
 
-      setNewDepInStore(store, state, deps, depKey, executionId);
+      deps.add(depKey);
+      setDepsInStore(store, state, deps, executionId);
 
       const depLoadable = getCachedNodeLoadable(store, state, depKey);
 


### PR DESCRIPTION
Summary: Add a unit test for dynamic dependencies with multiple stores.  Confirm that it properly handles updated dependencies based on subscriptions when the subscription is dynamic in a secondary store that was re-using the execution from another store.

Reviewed By: mondaychen

Differential Revision: D34101601

