### PR TITLE
Update typings to allow setters and getters of different types on selectors

### DIFF
--- a/packages/recoil/core/Recoil_AtomicUpdates.js
+++ b/packages/recoil/core/Recoil_AtomicUpdates.js
@@ -26,12 +26,12 @@ const {
 const err = require('recoil-shared/util/Recoil_err');
 
 export interface TransactionInterface {
-  get: <T>(RecoilValue<T>) => T;
-  set: <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
-  reset: <T>(RecoilState<T>) => void;
+  get: <T, U>(RecoilValue<T, U>) => T;
+  set: <T, U>(RecoilState<T, U>, ValueOrUpdater<T, U>) => void;
+  reset: <T, U>(RecoilState<T, U>) => void;
 }
 
-function isAtom<T>(recoilValue: RecoilValue<T>): boolean {
+function isAtom<T, U>(recoilValue: RecoilValue<T, U>): boolean {
   return getNode(recoilValue.key).nodeType === 'atom';
 }
 
@@ -48,7 +48,7 @@ class TransactionInterfaceImpl {
 
   // Allow destructing
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  get = <T>(recoilValue: RecoilValue<T>): T => {
+  get = <T, U>(recoilValue: RecoilValue<T, U>): T => {
     if (this._changes.has(recoilValue.key)) {
       // $FlowFixMe[incompatible-return]
       return this._changes.get(recoilValue.key);
@@ -74,9 +74,9 @@ class TransactionInterfaceImpl {
 
   // Allow destructing
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  set = <T>(
-    recoilState: RecoilState<T>,
-    valueOrUpdater: ValueOrUpdater<T>,
+  set = <T, U>(
+    recoilState: RecoilState<T, U>,
+    valueOrUpdater: ValueOrUpdater<T, U>,
   ): void => {
     if (!isAtom(recoilState)) {
       throw err('Setting selectors within atomicUpdate is not supported');
@@ -95,7 +95,7 @@ class TransactionInterfaceImpl {
 
   // Allow destructing
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  reset = <T>(recoilState: RecoilState<T>): void => {
+  reset = <T, U>(recoilState: RecoilState<T, U>): void => {
     this.set(recoilState, DEFAULT_VALUE);
   };
 

--- a/packages/recoil/core/Recoil_FunctionalCore.js
+++ b/packages/recoil/core/Recoil_FunctionalCore.js
@@ -181,9 +181,9 @@ export type RecoilValueInfo<T> = {
   isSet: boolean,
   isModified: boolean, // TODO report modified selectors
   type: 'atom' | 'selector',
-  deps: Iterable<RecoilValue<mixed>>,
+  deps: Iterable<RecoilValue<mixed, mixed>>,
   subscribers: {
-    nodes: Iterable<RecoilValue<mixed>>,
+    nodes: Iterable<RecoilValue<mixed, mixed>>,
     components: Iterable<ComponentInfo>,
   },
 };

--- a/packages/recoil/core/Recoil_Node.js
+++ b/packages/recoil/core/Recoil_Node.js
@@ -118,8 +118,8 @@ function recoilValuesForKeys(
 function registerNode<T, U>(node: Node<T, U>): RecoilValue<T, U> {
   if (nodes.has(node.key)) {
     const message = `Duplicate atom key "${node.key}". This is a FATAL ERROR in
-       production. But it is safe to ignore this warning if it occurred because of
-       hot module replacement.`;
+      production. But it is safe to ignore this warning if it occurred because of
+      hot module replacement.`;
     // TODO Need to figure out if there is a standard/open-source equivalent to see if hot module replacement is happening:
     // prettier-ignore
     // @fb-only: if (__DEV__) {

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -58,7 +58,7 @@ const useRefInitOnce = require('recoil-shared/util/Recoil_useRefInitOnce');
 
 type InternalProps = {
   initializeState_DEPRECATED?: ({
-    set: <T>(RecoilValue<T>, T) => void,
+    set: <T, U>(RecoilValue<T, U>, T) => void,
     setUnvalidatedAtomValues: (Map<string, mixed>) => void,
   }) => void,
   initializeState?: MutableSnapshot => void,
@@ -358,19 +358,19 @@ function RecoilRoot_INTERNAL({
 }: InternalProps): React.Node {
   // prettier-ignore
   // @fb-only: useEffect(() => {
-    // @fb-only: if (gkx('recoil_usage_logging')) {
-      // @fb-only: try {
-        // @fb-only: RecoilUsageLogFalcoEvent.log(() => ({
-          // @fb-only: type: RecoilusagelogEvent.RECOIL_ROOT_MOUNTED,
-          // @fb-only: path: URI.getRequestURI().getPath(),
-        // @fb-only: }));
-      // @fb-only: } catch {
-        // @fb-only: recoverableViolation(
-          // @fb-only: 'Error when logging Recoil Usage event',
-          // @fb-only: 'recoil',
-        // @fb-only: );
-      // @fb-only: }
-    // @fb-only: }
+  // @fb-only: if (gkx('recoil_usage_logging')) {
+  // @fb-only: try {
+  // @fb-only: RecoilUsageLogFalcoEvent.log(() => ({
+  // @fb-only: type: RecoilusagelogEvent.RECOIL_ROOT_MOUNTED,
+  // @fb-only: path: URI.getRequestURI().getPath(),
+  // @fb-only: }));
+  // @fb-only: } catch {
+  // @fb-only: recoverableViolation(
+  // @fb-only: 'Error when logging Recoil Usage event',
+  // @fb-only: 'recoil',
+  // @fb-only: );
+  // @fb-only: }
+  // @fb-only: }
   // @fb-only: }, []);
 
   let storeStateRef: {current: StoreState}; // eslint-disable-line prefer-const
@@ -529,7 +529,7 @@ function RecoilRoot_INTERNAL({
 type Props =
   | {
       initializeState_DEPRECATED?: ({
-        set: <T>(RecoilValue<T>, T) => void,
+        set: <T, U>(RecoilValue<T, U>, T) => void,
         setUnvalidatedAtomValues: (Map<string, mixed>) => void,
       }) => void,
       initializeState?: MutableSnapshot => void,

--- a/packages/recoil/core/Recoil_RecoilValue.js
+++ b/packages/recoil/core/Recoil_RecoilValue.js
@@ -20,11 +20,11 @@ class AbstractRecoilValue<+T> {
   }
 }
 
-class RecoilState<T> extends AbstractRecoilValue<T> {}
+class RecoilState<T, U = T> extends AbstractRecoilValue<T> {}
 
 class RecoilValueReadOnly<+T> extends AbstractRecoilValue<T> {}
 
-export type RecoilValue<T> = RecoilValueReadOnly<T> | RecoilState<T>;
+export type RecoilValue<T, U> = RecoilValueReadOnly<T> | RecoilState<T, U>;
 
 function isRecoilValue(x: mixed): boolean %checks {
   return x instanceof RecoilState || x instanceof RecoilValueReadOnly;

--- a/packages/recoil/core/Recoil_RecoilValueInterface.js
+++ b/packages/recoil/core/Recoil_RecoilValueInterface.js
@@ -87,12 +87,12 @@ function applyAtomValueWrites(
   return result;
 }
 
-function valueFromValueOrUpdater<T>(
+function valueFromValueOrUpdater<T, U>(
   store: Store,
   state: TreeState,
   {key}: AbstractRecoilValue<T>,
-  valueOrUpdater: ValueOrUpdater<T>,
-): T | DefaultValue {
+  valueOrUpdater: ValueOrUpdater<T, U>,
+): U | DefaultValue {
   if (typeof valueOrUpdater === 'function') {
     // Updater form: pass in the current value. Throw if the current value
     // is unavailable (namely when updating an async selector that's

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -58,17 +58,17 @@ const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViola
 export type SnapshotID = StateID;
 
 const retainWarning = `
-Recoil Snapshots only last for the duration of the callback they are provided to. To keep a Snapshot longer, do this:
-
-  const release = snapshot.retain();
-  try {
-    await doSomethingWithSnapshot(snapshot);
-  } finally {
-    release();
-  }
-
-This is currently a DEV-only warning but will become a thrown exception in the next release of Recoil.
-`;
+ Recoil Snapshots only last for the duration of the callback they are provided to. To keep a Snapshot longer, do this:
+ 
+   const release = snapshot.retain();
+   try {
+     await doSomethingWithSnapshot(snapshot);
+   } finally {
+     release();
+   }
+ 
+ This is currently a DEV-only warning but will become a thrown exception in the next release of Recoil.
+ `;
 
 // A "Snapshot" is "read-only" and captures a specific set of values of atoms.
 // However, the data-flow-graph and selector values may evolve as selector
@@ -193,8 +193,8 @@ class Snapshot {
 
   // We want to allow the methods to be destructured and used as accessors
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  getLoadable: <T>(RecoilValue<T>) => Loadable<T> = <T>(
-    recoilValue: RecoilValue<T>,
+  getLoadable: <T, U>(RecoilValue<T, U>) => Loadable<T> = <T, U>(
+    recoilValue: RecoilValue<T, U>,
   ): Loadable<T> => {
     this.checkRefCount_INTERNAL();
     return getRecoilValueAsLoadable(this._store, recoilValue);
@@ -202,8 +202,8 @@ class Snapshot {
 
   // We want to allow the methods to be destructured and used as accessors
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  getPromise: <T>(RecoilValue<T>) => Promise<T> = <T>(
-    recoilValue: RecoilValue<T>,
+  getPromise: <T, U>(RecoilValue<T, U>) => Promise<T> = <T, U>(
+    recoilValue: RecoilValue<T, U>,
   ): Promise<T> => {
     this.checkRefCount_INTERNAL();
     return this.getLoadable(recoilValue).toPromise();
@@ -216,7 +216,7 @@ class Snapshot {
       isModified?: boolean,
       isInitialized?: boolean,
     } | void,
-  ) => Iterable<RecoilValue<mixed>> = opt => {
+  ) => Iterable<RecoilValue<mixed, mixed>> = opt => {
     this.checkRefCount_INTERNAL();
 
     // TODO Deal with modified selectors
@@ -243,9 +243,9 @@ class Snapshot {
   // Report the current status of a node.
   // This peeks the current state and does not affect the snapshot state at all
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  getInfo_UNSTABLE: <T>(RecoilValue<T>) => RecoilValueInfo<T> = <T>({
+  getInfo_UNSTABLE: <T, U>(RecoilValue<T, U>) => RecoilValueInfo<T> = <T, U>({
     key,
-  }: RecoilValue<T>) => {
+  }: RecoilValue<T, U>) => {
     this.checkRefCount_INTERNAL();
     // $FlowFixMe[escaped-generic]
     return peekNodeInfo(this._store, this._store.getState().currentTree, key);
@@ -376,9 +376,9 @@ class MutableSnapshot extends Snapshot {
 
   // We want to allow the methods to be destructured and used as accessors
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  set: SetRecoilState = <T>(
-    recoilState: RecoilState<T>,
-    newValueOrUpdater: ValueOrUpdater<T>,
+  set: SetRecoilState = <T, U>(
+    recoilState: RecoilState<T, U>,
+    newValueOrUpdater: ValueOrUpdater<T, U>,
   ) => {
     this.checkRefCount_INTERNAL();
     const store = this.getStore_INTERNAL();
@@ -394,7 +394,7 @@ class MutableSnapshot extends Snapshot {
 
   // We want to allow the methods to be destructured and used as accessors
   // eslint-disable-next-line fb-www/extra-arrow-initializer
-  reset: ResetRecoilState = <T>(recoilState: RecoilState<T>) => {
+  reset: ResetRecoilState = <T, U>(recoilState: RecoilState<T, U>) => {
     this.checkRefCount_INTERNAL();
     const store = this.getStore_INTERNAL();
     // See note at `set` about batched updates.

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -58,17 +58,17 @@ const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViola
 export type SnapshotID = StateID;
 
 const retainWarning = `
- Recoil Snapshots only last for the duration of the callback they are provided to. To keep a Snapshot longer, do this:
- 
-   const release = snapshot.retain();
-   try {
-     await doSomethingWithSnapshot(snapshot);
-   } finally {
-     release();
-   }
- 
- This is currently a DEV-only warning but will become a thrown exception in the next release of Recoil.
- `;
+Recoil Snapshots only last for the duration of the callback they are provided to. To keep a Snapshot longer, do this:
+
+  const release = snapshot.retain();
+  try {
+    await doSomethingWithSnapshot(snapshot);
+  } finally {
+    release();
+  }
+
+This is currently a DEV-only warning but will become a thrown exception in the next release of Recoil.
+`;
 
 // A "Snapshot" is "read-only" and captures a specific set of values of atoms.
 // However, the data-flow-graph and selector values may evolve as selector

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -45,9 +45,9 @@ const gkx = require('recoil-shared/util/Recoil_gkx');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 const useComponentName = require('recoil-shared/util/Recoil_useComponentName');
 
-function handleLoadable<T>(
+function handleLoadable<T, U>(
   loadable: Loadable<T>,
-  recoilValue: RecoilValue<T>,
+  recoilValue: RecoilValue<T, U>,
   storeRef,
 ): T {
   // We can't just throw the promise we are waiting on to Suspense.  If the
@@ -71,7 +71,7 @@ function handleLoadable<T>(
   }
 }
 
-function validateRecoilValue<T>(recoilValue: RecoilValue<T>, hookName) {
+function validateRecoilValue<T, U>(recoilValue: RecoilValue<T, U>, hookName) {
   if (!isRecoilValue(recoilValue)) {
     throw err(
       `Invalid argument to ${hookName}: expected an atom or selector but got ${String(
@@ -81,17 +81,17 @@ function validateRecoilValue<T>(recoilValue: RecoilValue<T>, hookName) {
   }
 }
 
-export type SetterOrUpdater<T> = ((T => T) | T) => void;
+export type SetterOrUpdater<T, U = T> = ((T => U) | U) => void;
 export type Resetter = () => void;
 export type RecoilInterface = {
-  getRecoilValue: <T>(RecoilValue<T>) => T,
-  getRecoilValueLoadable: <T>(RecoilValue<T>) => Loadable<T>,
-  getRecoilState: <T>(RecoilState<T>) => [T, SetterOrUpdater<T>],
-  getRecoilStateLoadable: <T>(
-    RecoilState<T>,
-  ) => [Loadable<T>, SetterOrUpdater<T>],
-  getSetRecoilState: <T>(RecoilState<T>) => SetterOrUpdater<T>,
-  getResetRecoilState: <T>(RecoilState<T>) => Resetter,
+  getRecoilValue: <T, U>(RecoilValue<T, U>) => T,
+  getRecoilValueLoadable: <T, U>(RecoilValue<T, U>) => Loadable<T>,
+  getRecoilState: <T, U>(RecoilState<T, U>) => [T, SetterOrUpdater<T, U>],
+  getRecoilStateLoadable: <T, U>(
+    RecoilState<T, U>,
+  ) => [Loadable<T>, SetterOrUpdater<T, U>],
+  getSetRecoilState: <T, U>(RecoilState<T, U>) => SetterOrUpdater<T, U>,
+  getResetRecoilState: <T, U>(RecoilState<T, U>) => Resetter,
 };
 
 /**
@@ -205,21 +205,23 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
 
   return useMemo(() => {
     // eslint-disable-next-line no-shadow
-    function useSetRecoilState<T>(
-      recoilState: RecoilState<T>,
-    ): SetterOrUpdater<T> {
+    function useSetRecoilState<T, U>(
+      recoilState: RecoilState<T, U>,
+    ): SetterOrUpdater<T, U> {
       if (__DEV__) {
         validateRecoilValue(recoilState, 'useSetRecoilState');
       }
       return (
-        newValueOrUpdater: (T => T | DefaultValue) | T | DefaultValue,
+        newValueOrUpdater: (T => U | DefaultValue) | U | DefaultValue,
       ) => {
         setRecoilValue(storeRef.current, recoilState, newValueOrUpdater);
       };
     }
 
     // eslint-disable-next-line no-shadow
-    function useResetRecoilState<T>(recoilState: RecoilState<T>): Resetter {
+    function useResetRecoilState<T, U>(
+      recoilState: RecoilState<T, U>,
+    ): Resetter {
       if (__DEV__) {
         validateRecoilValue(recoilState, 'useResetRecoilState');
       }
@@ -227,8 +229,8 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
     }
 
     // eslint-disable-next-line no-shadow
-    function useRecoilValueLoadable<T>(
-      recoilValue: RecoilValue<T>,
+    function useRecoilValueLoadable<T, U>(
+      recoilValue: RecoilValue<T, U>,
     ): Loadable<T> {
       if (__DEV__) {
         validateRecoilValue(recoilValue, 'useRecoilValueLoadable');
@@ -251,7 +253,7 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
     }
 
     // eslint-disable-next-line no-shadow
-    function useRecoilValue<T>(recoilValue: RecoilValue<T>): T {
+    function useRecoilValue<T, U>(recoilValue: RecoilValue<T, U>): T {
       if (__DEV__) {
         validateRecoilValue(recoilValue, 'useRecoilValue');
       }
@@ -260,9 +262,9 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
     }
 
     // eslint-disable-next-line no-shadow
-    function useRecoilState<T>(
-      recoilState: RecoilState<T>,
-    ): [T, SetterOrUpdater<T>] {
+    function useRecoilState<T, U>(
+      recoilState: RecoilState<T, U>,
+    ): [T, SetterOrUpdater<T, U>] {
       if (__DEV__) {
         validateRecoilValue(recoilState, 'useRecoilState');
       }
@@ -270,9 +272,9 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
     }
 
     // eslint-disable-next-line no-shadow
-    function useRecoilStateLoadable<T>(
-      recoilState: RecoilState<T>,
-    ): [Loadable<T>, SetterOrUpdater<T>] {
+    function useRecoilStateLoadable<T, U>(
+      recoilState: RecoilState<T, U>,
+    ): [Loadable<T>, SetterOrUpdater<T, U>] {
       if (__DEV__) {
         validateRecoilValue(recoilState, 'useRecoilStateLoadable');
       }
@@ -295,8 +297,8 @@ function useRecoilInterface_DEPRECATED(): RecoilInterface {
 
 const recoilComponentGetRecoilValueCount_FOR_TESTING = {current: 0};
 
-function useRecoilValueLoadable_SYNC_EXTERNAL_STORE<T>(
-  recoilValue: RecoilValue<T>,
+function useRecoilValueLoadable_SYNC_EXTERNAL_STORE<T, U>(
+  recoilValue: RecoilValue<T, U>,
 ): Loadable<T> {
   const storeRef = useStoreRef();
   const componentName = useComponentName();
@@ -355,8 +357,8 @@ function useRecoilValueLoadable_SYNC_EXTERNAL_STORE<T>(
   ).loadable;
 }
 
-function useRecoilValueLoadable_MUTABLE_SOURCE<T>(
-  recoilValue: RecoilValue<T>,
+function useRecoilValueLoadable_MUTABLE_SOURCE<T, U>(
+  recoilValue: RecoilValue<T, U>,
 ): Loadable<T> {
   const storeRef = useStoreRef();
 
@@ -422,8 +424,8 @@ function useRecoilValueLoadable_MUTABLE_SOURCE<T>(
   return loadable;
 }
 
-function useRecoilValueLoadable_TRANSITION_SUPPORT<T>(
-  recoilValue: RecoilValue<T>,
+function useRecoilValueLoadable_TRANSITION_SUPPORT<T, U>(
+  recoilValue: RecoilValue<T, U>,
 ): Loadable<T> {
   const storeRef = useStoreRef();
   const componentName = useComponentName();
@@ -484,8 +486,8 @@ function useRecoilValueLoadable_TRANSITION_SUPPORT<T>(
   return state.key !== recoilValue.key ? getState().loadable : state.loadable;
 }
 
-function useRecoilValueLoadable_LEGACY<T>(
-  recoilValue: RecoilValue<T>,
+function useRecoilValueLoadable_LEGACY<T, U>(
+  recoilValue: RecoilValue<T, U>,
 ): Loadable<T> {
   const storeRef = useStoreRef();
   const [, forceUpdate] = useState([]);
@@ -567,10 +569,12 @@ function useRecoilValueLoadable_LEGACY<T>(
 }
 
 /**
-  Like useRecoilValue(), but either returns the value if available or
-  just undefined if not available for any reason, such as pending or error.
-*/
-function useRecoilValueLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
+   Like useRecoilValue(), but either returns the value if available or
+   just undefined if not available for any reason, such as pending or error.
+ */
+function useRecoilValueLoadable<T, U = T>(
+  recoilValue: RecoilValue<T, U>,
+): Loadable<T> {
   if (__DEV__) {
     validateRecoilValue(recoilValue, 'useRecoilValueLoadable');
   }
@@ -587,12 +591,12 @@ function useRecoilValueLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T> {
 }
 
 /**
-  Returns the value represented by the RecoilValue.
-  If the value is pending, it will throw a Promise to suspend the component,
-  if the value is an error it will throw it for the nearest React error boundary.
-  This will also subscribe the component for any updates in the value.
-  */
-function useRecoilValue<T>(recoilValue: RecoilValue<T>): T {
+   Returns the value represented by the RecoilValue.
+   If the value is pending, it will throw a Promise to suspend the component,
+   if the value is an error it will throw it for the nearest React error boundary.
+   This will also subscribe the component for any updates in the value.
+   */
+function useRecoilValue<T, U = T>(recoilValue: RecoilValue<T, U>): T {
   if (__DEV__) {
     validateRecoilValue(recoilValue, 'useRecoilValue');
   }
@@ -602,16 +606,18 @@ function useRecoilValue<T>(recoilValue: RecoilValue<T>): T {
 }
 
 /**
-  Returns a function that allows the value of a RecoilState to be updated, but does
-  not subscribe the component to changes to that RecoilState.
-*/
-function useSetRecoilState<T>(recoilState: RecoilState<T>): SetterOrUpdater<T> {
+   Returns a function that allows the value of a RecoilState to be updated, but does
+   not subscribe the component to changes to that RecoilState.
+ */
+function useSetRecoilState<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): SetterOrUpdater<T, U> {
   if (__DEV__) {
     validateRecoilValue(recoilState, 'useSetRecoilState');
   }
   const storeRef = useStoreRef();
   return useCallback(
-    (newValueOrUpdater: (T => T | DefaultValue) | T | DefaultValue) => {
+    (newValueOrUpdater: (T => U | DefaultValue) | U | DefaultValue) => {
       setRecoilValue(storeRef.current, recoilState, newValueOrUpdater);
     },
     [storeRef, recoilState],
@@ -619,9 +625,11 @@ function useSetRecoilState<T>(recoilState: RecoilState<T>): SetterOrUpdater<T> {
 }
 
 /**
-  Returns a function that will reset the value of a RecoilState to its default
-*/
-function useResetRecoilState<T>(recoilState: RecoilState<T>): Resetter {
+   Returns a function that will reset the value of a RecoilState to its default
+ */
+function useResetRecoilState<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): Resetter {
   if (__DEV__) {
     validateRecoilValue(recoilState, 'useResetRecoilState');
   }
@@ -632,15 +640,15 @@ function useResetRecoilState<T>(recoilState: RecoilState<T>): Resetter {
 }
 
 /**
-  Equivalent to useState(). Allows the value of the RecoilState to be read and written.
-  Subsequent updates to the RecoilState will cause the component to re-render. If the
-  RecoilState is pending, this will suspend the component and initiate the
-  retrieval of the value. If evaluating the RecoilState resulted in an error, this will
-  throw the error so that the nearest React error boundary can catch it.
-*/
-function useRecoilState<T>(
-  recoilState: RecoilState<T>,
-): [T, SetterOrUpdater<T>] {
+   Equivalent to useState(). Allows the value of the RecoilState to be read and written.
+   Subsequent updates to the RecoilState will cause the component to re-render. If the
+   RecoilState is pending, this will suspend the component and initiate the
+   retrieval of the value. If evaluating the RecoilState resulted in an error, this will
+   throw the error so that the nearest React error boundary can catch it.
+ */
+function useRecoilState<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): [T, SetterOrUpdater<T, U>] {
   if (__DEV__) {
     validateRecoilValue(recoilState, 'useRecoilState');
   }
@@ -648,13 +656,13 @@ function useRecoilState<T>(
 }
 
 /**
-  Like useRecoilState(), but does not cause Suspense or React error handling. Returns
-  an object that indicates whether the RecoilState is available, pending, or
-  unavailable due to an error.
-*/
-function useRecoilStateLoadable<T>(
-  recoilState: RecoilState<T>,
-): [Loadable<T>, SetterOrUpdater<T>] {
+   Like useRecoilState(), but does not cause Suspense or React error handling. Returns
+   an object that indicates whether the RecoilState is available, pending, or
+   unavailable due to an error.
+ */
+function useRecoilStateLoadable<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): [Loadable<T>, SetterOrUpdater<T, U>] {
   if (__DEV__) {
     validateRecoilValue(recoilState, 'useRecoilStateLoadable');
   }
@@ -684,8 +692,8 @@ function useSetUnvalidatedAtomValues(): (
  * Experimental variants of hooks with support for useTransition()
  */
 
-function useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE<T>(
-  recoilValue: RecoilValue<T>,
+function useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE<T, U = T>(
+  recoilValue: RecoilValue<T, U>,
 ): Loadable<T> {
   if (__DEV__) {
     validateRecoilValue(
@@ -706,8 +714,8 @@ function useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE<T>(
   return useRecoilValueLoadable_TRANSITION_SUPPORT(recoilValue);
 }
 
-function useRecoilValue_TRANSITION_SUPPORT_UNSTABLE<T>(
-  recoilValue: RecoilValue<T>,
+function useRecoilValue_TRANSITION_SUPPORT_UNSTABLE<T, U = T>(
+  recoilValue: RecoilValue<T, U>,
 ): T {
   if (__DEV__) {
     validateRecoilValue(
@@ -721,9 +729,9 @@ function useRecoilValue_TRANSITION_SUPPORT_UNSTABLE<T>(
   return handleLoadable(loadable, recoilValue, storeRef);
 }
 
-function useRecoilState_TRANSITION_SUPPORT_UNSTABLE<T>(
-  recoilState: RecoilState<T>,
-): [T, SetterOrUpdater<T>] {
+function useRecoilState_TRANSITION_SUPPORT_UNSTABLE<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): [T, SetterOrUpdater<T, U>] {
   if (__DEV__) {
     validateRecoilValue(
       recoilState,

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -569,9 +569,9 @@ function useRecoilValueLoadable_LEGACY<T, U>(
 }
 
 /**
-   Like useRecoilValue(), but either returns the value if available or
-   just undefined if not available for any reason, such as pending or error.
- */
+  Like useRecoilValue(), but either returns the value if available or
+  just undefined if not available for any reason, such as pending or error.
+*/
 function useRecoilValueLoadable<T, U = T>(
   recoilValue: RecoilValue<T, U>,
 ): Loadable<T> {
@@ -591,11 +591,11 @@ function useRecoilValueLoadable<T, U = T>(
 }
 
 /**
-   Returns the value represented by the RecoilValue.
-   If the value is pending, it will throw a Promise to suspend the component,
-   if the value is an error it will throw it for the nearest React error boundary.
-   This will also subscribe the component for any updates in the value.
-   */
+  Returns the value represented by the RecoilValue.
+  If the value is pending, it will throw a Promise to suspend the component,
+  if the value is an error it will throw it for the nearest React error boundary.
+  This will also subscribe the component for any updates in the value.
+  */
 function useRecoilValue<T, U = T>(recoilValue: RecoilValue<T, U>): T {
   if (__DEV__) {
     validateRecoilValue(recoilValue, 'useRecoilValue');
@@ -606,9 +606,9 @@ function useRecoilValue<T, U = T>(recoilValue: RecoilValue<T, U>): T {
 }
 
 /**
-   Returns a function that allows the value of a RecoilState to be updated, but does
-   not subscribe the component to changes to that RecoilState.
- */
+  Returns a function that allows the value of a RecoilState to be updated, but does
+  not subscribe the component to changes to that RecoilState.
+*/
 function useSetRecoilState<T, U = T>(
   recoilState: RecoilState<T, U>,
 ): SetterOrUpdater<T, U> {
@@ -625,8 +625,8 @@ function useSetRecoilState<T, U = T>(
 }
 
 /**
-   Returns a function that will reset the value of a RecoilState to its default
- */
+  Returns a function that will reset the value of a RecoilState to its default
+*/
 function useResetRecoilState<T, U = T>(
   recoilState: RecoilState<T, U>,
 ): Resetter {
@@ -640,12 +640,12 @@ function useResetRecoilState<T, U = T>(
 }
 
 /**
-   Equivalent to useState(). Allows the value of the RecoilState to be read and written.
-   Subsequent updates to the RecoilState will cause the component to re-render. If the
-   RecoilState is pending, this will suspend the component and initiate the
-   retrieval of the value. If evaluating the RecoilState resulted in an error, this will
-   throw the error so that the nearest React error boundary can catch it.
- */
+ Equivalent to useState(). Allows the value of the RecoilState to be read and written.
+  Subsequent updates to the RecoilState will cause the component to re-render. If the
+  RecoilState is pending, this will suspend the component and initiate the
+  retrieval of the value. If evaluating the RecoilState resulted in an error, this will
+  throw the error so that the nearest React error boundary can catch it.
+*/
 function useRecoilState<T, U = T>(
   recoilState: RecoilState<T, U>,
 ): [T, SetterOrUpdater<T, U>] {
@@ -656,10 +656,10 @@ function useRecoilState<T, U = T>(
 }
 
 /**
-   Like useRecoilState(), but does not cause Suspense or React error handling. Returns
-   an object that indicates whether the RecoilState is available, pending, or
-   unavailable due to an error.
- */
+ Like useRecoilState(), but does not cause Suspense or React error handling. Returns
+  an object that indicates whether the RecoilState is available, pending, or
+  unavailable due to an error.
+*/
 function useRecoilStateLoadable<T, U = T>(
   recoilState: RecoilState<T, U>,
 ): [Loadable<T>, SetterOrUpdater<T, U>] {

--- a/packages/recoil/hooks/Recoil_useGetRecoilValueInfo.js
+++ b/packages/recoil/hooks/Recoil_useGetRecoilValueInfo.js
@@ -13,7 +13,9 @@ import type {RecoilValue} from '../core/Recoil_RecoilValue';
 const {peekNodeInfo} = require('../core/Recoil_FunctionalCore');
 const {useStoreRef} = require('../core/Recoil_RecoilRoot');
 
-function useGetRecoilValueInfo(): <T>(RecoilValue<T>) => RecoilValueInfo<T> {
+function useGetRecoilValueInfo(): <T, U>(
+  RecoilValue<T, U>,
+) => RecoilValueInfo<T> {
   const storeRef = useStoreRef();
 
   return <T>({key}): RecoilValueInfo<T> =>

--- a/packages/recoil/hooks/Recoil_useRecoilCallback.js
+++ b/packages/recoil/hooks/Recoil_useRecoilCallback.js
@@ -31,9 +31,9 @@ const invariant = require('recoil-shared/util/Recoil_invariant');
 const lazyProxy = require('recoil-shared/util/Recoil_lazyProxy');
 
 export type RecoilCallbackInterface = $ReadOnly<{
-  set: <T>(RecoilState<T>, (T => T) | T) => void,
-  reset: <T>(RecoilState<T>) => void,
-  refresh: <T>(RecoilValue<T>) => void,
+  set: <T, U>(RecoilState<T, U>, (T => U) | U) => void,
+  reset: <T, U>(RecoilState<T, U>) => void,
+  refresh: <T, U>(RecoilValue<T, U>) => void,
   snapshot: Snapshot,
   gotoSnapshot: Snapshot => void,
   transact_UNSTABLE: ((TransactionInterface) => void) => void,
@@ -70,11 +70,12 @@ function recoilCallback<Args: $ReadOnlyArray<mixed>, Return, ExtraInterface>(
     } = lazyProxy(
       {
         ...(extraInterface ?? ({}: any)), // flowlint-line unclear-type:off
-        set: <T>(node: RecoilState<T>, newValue: T | (T => T)) =>
+        set: <T, U>(node: RecoilState<T, U>, newValue: U | (T => U)) =>
           setRecoilValue(store, node, newValue),
-        reset: <T>(node: RecoilState<T>) =>
+        reset: <T, U>(node: RecoilState<T, U>) =>
           setRecoilValue(store, node, DEFAULT_VALUE),
-        refresh: <T>(node: RecoilValue<T>) => refreshRecoilValue(store, node),
+        refresh: <T, U>(node: RecoilValue<T, U>) =>
+          refreshRecoilValue(store, node),
         gotoSnapshot: snapshot => gotoSnapshot(store, snapshot),
         transact_UNSTABLE: transaction => atomicUpdater(store)(transaction),
       },

--- a/packages/recoil/hooks/Recoil_useRecoilRefresher.js
+++ b/packages/recoil/hooks/Recoil_useRecoilRefresher.js
@@ -16,7 +16,9 @@ const {useStoreRef} = require('../core/Recoil_RecoilRoot');
 const {refreshRecoilValue} = require('../core/Recoil_RecoilValueInterface');
 const {useCallback} = require('react');
 
-function useRecoilRefresher<T>(recoilValue: RecoilValue<T>): () => void {
+function useRecoilRefresher<T, U = T>(
+  recoilValue: RecoilValue<T, U>,
+): () => void {
   const storeRef = useStoreRef();
   return useCallback(() => {
     const store = storeRef.current;

--- a/packages/recoil/hooks/Recoil_useRetain.js
+++ b/packages/recoil/hooks/Recoil_useRetain.js
@@ -26,9 +26,9 @@ const usePrevious = require('recoil-shared/util/Recoil_usePrevious');
 // and writable values with any type parameter, but normally with writable ones
 // RecoilState<SomeT> is not a subtype of RecoilState<mixed>.
 type ToRetain =
-  | RecoilValue<any> // flowlint-line unclear-type:off
+  | RecoilValue<any, any> // flowlint-line unclear-type:off
   | RetentionZone
-  | $ReadOnlyArray<RecoilValue<any> | RetentionZone>; // flowlint-line unclear-type:off
+  | $ReadOnlyArray<RecoilValue<any, any> | RetentionZone>; // flowlint-line unclear-type:off
 
 function useRetain(toRetain: ToRetain): void {
   if (!gkx('recoil_memory_managament_2020')) {

--- a/packages/recoil/recoil_values/Recoil_WaitFor.js
+++ b/packages/recoil/recoil_values/Recoil_WaitFor.js
@@ -60,7 +60,7 @@ function unwrapDependencies(
   dependencies:
     | $ReadOnlyArray<RecoilValueReadOnly<mixed>>
     | {+[string]: RecoilValueReadOnly<mixed>},
-): $ReadOnlyArray<RecoilValue<mixed>> {
+): $ReadOnlyArray<RecoilValue<mixed, mixed>> {
   return Array.isArray(dependencies)
     ? dependencies
     : Object.getOwnPropertyNames(dependencies).map(key => dependencies[key]);
@@ -298,7 +298,7 @@ const waitForAllSettled: <
 });
 
 const noWait: (
-  RecoilValue<mixed>,
+  RecoilValue<mixed, mixed>,
   // $FlowFixMe[incompatible-type] added when improving typing for this parameters
 ) => RecoilValueReadOnly<Loadable<mixed>> = selectorFamily({
   key: '__noWait',

--- a/packages/recoil/recoil_values/Recoil_WaitFor.js.flow
+++ b/packages/recoil/recoil_values/Recoil_WaitFor.js.flow
@@ -8,83 +8,82 @@
  * @format
  * @flow strict-local
  */
- 'use strict';
+'use strict';
 
- import type {Loadable} from '../adt/Recoil_Loadable';
- import type {
-   RecoilValue,
-   RecoilValueReadOnly,
- } from '../core/Recoil_RecoilValue';
- 
- type UnwrapArrayRecoilValues<RecoilValues> = $TupleMap<
-   RecoilValues,
-   <T, U>(RecoilValue<T, U>) => T,
- >;
- type UnwrapArrayRecoilValueLoadables<RecoilValues> = $TupleMap<
-   RecoilValues,
-   <T, U>(RecoilValue<T, U>) => Loadable<T>,
- >;
- 
- type UnwrapObjRecoilValues<RecoilValues> = $ObjMap<
-   RecoilValues,
-   <T, U>(RecoilValue<T, U>) => T,
- >;
- type UnwrapObjRecoilValueLoadables<RecoilValues> = $ObjMap<
-   RecoilValues,
-   <T, U>(RecoilValue<T, U>) => Loadable<T>,
- >;
- 
- /* eslint-disable no-redeclare */
- 
- declare function waitForNone<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
- declare function waitForNone<
-   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
- >(
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
- 
- declare function waitForAny<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
- declare function waitForAny<
-   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
- >(
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
- 
- // waitForAll() does not return placeholder Promises or Errors in the results
- // as it only returns when all values are available.
- declare function waitForAll<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapArrayRecoilValues<RecoilValues>>;
- declare function waitForAll<
-   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
- >(
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapObjRecoilValues<RecoilValues>>;
- 
- declare function waitForAllSettled<
-   RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>, // flowlint-line unclear-type:off
- >(
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
- declare function waitForAllSettled<
-   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
- >(
-   RecoilValues,
- ): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
- 
- /* eslint-enable no-redeclare */
- 
- declare function noWait<T, U>(RecoilValue<T, U>): RecoilValueReadOnly<Loadable<T>>;
- 
- module.exports = {
-   waitForNone,
-   waitForAny,
-   waitForAll,
-   waitForAllSettled,
-   noWait,
- };
- 
+import type {Loadable} from '../adt/Recoil_Loadable';
+import type {
+  RecoilValue,
+  RecoilValueReadOnly,
+} from '../core/Recoil_RecoilValue';
+
+type UnwrapArrayRecoilValues<RecoilValues> = $TupleMap<
+  RecoilValues,
+  <T, U>(RecoilValue<T, U>) => T,
+>;
+type UnwrapArrayRecoilValueLoadables<RecoilValues> = $TupleMap<
+  RecoilValues,
+  <T, U>(RecoilValue<T, U>) => Loadable<T>,
+>;
+
+type UnwrapObjRecoilValues<RecoilValues> = $ObjMap<
+  RecoilValues,
+  <T, U>(RecoilValue<T, U>) => T,
+>;
+type UnwrapObjRecoilValueLoadables<RecoilValues> = $ObjMap<
+  RecoilValues,
+  <T, U>(RecoilValue<T, U>) => Loadable<T>,
+>;
+
+/* eslint-disable no-redeclare */
+
+declare function waitForNone<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
+declare function waitForNone<
+  RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+>(
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
+
+declare function waitForAny<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
+declare function waitForAny<
+  RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+>(
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
+
+// waitForAll() does not return placeholder Promises or Errors in the results
+// as it only returns when all values are available.
+declare function waitForAll<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapArrayRecoilValues<RecoilValues>>;
+declare function waitForAll<
+  RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+>(
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapObjRecoilValues<RecoilValues>>;
+
+declare function waitForAllSettled<
+  RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>, // flowlint-line unclear-type:off
+>(
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
+declare function waitForAllSettled<
+  RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+>(
+  RecoilValues,
+): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
+
+/* eslint-enable no-redeclare */
+
+declare function noWait<T, U>(RecoilValue<T, U>): RecoilValueReadOnly<Loadable<T>>;
+
+module.exports = {
+  waitForNone,
+  waitForAny,
+  waitForAll,
+  waitForAllSettled,
+  noWait,
+};

--- a/packages/recoil/recoil_values/Recoil_WaitFor.js.flow
+++ b/packages/recoil/recoil_values/Recoil_WaitFor.js.flow
@@ -8,82 +8,83 @@
  * @format
  * @flow strict-local
  */
-'use strict';
+ 'use strict';
 
-import type {Loadable} from '../adt/Recoil_Loadable';
-import type {
-  RecoilValue,
-  RecoilValueReadOnly,
-} from '../core/Recoil_RecoilValue';
-
-type UnwrapArrayRecoilValues<RecoilValues> = $TupleMap<
-  RecoilValues,
-  <T>(RecoilValue<T>) => T,
->;
-type UnwrapArrayRecoilValueLoadables<RecoilValues> = $TupleMap<
-  RecoilValues,
-  <T>(RecoilValue<T>) => Loadable<T>,
->;
-
-type UnwrapObjRecoilValues<RecoilValues> = $ObjMap<
-  RecoilValues,
-  <T>(RecoilValue<T>) => T,
->;
-type UnwrapObjRecoilValueLoadables<RecoilValues> = $ObjMap<
-  RecoilValues,
-  <T>(RecoilValue<T>) => Loadable<T>,
->;
-
-/* eslint-disable no-redeclare */
-
-declare function waitForNone<RecoilValues: $ReadOnlyArray<RecoilValue<any>>>( // flowlint-line unclear-type:off
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
-declare function waitForNone<
-  RecoilValues: $ReadOnly<{[string]: RecoilValue<any>, ...}>, // flowlint-line unclear-type:off
->(
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
-
-declare function waitForAny<RecoilValues: $ReadOnlyArray<RecoilValue<any>>>( // flowlint-line unclear-type:off
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
-declare function waitForAny<
-  RecoilValues: $ReadOnly<{[string]: RecoilValue<any>, ...}>, // flowlint-line unclear-type:off
->(
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
-
-// waitForAll() does not return placeholder Promises or Errors in the results
-// as it only returns when all values are available.
-declare function waitForAll<RecoilValues: $ReadOnlyArray<RecoilValue<any>>>( // flowlint-line unclear-type:off
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapArrayRecoilValues<RecoilValues>>;
-declare function waitForAll<
-  RecoilValues: $ReadOnly<{[string]: RecoilValue<any>, ...}>, // flowlint-line unclear-type:off
->(
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapObjRecoilValues<RecoilValues>>;
-
-declare function waitForAllSettled<
-  RecoilValues: $ReadOnlyArray<RecoilValue<any>>, // flowlint-line unclear-type:off
->(
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
-declare function waitForAllSettled<
-  RecoilValues: $ReadOnly<{[string]: RecoilValue<any>, ...}>, // flowlint-line unclear-type:off
->(
-  RecoilValues,
-): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
-
-/* eslint-enable no-redeclare */
-
-declare function noWait<T>(RecoilValue<T>): RecoilValueReadOnly<Loadable<T>>;
-
-module.exports = {
-  waitForNone,
-  waitForAny,
-  waitForAll,
-  waitForAllSettled,
-  noWait,
-};
+ import type {Loadable} from '../adt/Recoil_Loadable';
+ import type {
+   RecoilValue,
+   RecoilValueReadOnly,
+ } from '../core/Recoil_RecoilValue';
+ 
+ type UnwrapArrayRecoilValues<RecoilValues> = $TupleMap<
+   RecoilValues,
+   <T, U>(RecoilValue<T, U>) => T,
+ >;
+ type UnwrapArrayRecoilValueLoadables<RecoilValues> = $TupleMap<
+   RecoilValues,
+   <T, U>(RecoilValue<T, U>) => Loadable<T>,
+ >;
+ 
+ type UnwrapObjRecoilValues<RecoilValues> = $ObjMap<
+   RecoilValues,
+   <T, U>(RecoilValue<T, U>) => T,
+ >;
+ type UnwrapObjRecoilValueLoadables<RecoilValues> = $ObjMap<
+   RecoilValues,
+   <T, U>(RecoilValue<T, U>) => Loadable<T>,
+ >;
+ 
+ /* eslint-disable no-redeclare */
+ 
+ declare function waitForNone<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
+ declare function waitForNone<
+   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+ >(
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
+ 
+ declare function waitForAny<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
+ declare function waitForAny<
+   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+ >(
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
+ 
+ // waitForAll() does not return placeholder Promises or Errors in the results
+ // as it only returns when all values are available.
+ declare function waitForAll<RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>>( // flowlint-line unclear-type:off
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapArrayRecoilValues<RecoilValues>>;
+ declare function waitForAll<
+   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+ >(
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapObjRecoilValues<RecoilValues>>;
+ 
+ declare function waitForAllSettled<
+   RecoilValues: $ReadOnlyArray<RecoilValue<any, any>>, // flowlint-line unclear-type:off
+ >(
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapArrayRecoilValueLoadables<RecoilValues>>;
+ declare function waitForAllSettled<
+   RecoilValues: $ReadOnly<{[string]: RecoilValue<any, any>, ...}>, // flowlint-line unclear-type:off
+ >(
+   RecoilValues,
+ ): RecoilValueReadOnly<UnwrapObjRecoilValueLoadables<RecoilValues>>;
+ 
+ /* eslint-enable no-redeclare */
+ 
+ declare function noWait<T, U>(RecoilValue<T, U>): RecoilValueReadOnly<Loadable<T>>;
+ 
+ module.exports = {
+   waitForNone,
+   waitForAny,
+   waitForAll,
+   waitForAllSettled,
+   noWait,
+ };
+ 

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -559,43 +559,43 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
 
 // prettier-ignore
 function atom<T>(options: AtomOptions<T>): RecoilState<T> {
-   if (__DEV__) {
-     if (typeof options.key !== 'string') {
-       throw err(
-         'A key option with a unique string value must be provided when creating an atom.',
-       );
-     }
-   }
- 
-   const {
-     // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS,
-     ...restOptions
-   } = options;
-   const optionsDefault: RecoilValue<T, T> | Promise<T> | T = 'default' in options
-   ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
-     options.default
-   : new Promise(() => {});
- 
-   if (isRecoilValue(optionsDefault)
-     // Continue to use atomWithFallback for promise defaults for scoped atoms
-     // for now, since scoped atoms don't support async defaults
-    // @fb-only: || (isPromise(optionsDefault) && scopeRules_APPEND_ONLY_READ_THE_DOCS)
-   ) {
-     return atomWithFallback<T, T>({
-       ...restOptions,
-       default: optionsDefault,
-       // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS,
-     });
-   // @fb-only: } else if (scopeRules_APPEND_ONLY_READ_THE_DOCS && !isPromise(optionsDefault)) {
-     // @fb-only: return scopedAtom<T>({
-       // @fb-only: ...restOptions,
-       // @fb-only: default: optionsDefault,
-       // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS,
-     // @fb-only: });
-   } else {
-     return baseAtom<T>({...restOptions, default: optionsDefault});
-   }
- }
+  if (__DEV__) {
+    if (typeof options.key !== 'string') {
+      throw err(
+        'A key option with a unique string value must be provided when creating an atom.',
+      );
+    }
+  }
+
+  const {
+    // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS,
+    ...restOptions
+  } = options;
+  const optionsDefault: RecoilValue<T, T> | Promise<T> | T = 'default' in options
+  ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
+    options.default
+  : new Promise(() => {});
+
+  if (isRecoilValue(optionsDefault)
+    // Continue to use atomWithFallback for promise defaults for scoped atoms
+    // for now, since scoped atoms don't support async defaults
+  // @fb-only: || (isPromise(optionsDefault) && scopeRules_APPEND_ONLY_READ_THE_DOCS)
+  ) {
+    return atomWithFallback<T, T>({
+      ...restOptions,
+      default: optionsDefault,
+      // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS,
+    });
+  // @fb-only: } else if (scopeRules_APPEND_ONLY_READ_THE_DOCS && !isPromise(optionsDefault)) {
+    // @fb-only: return scopedAtom<T>({
+      // @fb-only: ...restOptions,
+      // @fb-only: default: optionsDefault,
+      // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS,
+    // @fb-only: });
+  } else {
+    return baseAtom<T>({...restOptions, default: optionsDefault});
+  }
+}
 
 type AtomWithFallbackOptions<T> = $ReadOnly<{
   ...AtomOptions<T>,

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -56,107 +56,107 @@ export type AtomFamilyOptions<T, P: Parameter> =
   | $ReadOnly<{
       ...AtomFamilyOptionsWithoutDefault<T, P>,
       default:
-        | RecoilValue<T>
+        | RecoilValue<T, T>
         | Promise<T>
         | T
-        | (P => T | RecoilValue<T> | Promise<T>),
+        | (P => T | RecoilValue<T, T> | Promise<T>),
     }>
   | AtomFamilyOptionsWithoutDefault<T, P>;
 
 // Process scopeRules to handle any entries which are functions taking parameters
 // prettier-ignore
 // @fb-only: function mapScopeRules<P>(
-  // @fb-only: scopeRules?: ParameterizedScopeRules<P>,
-  // @fb-only: param: P,
+// @fb-only: scopeRules?: ParameterizedScopeRules<P>,
+// @fb-only: param: P,
 // @fb-only: ): ScopeRules | void {
-  // @fb-only: return scopeRules?.map(rule =>
-    // @fb-only: Array.isArray(rule)
-      // @fb-only: ? rule.map(entry => (typeof entry === 'function' ? entry(param) : entry))
-      // @fb-only: : rule,
-  // @fb-only: );
+// @fb-only: return scopeRules?.map(rule =>
+// @fb-only: Array.isArray(rule)
+// @fb-only: ? rule.map(entry => (typeof entry === 'function' ? entry(param) : entry))
+// @fb-only: : rule,
+// @fb-only: );
 // @fb-only: }
 
 /*
-A function which returns an atom based on the input parameter.
-
-Each unique parameter returns a unique atom. E.g.,
-
-  const f = atomFamily(...);
-  f({a: 1}) => an atom
-  f({a: 2}) => a different atom
-
-This allows components to persist local, private state using atoms.  Each
-instance of the component may have a different key, which it uses as the
-parameter for a family of atoms; in this way, each component will have
-its own atom not shared by other instances.  These state keys may be composed
-into children's state keys as well.
-*/
+ A function which returns an atom based on the input parameter.
+ 
+ Each unique parameter returns a unique atom. E.g.,
+ 
+   const f = atomFamily(...);
+   f({a: 1}) => an atom
+   f({a: 2}) => a different atom
+ 
+ This allows components to persist local, private state using atoms.  Each
+ instance of the component may have a different key, which it uses as the
+ parameter for a family of atoms; in this way, each component will have
+ its own atom not shared by other instances.  These state keys may be composed
+ into children's state keys as well.
+ */
 function atomFamily<T, P: Parameter>(
-  options: AtomFamilyOptions<T, P>,
-): P => RecoilState<T> {
-  const atomCache = cacheFromPolicy<P, RecoilState<T>>({
-    equality: options.cachePolicyForParams_UNSTABLE?.equality ?? 'value',
-    eviction: 'keep-all',
-  });
-
-  // Simple atomFamily implementation to cache individual atoms based
-  // on the parameter value equality.
-  return (params: P) => {
-    const cachedAtom = atomCache.get(params);
-    if (cachedAtom != null) {
-      return cachedAtom;
-    }
-
-    const {cachePolicyForParams_UNSTABLE, ...atomOptions} = options;
-    const optionsDefault:
-      | RecoilValue<T>
-      | Promise<T>
-      | T
-      | (P => T | RecoilValue<T> | Promise<T>) =
-      'default' in options
-        ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
-          options.default
-        : new Promise(() => {});
-
-    const newAtom = atom<T>({
-      ...atomOptions,
-      key: `${options.key}__${stableStringify(params) ?? 'void'}`,
-      default:
-        typeof optionsDefault === 'function'
-          ? // The default was parameterized
-            // Flow doesn't know that T isn't a function, so we need to case to any
-            // $FlowIssue[incompatible-use]
-            optionsDefault(params)
-          : // Default may be a static value, promise, or RecoilValue
-            optionsDefault,
-
-      retainedBy_UNSTABLE:
-        typeof options.retainedBy_UNSTABLE === 'function'
-          ? options.retainedBy_UNSTABLE(params)
-          : options.retainedBy_UNSTABLE,
-
-      effects:
-        typeof options.effects === 'function'
-          ? options.effects(params)
-          : typeof options.effects_UNSTABLE === 'function'
-          ? options.effects_UNSTABLE(params)
-          : options.effects ?? options.effects_UNSTABLE,
-
-      // prettier-ignore
-      // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS: mapScopeRules(
-      // @fb-only: options.scopeRules_APPEND_ONLY_READ_THE_DOCS,
-      // @fb-only: params,
-      // @fb-only: ),
-    });
-
-    atomCache.set(params, newAtom);
-
-    setConfigDeletionHandler(newAtom.key, () => {
-      atomCache.delete(params);
-    });
-
-    return newAtom;
-  };
-}
+   options: AtomFamilyOptions<T, P>,
+ ): P => RecoilState<T> {
+   const atomCache = cacheFromPolicy<P, RecoilState<T>>({
+     equality: options.cachePolicyForParams_UNSTABLE?.equality ?? 'value',
+     eviction: 'keep-all',
+   });
+ 
+   // Simple atomFamily implementation to cache individual atoms based
+   // on the parameter value equality.
+   return (params: P) => {
+     const cachedAtom = atomCache.get(params);
+     if (cachedAtom != null) {
+       return cachedAtom;
+     }
+ 
+     const {cachePolicyForParams_UNSTABLE, ...atomOptions} = options;
+     const optionsDefault:
+       | RecoilValue<T, T>
+       | Promise<T>
+       | T
+       | (P => T | RecoilValue<T, T> | Promise<T>) =
+       'default' in options
+         ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
+           options.default
+         : new Promise(() => {});
+ 
+     const newAtom = atom<T>({
+       ...atomOptions,
+       key: `${options.key}__${stableStringify(params) ?? 'void'}`,
+       default:
+         typeof optionsDefault === 'function'
+           ? // The default was parameterized
+             // Flow doesn't know that T isn't a function, so we need to case to any
+             // $FlowIssue[incompatible-use]
+             optionsDefault(params)
+           : // Default may be a static value, promise, or RecoilValue
+             optionsDefault,
+ 
+       retainedBy_UNSTABLE:
+         typeof options.retainedBy_UNSTABLE === 'function'
+           ? options.retainedBy_UNSTABLE(params)
+           : options.retainedBy_UNSTABLE,
+ 
+       effects:
+         typeof options.effects === 'function'
+           ? options.effects(params)
+           : typeof options.effects_UNSTABLE === 'function'
+           ? options.effects_UNSTABLE(params)
+           : options.effects ?? options.effects_UNSTABLE,
+ 
+       // prettier-ignore
+       // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS: mapScopeRules(
+       // @fb-only: options.scopeRules_APPEND_ONLY_READ_THE_DOCS,
+       // @fb-only: params,
+       // @fb-only: ),
+     });
+ 
+     atomCache.set(params, newAtom);
+ 
+     setConfigDeletionHandler(newAtom.key, () => {
+       atomCache.delete(params);
+     });
+ 
+     return newAtom;
+   };
+ }
 
 module.exports = atomFamily;

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -77,86 +77,86 @@ export type AtomFamilyOptions<T, P: Parameter> =
 // @fb-only: }
 
 /*
- A function which returns an atom based on the input parameter.
- 
- Each unique parameter returns a unique atom. E.g.,
- 
-   const f = atomFamily(...);
-   f({a: 1}) => an atom
-   f({a: 2}) => a different atom
- 
- This allows components to persist local, private state using atoms.  Each
- instance of the component may have a different key, which it uses as the
- parameter for a family of atoms; in this way, each component will have
- its own atom not shared by other instances.  These state keys may be composed
- into children's state keys as well.
- */
+A function which returns an atom based on the input parameter.
+
+Each unique parameter returns a unique atom. E.g.,
+
+  const f = atomFamily(...);
+  f({a: 1}) => an atom
+  f({a: 2}) => a different atom
+
+This allows components to persist local, private state using atoms.  Each
+instance of the component may have a different key, which it uses as the
+parameter for a family of atoms; in this way, each component will have
+its own atom not shared by other instances.  These state keys may be composed
+into children's state keys as well.
+*/
 function atomFamily<T, P: Parameter>(
-   options: AtomFamilyOptions<T, P>,
+  options: AtomFamilyOptions<T, P>,
  ): P => RecoilState<T> {
-   const atomCache = cacheFromPolicy<P, RecoilState<T>>({
-     equality: options.cachePolicyForParams_UNSTABLE?.equality ?? 'value',
-     eviction: 'keep-all',
-   });
+  const atomCache = cacheFromPolicy<P, RecoilState<T>>({
+    equality: options.cachePolicyForParams_UNSTABLE?.equality ?? 'value',
+    eviction: 'keep-all',
+  });
  
    // Simple atomFamily implementation to cache individual atoms based
    // on the parameter value equality.
-   return (params: P) => {
-     const cachedAtom = atomCache.get(params);
-     if (cachedAtom != null) {
-       return cachedAtom;
-     }
- 
-     const {cachePolicyForParams_UNSTABLE, ...atomOptions} = options;
-     const optionsDefault:
-       | RecoilValue<T, T>
-       | Promise<T>
-       | T
-       | (P => T | RecoilValue<T, T> | Promise<T>) =
-       'default' in options
-         ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
-           options.default
-         : new Promise(() => {});
- 
-     const newAtom = atom<T>({
-       ...atomOptions,
-       key: `${options.key}__${stableStringify(params) ?? 'void'}`,
-       default:
-         typeof optionsDefault === 'function'
-           ? // The default was parameterized
-             // Flow doesn't know that T isn't a function, so we need to case to any
-             // $FlowIssue[incompatible-use]
-             optionsDefault(params)
-           : // Default may be a static value, promise, or RecoilValue
-             optionsDefault,
- 
-       retainedBy_UNSTABLE:
-         typeof options.retainedBy_UNSTABLE === 'function'
-           ? options.retainedBy_UNSTABLE(params)
-           : options.retainedBy_UNSTABLE,
- 
-       effects:
-         typeof options.effects === 'function'
-           ? options.effects(params)
-           : typeof options.effects_UNSTABLE === 'function'
-           ? options.effects_UNSTABLE(params)
-           : options.effects ?? options.effects_UNSTABLE,
- 
-       // prettier-ignore
-       // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS: mapScopeRules(
-       // @fb-only: options.scopeRules_APPEND_ONLY_READ_THE_DOCS,
-       // @fb-only: params,
-       // @fb-only: ),
-     });
- 
-     atomCache.set(params, newAtom);
- 
-     setConfigDeletionHandler(newAtom.key, () => {
-       atomCache.delete(params);
-     });
- 
-     return newAtom;
-   };
- }
+  return (params: P) => {
+    const cachedAtom = atomCache.get(params);
+    if (cachedAtom != null) {
+      return cachedAtom;
+    }
+
+    const {cachePolicyForParams_UNSTABLE, ...atomOptions} = options;
+    const optionsDefault:
+      | RecoilValue<T, T>
+      | Promise<T>
+      | T
+      | (P => T | RecoilValue<T, T> | Promise<T>) =
+      'default' in options
+        ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
+          options.default
+        : new Promise(() => {});
+
+    const newAtom = atom<T>({
+      ...atomOptions,
+      key: `${options.key}__${stableStringify(params) ?? 'void'}`,
+      default:
+        typeof optionsDefault === 'function'
+          ? // The default was parameterized
+            // Flow doesn't know that T isn't a function, so we need to case to any
+            // $FlowIssue[incompatible-use]
+            optionsDefault(params)
+          : // Default may be a static value, promise, or RecoilValue
+            optionsDefault,
+
+      retainedBy_UNSTABLE:
+        typeof options.retainedBy_UNSTABLE === 'function'
+          ? options.retainedBy_UNSTABLE(params)
+          : options.retainedBy_UNSTABLE,
+
+      effects:
+        typeof options.effects === 'function'
+          ? options.effects(params)
+          : typeof options.effects_UNSTABLE === 'function'
+          ? options.effects_UNSTABLE(params)
+          : options.effects ?? options.effects_UNSTABLE,
+
+      // prettier-ignore
+      // @fb-only: scopeRules_APPEND_ONLY_READ_THE_DOCS: mapScopeRules(
+      // @fb-only: options.scopeRules_APPEND_ONLY_READ_THE_DOCS,
+      // @fb-only: params,
+      // @fb-only: ),
+    });
+
+    atomCache.set(params, newAtom);
+
+    setConfigDeletionHandler(newAtom.key, () => {
+      atomCache.delete(params);
+    });
+
+    return newAtom;
+  };
+}
 
 module.exports = atomFamily;

--- a/packages/recoil/recoil_values/Recoil_callbackTypes.js
+++ b/packages/recoil/recoil_values/Recoil_callbackTypes.js
@@ -13,12 +13,15 @@
 import type {DefaultValue} from '../core/Recoil_Node';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
 
-export type ValueOrUpdater<T> =
-  | T
+export type ValueOrUpdater<T, U> =
+  | U
   | DefaultValue
-  | ((prevValue: T) => T | DefaultValue);
-export type GetRecoilValue = <T>(RecoilValue<T>) => T;
-export type SetRecoilState = <T>(RecoilState<T>, ValueOrUpdater<T>) => void;
-export type ResetRecoilState = <T>(RecoilState<T>) => void;
+  | ((prevValue: T) => U | DefaultValue);
+export type GetRecoilValue = <T, U>(RecoilValue<T, U>) => T;
+export type SetRecoilState = <T, U>(
+  RecoilState<T, U>,
+  ValueOrUpdater<T, U>,
+) => void;
+export type ResetRecoilState = <T, U>(RecoilState<T, U>) => void;
 
 module.exports = ({}: {...});

--- a/packages/recoil/recoil_values/Recoil_constSelector.js
+++ b/packages/recoil/recoil_values/Recoil_constSelector.js
@@ -16,7 +16,7 @@ import type {Parameter} from './Recoil_selectorFamily';
 const selectorFamily = require('./Recoil_selectorFamily');
 
 // flowlint-next-line unclear-type:off
-const constantSelector = selectorFamily<any, any>({
+const constantSelector = selectorFamily<any, any, any>({
   key: '__constant',
   get: constant => () => constant,
   cachePolicyForParams_UNSTABLE: {

--- a/packages/recoil/recoil_values/Recoil_errorSelector.js
+++ b/packages/recoil/recoil_values/Recoil_errorSelector.js
@@ -16,7 +16,7 @@ const selectorFamily = require('./Recoil_selectorFamily');
 const err = require('recoil-shared/util/Recoil_err');
 
 // flowlint-next-line unclear-type:off
-const throwingSelector = selectorFamily<any, any>({
+const throwingSelector = selectorFamily<any, any, any>({
   key: '__error',
   get: message => () => {
     throw err(message);

--- a/packages/recoil/recoil_values/Recoil_readOnlySelector.js
+++ b/packages/recoil/recoil_values/Recoil_readOnlySelector.js
@@ -18,7 +18,9 @@ import type {
   RecoilValueReadOnly,
 } from '../core/Recoil_RecoilValue';
 
-function readOnlySelector<T>(atom: RecoilValue<T>): RecoilValueReadOnly<T> {
+function readOnlySelector<T, U>(
+  atom: RecoilValue<T, U>,
+): RecoilValueReadOnly<T> {
   // flowlint-next-line unclear-type: off
   return (atom: any);
 }

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -277,7 +277,6 @@ function selector<T, U = T>(
     depValues: DepValues,
   ): void {
     setCache(state, loadable, depValues);
-    setDepsInStore(store, state, new Set(depValues.keys()), executionId);
     notifyStoresOfResolvedAsync(store, executionId);
   }
 
@@ -647,18 +646,6 @@ function selector<T, U = T>(
       );
       deps.forEach(nodeKey => discoveredDependencyNodeKeys.add(nodeKey));
     }
-  }
-
-  function setNewDepInStore(
-    store: Store,
-    state: TreeState,
-    deps: Set<NodeKey>,
-    newDepKey: NodeKey,
-    executionId: ?ExecutionId,
-  ): void {
-    deps.add(newDepKey);
-
-    setDepsInStore(store, state, deps, executionId);
   }
 
   function evaluateSelectorGetter(

--- a/packages/recoil/recoil_values/__flowtests__/Recoil_WaitFor-flowtest.js
+++ b/packages/recoil/recoil_values/__flowtests__/Recoil_WaitFor-flowtest.js
@@ -23,14 +23,8 @@ const {
   waitForNone,
 } = require('../Recoil_WaitFor');
 
-const numberAtom: RecoilState<number> = atom({
-  key: 'number',
-  default: 0,
-});
-const stringAtom: RecoilState<string> = atom({
-  key: 'string',
-  default: '',
-});
+const numberAtom: RecoilState<number> = atom({key: 'number', default: 0});
+const stringAtom: RecoilState<string> = atom({key: 'string', default: ''});
 
 // eslint-disable-next-line no-unused-vars
 let num: number;

--- a/packages/recoil/recoil_values/__flowtests__/Recoil_WaitFor-flowtest.js
+++ b/packages/recoil/recoil_values/__flowtests__/Recoil_WaitFor-flowtest.js
@@ -23,8 +23,14 @@ const {
   waitForNone,
 } = require('../Recoil_WaitFor');
 
-const numberAtom: RecoilState<number> = atom({key: 'number', default: 0});
-const stringAtom: RecoilState<string> = atom({key: 'string', default: ''});
+const numberAtom: RecoilState<number> = atom({
+  key: 'number',
+  default: 0,
+});
+const stringAtom: RecoilState<string> = atom({
+  key: 'string',
+  default: '',
+});
 
 // eslint-disable-next-line no-unused-vars
 let num: number;

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -210,18 +210,18 @@ function renderElementsWithSuspenseCount(
 ////////////////////////////////////////
 let id = 0;
 
-function stringAtom(): RecoilState<string> {
+function stringAtom(): RecoilState<string, string> {
   return atom({key: `StringAtom-${id++}`, default: 'DEFAULT'});
 }
 
-const errorThrowingAsyncSelector: <T, S>(
+const errorThrowingAsyncSelector: <T, S, U>(
   string,
-  ?RecoilValue<S>,
-) => RecoilValue<T> = <T, S>(
+  ?RecoilValue<S, U>,
+) => RecoilValue<T, U> = <T, S, U>(
   msg,
-  dep: ?RecoilValue<S>,
+  dep: ?RecoilValue<S, U>,
 ): RecoilValueReadOnly<T> =>
-  selector<T>({
+  selector<T, T>({
     key: `AsyncErrorThrowingSelector${id++}`,
     get: ({get}) => {
       if (dep != null) {
@@ -231,7 +231,7 @@ const errorThrowingAsyncSelector: <T, S>(
     },
   });
 
-const resolvingAsyncSelector: <T>(T) => RecoilValue<T> = <T>(
+const resolvingAsyncSelector: <T, U>(T) => RecoilValue<T, U> = <T>(
   value: T,
   // $FlowFixMe[incompatible-type]
 ): RecoilValueReadOnly<T> | RecoilValueReadOnly<mixed> =>
@@ -246,9 +246,9 @@ const loadingAsyncSelector: () => RecoilValueReadOnly<void> = () =>
     get: () => new Promise(() => {}),
   });
 
-function asyncSelector<T, S>(
-  dep?: RecoilValue<S>,
-): [RecoilValue<T>, (T) => void, (Error) => void] {
+function asyncSelector<T, S, U>(
+  dep?: RecoilValue<S, U>,
+): [RecoilValue<T, U>, (T) => void, (Error) => void] {
   let resolve = () => invariant(false, 'bug in test code'); // make flow happy with initialization
   let reject = () => invariant(false, 'bug in test code');
   const promise = new Promise((res, rej) => {
@@ -271,10 +271,10 @@ function asyncSelector<T, S>(
 // Useful Components for testing
 //////////////////////////////////
 
-function ReadsAtom<T>({
+function ReadsAtom<T, U>({
   atom, // eslint-disable-line no-shadow
 }: {
-  atom: RecoilValue<T>,
+  atom: RecoilValue<T, U>,
 }): React.Node {
   return stableStringify(useRecoilValue(atom));
 }
@@ -284,9 +284,9 @@ function ReadsAtom<T>({
 //   setValue(T),
 //   resetValue()
 // ]
-function componentThatReadsAndWritesAtom<T>(
-  recoilState: RecoilState<T>,
-): [() => React.Node, (T) => void, () => void] {
+function componentThatReadsAndWritesAtom<T, U>(
+  recoilState: RecoilState<T, U>,
+): [() => React.Node, (U) => void, () => void] {
   let setValue;
   let resetValue;
   const ReadsAndWritesAtom = (): React.Node => {
@@ -296,7 +296,7 @@ function componentThatReadsAndWritesAtom<T>(
   };
   return [
     ReadsAndWritesAtom,
-    (value: T) => setValue(value),
+    (value: U) => setValue(value),
     () => resetValue(),
   ];
 }

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -13,174 +13,195 @@
  * This file is a manual translation of the flow types, which are the source of truth, so we should not introduce new terminology or behavior in this file.
  */
 
- export { };
+export {};
 
- import * as React from 'react';
+import * as React from 'react';
 
- // state.d.ts
- type NodeKey = string;
+// state.d.ts
+type NodeKey = string;
 
- // node.d.ts
- export class DefaultValue {
+// node.d.ts
+export class DefaultValue {
   private __tag: 'DefaultValue';
- }
+}
 
- // recoilRoot.d.ts
- export type RecoilRootProps = {
-  initializeState?: (mutableSnapshot: MutableSnapshot) => void,
-  override?: true,
- } | {override: false};
+// recoilRoot.d.ts
+export type RecoilRootProps =
+  | {
+      initializeState?: (mutableSnapshot: MutableSnapshot) => void;
+      override?: true;
+    }
+  | {override: false};
 
- /**
-  * Root component for managing Recoil state.  Most Recoil hooks should be
-  * called from a component nested in a <RecoilRoot>
-  */
- export const RecoilRoot: React.FC<RecoilRootProps>;
+/**
+ * Root component for managing Recoil state.  Most Recoil hooks should be
+ * called from a component nested in a <RecoilRoot>
+ */
+export const RecoilRoot: React.FC<RecoilRootProps>;
 
- // Snapshot.d.ts
- declare const SnapshotID_OPAQUE: unique symbol;
- export interface SnapshotID {
+// Snapshot.d.ts
+declare const SnapshotID_OPAQUE: unique symbol;
+export interface SnapshotID {
   readonly [SnapshotID_OPAQUE]: true;
- }
+}
 
- interface ComponentInfo {
+interface ComponentInfo {
   name: string;
- }
+}
 
- interface RecoilStateInfo<T> {
+interface RecoilStateInfo<T, U> {
   loadable?: Loadable<T>;
   isActive: boolean;
   isSet: boolean;
   isModified: boolean; // TODO report modified selectors
   type: 'atom' | 'selector';
-  deps: Iterable<RecoilValue<T>>;
+  deps: Iterable<RecoilValue<T, U>>;
   subscribers: {
-    nodes: Iterable<RecoilValue<T>>,
-    components: Iterable<ComponentInfo>,
+    nodes: Iterable<RecoilValue<T, U>>;
+    components: Iterable<ComponentInfo>;
   };
- }
+}
 
- export class Snapshot {
+export class Snapshot {
   getID(): SnapshotID;
-  getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
-  getPromise<T>(recoilValue: RecoilValue<T>): Promise<T>;
-  getNodes_UNSTABLE(opts?: { isModified?: boolean, isInitialized?: boolean }): Iterable<RecoilValue<unknown>>;
-  getInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): RecoilStateInfo<T>;
+  getLoadable<T, U>(recoilValue: RecoilValue<T, U>): Loadable<T>;
+  getPromise<T, U>(recoilValue: RecoilValue<T, U>): Promise<T>;
+  getNodes_UNSTABLE(opts?: {
+    isModified?: boolean;
+    isInitialized?: boolean;
+  }): Iterable<RecoilValue<unknown, unknown>>;
+  getInfo_UNSTABLE<T, U>(recoilValue: RecoilValue<T, U>): RecoilStateInfo<T, U>;
   map(cb: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
-  asyncMap(cb: (mutableSnapshot: MutableSnapshot) => Promise<void>): Promise<Snapshot>;
+  asyncMap(
+    cb: (mutableSnapshot: MutableSnapshot) => Promise<void>,
+  ): Promise<Snapshot>;
   retain(): () => void;
   isRetained(): boolean;
- }
+}
 
- export class MutableSnapshot extends Snapshot {
+export class MutableSnapshot extends Snapshot {
   set: SetRecoilState;
   reset: ResetRecoilState;
- }
+}
 
- // Effect is called the first time a node is used with a <RecoilRoot>
- export type AtomEffect<T> = (param: {
-  node: RecoilState<T>,
-  storeID: StoreID,
-  trigger: 'set' | 'get',
+// Effect is called the first time a node is used with a <RecoilRoot>
+export type AtomEffect<T> = (param: {
+  node: RecoilState<T, T>;
+  storeID: StoreID;
+  trigger: 'set' | 'get';
 
   // Call synchronously to initialize value or async to change it later
-  setSelf: (param:
-    | T
-    | DefaultValue
-    | Promise<T | DefaultValue>
-    | ((param: T | DefaultValue) => T | DefaultValue),
-  ) => void,
-  resetSelf: () => void,
+  setSelf: (
+    param:
+      | T
+      | DefaultValue
+      | Promise<T | DefaultValue>
+      | ((param: T | DefaultValue) => T | DefaultValue),
+  ) => void;
+  resetSelf: () => void;
 
   // Subscribe callbacks to events.
   // Atom effect observers are called before global transaction observers
   onSet: (
     param: (newValue: T, oldValue: T | DefaultValue, isReset: boolean) => void,
-  ) => void,
+  ) => void;
 
   // Accessors to read other atoms/selectors
-  getPromise: <S>(recoilValue: RecoilValue<S>) => Promise<S>,
-  getLoadable: <S>(recoilValue: RecoilValue<S>) => Loadable<S>,
-  getInfo_UNSTABLE: <S>(recoilValue: RecoilValue<S>) => RecoilStateInfo<S>,
- }) => void | (() => void);
+  getPromise: <S>(recoilValue: RecoilValue<S, S>) => Promise<S>;
+  getLoadable: <S>(recoilValue: RecoilValue<S, S>) => Loadable<S>;
+  getInfo_UNSTABLE: <S>(
+    recoilValue: RecoilValue<S, S>,
+  ) => RecoilStateInfo<S, S>;
+}) => void | (() => void);
 
- // atom.d.ts
- interface AtomOptionsWithoutDefault<T> {
-   key: NodeKey;
-   effects?: ReadonlyArray<AtomEffect<T>>;
-   effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
-   dangerouslyAllowMutability?: boolean;
- }
- interface AtomOptionsWithDefault<T> extends AtomOptionsWithoutDefault<T> {
-   default: RecoilValue<T> | Promise<T> | T;
- }
- export type AtomOptions<T> = AtomOptionsWithoutDefault<T> | AtomOptionsWithDefault<T>;
+// atom.d.ts
+interface AtomOptionsWithoutDefault<T> {
+  key: NodeKey;
+  effects?: ReadonlyArray<AtomEffect<T>>;
+  effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
+  dangerouslyAllowMutability?: boolean;
+}
+interface AtomOptionsWithDefault<T> extends AtomOptionsWithoutDefault<T> {
+  default: RecoilValue<T, T> | Promise<T> | T;
+}
+export type AtomOptions<T> =
+  | AtomOptionsWithoutDefault<T>
+  | AtomOptionsWithDefault<T>;
 
- /**
-  * Creates an atom, which represents a piece of writeable state
-  */
- export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
+/**
+ * Creates an atom, which represents a piece of writeable state
+ */
+export function atom<T>(options: AtomOptions<T>): RecoilState<T, T>;
 
- export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
- export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
- export type Resetter = () => void;
- export interface TransactionInterface_UNSTABLE {
-  get<T>(a: RecoilValue<T>): T;
-  set<T>(s: RecoilState<T>, u: ((currVal: T) => T) | T): void;
-  reset(s: RecoilState<any>): void;
- }
- export interface CallbackInterface {
-  set: <T>(recoilVal: RecoilState<T>, valOrUpdater: ((currVal: T) => T) | T) => void;
-  reset: (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
-  refresh: (recoilValue: RecoilValue<any>) => void;
+export type GetRecoilValue = <T>(recoilVal: RecoilValue<T, T>) => T;
+export type SetterOrUpdater<T, U> = (
+  valOrUpdater: ((currVal: T) => U) | U,
+) => void;
+export type Resetter = () => void;
+export interface TransactionInterface_UNSTABLE {
+  get<T, U>(a: RecoilValue<T, U>): T;
+  set<T, U>(s: RecoilState<T, U>, u: ((currVal: T) => U) | U): void;
+  reset(s: RecoilState<any, any>): void;
+}
+export interface CallbackInterface {
+  set: <T, U>(
+    recoilVal: RecoilState<T, U>,
+    valOrUpdater: ((currVal: T) => U) | U,
+  ) => void;
+  reset: (recoilVal: RecoilState<any, any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  refresh: (recoilValue: RecoilValue<any, any>) => void;
   snapshot: Snapshot;
   gotoSnapshot: (snapshot: Snapshot) => void;
   transact_UNSTABLE: (cb: (i: TransactionInterface_UNSTABLE) => void) => void;
- }
+}
 
- // selector.d.ts
- export interface SelectorCallbackInterface extends CallbackInterface {
-   node: RecoilState<unknown>; // TODO This isn't properly typed
- }
- export type GetCallback = <Args extends ReadonlyArray<unknown>, Return>(
+// selector.d.ts
+export interface SelectorCallbackInterface extends CallbackInterface {
+  node: RecoilState<unknown, unknown>; // TODO This isn't properly typed
+}
+export type GetCallback = <Args extends ReadonlyArray<unknown>, Return>(
   fn: (interface: SelectorCallbackInterface) => (...args: Args) => Return,
- ) => (...args: Args) => Return;
+) => (...args: Args) => Return;
 
- export type SetRecoilState = <T>(
-    recoilVal: RecoilState<T>,
-    newVal: T | DefaultValue | ((prevValue: T) => T | DefaultValue),
- ) => void;
+export type SetRecoilState = <T, U>(
+  recoilVal: RecoilState<T, U>,
+  newVal: U | DefaultValue | ((prevValue: T) => U | DefaultValue),
+) => void;
 
- export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+export type ResetRecoilState = (recoilVal: RecoilState<any, any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
 
- // export type EqualityPolicy = 'reference' | 'value'; TODO: removing while we discuss long term API
+// export type EqualityPolicy = 'reference' | 'value'; TODO: removing while we discuss long term API
 
- export type EvictionPolicy = 'lru' | 'keep-all' | 'most-recent';
+export type EvictionPolicy = 'lru' | 'keep-all' | 'most-recent';
 
- // TODO: removing while we discuss long term API
- // export type CachePolicy =
- //   | {eviction: 'lru', maxSize: number, equality?: EqualityPolicy}
- //   | {eviction: 'none', equality?: EqualityPolicy}
- //   | {eviction?: undefined, equality: EqualityPolicy};
+// TODO: removing while we discuss long term API
+// export type CachePolicy =
+//   | {eviction: 'lru', maxSize: number, equality?: EqualityPolicy}
+//   | {eviction: 'none', equality?: EqualityPolicy}
+//   | {eviction?: undefined, equality: EqualityPolicy};
 
- // TODO: removing while we discuss long term API
- // export interface CachePolicyWithoutEviction {
- //   equality: EqualityPolicy;
- // }
+// TODO: removing while we discuss long term API
+// export interface CachePolicyWithoutEviction {
+//   equality: EqualityPolicy;
+// }
 
- export type CachePolicyWithoutEquality = {eviction: 'lru', maxSize: number} | {eviction: 'keep-all'} | {eviction: 'most-recent'};
+export type CachePolicyWithoutEquality =
+  | {eviction: 'lru'; maxSize: number}
+  | {eviction: 'keep-all'}
+  | {eviction: 'most-recent'};
 
- export interface ReadOnlySelectorOptions<T> {
-    key: string;
-    get: (opts: {
-      get: GetRecoilValue,
-      getCallback: GetCallback,
-    }) => Promise<T> | RecoilValue<T> | T;
-    dangerouslyAllowMutability?: boolean;
-    cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
- }
+export interface ReadOnlySelectorOptions<T> {
+  key: string;
+  get: (opts: {
+    get: GetRecoilValue;
+    getCallback: GetCallback;
+  }) => Promise<T> | RecoilValue<T, T> | T;
+  dangerouslyAllowMutability?: boolean;
+  cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
+}
 
- export interface ReadWriteSelectorOptions<T> extends ReadOnlySelectorOptions<T> {
+export interface ReadWriteSelectorOptions<T>
+  extends ReadOnlySelectorOptions<T> {
   set: (
     opts: {
       set: SetRecoilState;
@@ -189,129 +210,152 @@
     },
     newValue: T | DefaultValue,
   ) => void;
- }
+}
 
- /**
-  * Creates a selector which represents derived state.
-  */
- export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<T>;
- export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
+/**
+ * Creates a selector which represents derived state.
+ */
+export function selector<T, U = T>(
+  options: ReadWriteSelectorOptions<T>,
+): RecoilState<T, U>;
+export function selector<T>(
+  options: ReadOnlySelectorOptions<T>,
+): RecoilValueReadOnly<T>;
 
- // hooks.d.ts
+// hooks.d.ts
 
- /**
-  * Returns the value of an atom or selector (readonly or writeable) and
-  * subscribes the components to future updates of that state.
-  */
- export function useRecoilValue<T>(recoilValue: RecoilValue<T>): T;
+/**
+ * Returns the value of an atom or selector (readonly or writeable) and
+ * subscribes the components to future updates of that state.
+ */
+export function useRecoilValue<T, U = T>(recoilValue: RecoilValue<T, U>): T;
 
- /**
-  * Returns a Loadable representing the status of the given Recoil state
-  * and subscribes the component to future updates of that state. Useful
-  * for working with async selectors.
-  */
- export function useRecoilValueLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
+/**
+ * Returns a Loadable representing the status of the given Recoil state
+ * and subscribes the component to future updates of that state. Useful
+ * for working with async selectors.
+ */
+export function useRecoilValueLoadable<T, U = T>(
+  recoilValue: RecoilValue<T, U>,
+): Loadable<T>;
 
- /**
-  * Returns a tuple where the first element is the value of the recoil state
-  * and the second is a setter to update that state. Subscribes component
-  * to updates of the given state.
-  */
- export function useRecoilState<T>(recoilState: RecoilState<T>): [T, SetterOrUpdater<T>];
+/**
+ * Returns a tuple where the first element is the value of the recoil state
+ * and the second is a setter to update that state. Subscribes component
+ * to updates of the given state.
+ */
+export function useRecoilState<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): [T, SetterOrUpdater<T, U>];
 
- /**
-  * Returns a tuple where the first element is a Loadable and the second
-  * element is a setter function to update the given state. Subscribes
-  * component to updates of the given state.
-  */
- export function useRecoilStateLoadable<T>(recoilState: RecoilState<T>): [Loadable<T>, SetterOrUpdater<T>];
+/**
+ * Returns a tuple where the first element is a Loadable and the second
+ * element is a setter function to update the given state. Subscribes
+ * component to updates of the given state.
+ */
+export function useRecoilStateLoadable<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): [Loadable<T>, SetterOrUpdater<T, U>];
 
- /**
-  * Returns a setter function for updating Recoil state. Does not subscribe
-  * the component to the given state.
-  */
+/**
+ * Returns a setter function for updating Recoil state. Does not subscribe
+ * the component to the given state.
+ */
 
- export function useSetRecoilState<T>(recoilState: RecoilState<T>): SetterOrUpdater<T>;
+export function useSetRecoilState<T, U = T>(
+  recoilState: RecoilState<T, U>,
+): SetterOrUpdater<T, U>;
 
- /**
-  * Returns a function that will reset the given state to its default value.
-  */
- export function useResetRecoilState(recoilState: RecoilState<any>): Resetter; // eslint-disable-line @typescript-eslint/no-explicit-any
+/**
+ * Returns a function that will reset the given state to its default value.
+ */
+export function useResetRecoilState(
+  recoilState: RecoilState<any, any>,
+): Resetter; // eslint-disable-line @typescript-eslint/no-explicit-any
 
- /**
-  * Returns current info about an atom
-  */
- export function useGetRecoilValueInfo_UNSTABLE(): <T>(recoilValue: RecoilValue<T>) => RecoilStateInfo<T>;
+/**
+ * Returns current info about an atom
+ */
+export function useGetRecoilValueInfo_UNSTABLE(): <T, U>(
+  recoilValue: RecoilValue<T, U>,
+) => RecoilStateInfo<T, U>;
 
 /**
  * Experimental version of hooks for useTransition() support
  */
- export function useRecoilValue_TRANSITION_SUPPORT_UNSTABLE<T>(recoilValue: RecoilValue<T>): T;
- export function useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE<T>(recoilValue: RecoilValue<T>): Loadable<T>;
- export function useRecoilState_TRANSITION_SUPPORT_UNSTABLE<T>(recoilState: RecoilState<T>): [T, SetterOrUpdater<T>];
+export function useRecoilValue_TRANSITION_SUPPORT_UNSTABLE<T, U>(
+  recoilValue: RecoilValue<T, U>,
+): T;
+export function useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE<T, U>(
+  recoilValue: RecoilValue<T, U>,
+): Loadable<T>;
+export function useRecoilState_TRANSITION_SUPPORT_UNSTABLE<T, U>(
+  recoilState: RecoilState<T, U>,
+): [T, SetterOrUpdater<T, U>];
 
- /**
-  * Returns a function that will run the callback that was passed when
-  * calling this hook. Useful for accessing Recoil state in response to
-  * events.
-  */
- export function useRecoilCallback<Args extends ReadonlyArray<unknown>, Return>(
+/**
+ * Returns a function that will run the callback that was passed when
+ * calling this hook. Useful for accessing Recoil state in response to
+ * events.
+ */
+export function useRecoilCallback<Args extends ReadonlyArray<unknown>, Return>(
   fn: (interface: CallbackInterface) => (...args: Args) => Return,
   deps?: ReadonlyArray<unknown>,
- ): (...args: Args) => Return;
+): (...args: Args) => Return;
 
- /**
-  * Returns a function that executes an atomic transaction for updating Recoil state.
-  */
- export function useRecoilTransaction_UNSTABLE<Args extends ReadonlyArray<unknown>>(
+/**
+ * Returns a function that executes an atomic transaction for updating Recoil state.
+ */
+export function useRecoilTransaction_UNSTABLE<
+  Args extends ReadonlyArray<unknown>,
+>(
   fn: (interface: TransactionInterface_UNSTABLE) => (...args: Args) => void,
   deps?: ReadonlyArray<unknown>,
- ): (...args: Args) => void;
+): (...args: Args) => void;
 
- export function useRecoilTransactionObserver_UNSTABLE(
-  callback: (opts: {
-    snapshot: Snapshot,
-    previousSnapshot: Snapshot,
-  }) => void,
- ): void;
+export function useRecoilTransactionObserver_UNSTABLE(
+  callback: (opts: {snapshot: Snapshot; previousSnapshot: Snapshot}) => void,
+): void;
 
- /**
-  * Updates Recoil state to match the provided snapshot.
-  */
- export function useGotoRecoilSnapshot(): (snapshot: Snapshot) => void;
+/**
+ * Updates Recoil state to match the provided snapshot.
+ */
+export function useGotoRecoilSnapshot(): (snapshot: Snapshot) => void;
 
- /**
-  * Returns a snapshot of the current Recoil state and subscribes the component
-  * to re-render when any state is updated.
-  */
- export function useRecoilSnapshot(): Snapshot;
+/**
+ * Returns a snapshot of the current Recoil state and subscribes the component
+ * to re-render when any state is updated.
+ */
+export function useRecoilSnapshot(): Snapshot;
 
- // useRecoilRefresher.d.ts
- /**
-  * Clears the cache for a selector causing it to be reevaluated.
-  */
- export function useRecoilRefresher_UNSTABLE(recoilValue: RecoilValue<any>): () => void;
+// useRecoilRefresher.d.ts
+/**
+ * Clears the cache for a selector causing it to be reevaluated.
+ */
+export function useRecoilRefresher_UNSTABLE(
+  recoilValue: RecoilValue<any, any>,
+): () => void;
 
- // useRecoilBridgeAcrossReactRoots.d.ts
- export const RecoilBridge: React.FC;
- /**
-  * Returns a component that acts like a <RecoilRoot> but shares the same store
-  * as the current <RecoilRoot>.
-  */
- export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
+// useRecoilBridgeAcrossReactRoots.d.ts
+export const RecoilBridge: React.FC;
+/**
+ * Returns a component that acts like a <RecoilRoot> but shares the same store
+ * as the current <RecoilRoot>.
+ */
+export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
 
- // useRecoilStoreID
- declare const StoreID_OPAQUE: unique symbol;
- export interface StoreID {
+// useRecoilStoreID
+declare const StoreID_OPAQUE: unique symbol;
+export interface StoreID {
   readonly [StoreID_OPAQUE]: true;
- }
- /**
-  * Returns an ID for the currently active state store of the host <RecoilRoot>
-  */
- export function useRecoilStoreID(): StoreID;
+}
+/**
+ * Returns an ID for the currently active state store of the host <RecoilRoot>
+ */
+export function useRecoilStoreID(): StoreID;
 
- // loadable.d.ts
- interface BaseLoadable<T> {
+// loadable.d.ts
+interface BaseLoadable<T> {
   getValue: () => T;
   toPromise: () => Promise<T>;
   valueOrThrow: () => T;
@@ -319,141 +363,159 @@
   promiseOrThrow: () => Promise<T>;
   is: (other: Loadable<any>) => boolean;
   map: <S>(map: (from: T) => Loadable<S> | Promise<S> | S) => Loadable<S>;
- }
+}
 
- interface ValueLoadable<T> extends BaseLoadable<T> {
+interface ValueLoadable<T> extends BaseLoadable<T> {
   state: 'hasValue';
   contents: T;
   valueMaybe: () => T;
   errorMaybe: () => undefined;
   promiseMaybe: () => undefined;
- }
+}
 
- interface LoadingLoadable<T> extends BaseLoadable<T> {
+interface LoadingLoadable<T> extends BaseLoadable<T> {
   state: 'loading';
   contents: Promise<T>;
   valueMaybe: () => undefined;
   errorMaybe: () => undefined;
   promiseMaybe: () => Promise<T>;
- }
+}
 
- interface ErrorLoadable<T> extends BaseLoadable<T> {
+interface ErrorLoadable<T> extends BaseLoadable<T> {
   state: 'hasError';
   contents: any;
   valueMaybe: () => undefined;
   errorMaybe: () => any;
   promiseMaybe: () => undefined;
- }
+}
 
- export type Loadable<T> =
+export type Loadable<T> =
   | ValueLoadable<T>
   | LoadingLoadable<T>
   | ErrorLoadable<T>;
 
- // recoilValue.d.ts
- declare class AbstractRecoilValue<T> {
+// recoilValue.d.ts
+declare class AbstractRecoilValue<T> {
   __tag: [T];
   __cTag: (t: T) => void; // for contravariance
 
   key: NodeKey;
   constructor(newKey: NodeKey);
- }
+}
 
- declare class AbstractRecoilValueReadonly<T> {
+declare class AbstractRecoilValueReadonly<T> {
   __tag: [T];
 
   key: NodeKey;
   constructor(newKey: NodeKey);
- }
+}
 
- export class RecoilState<T> extends AbstractRecoilValue<T> {}
- export class RecoilValueReadOnly<T> extends AbstractRecoilValueReadonly<T> {}
- export type RecoilValue<T> = RecoilValueReadOnly<T> | RecoilState<T>;
+export class RecoilState<T, _U> extends AbstractRecoilValue<T> {}
+export class RecoilValueReadOnly<T> extends AbstractRecoilValueReadonly<T> {}
+export type RecoilValue<T, U> = RecoilValueReadOnly<T> | RecoilState<T, U>;
 
- /**
-  * Returns true if the parameter is a Recoil atom or selector.
-  */
- export function isRecoilValue(val: unknown): val is RecoilValue<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+/**
+ * Returns true if the parameter is a Recoil atom or selector.
+ */
+export function isRecoilValue(val: unknown): val is RecoilValue<any, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
- /** Utilities */
+/** Utilities */
 
- // bigint not supported yet
- type Primitive = undefined | null | boolean | number | symbol | string;
+// bigint not supported yet
+type Primitive = undefined | null | boolean | number | symbol | string;
 
- export type SerializableParam =
+export type SerializableParam =
   | Primitive
   | {toJSON: () => string}
   | ReadonlyArray<SerializableParam>
   | Readonly<{[key: string]: SerializableParam}>;
 
- interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
+interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
   key: NodeKey;
   dangerouslyAllowMutability?: boolean;
-  effects?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
-  effects_UNSTABLE?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
+  effects?:
+    | ReadonlyArray<AtomEffect<T>>
+    | ((param: P) => ReadonlyArray<AtomEffect<T>>);
+  effects_UNSTABLE?:
+    | ReadonlyArray<AtomEffect<T>>
+    | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
- }
- interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam>
-   extends AtomFamilyOptionsWithoutDefault<T, P> {
-  default: RecoilValue<T> | Promise<T> | T | ((param: P) => T | RecoilValue<T> | Promise<T>);
- }
- export type AtomFamilyOptions<T, P extends SerializableParam> =
-   | AtomFamilyOptionsWithDefault<T, P>
-   | AtomFamilyOptionsWithoutDefault<T, P>;
+}
+interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam>
+  extends AtomFamilyOptionsWithoutDefault<T, P> {
+  default:
+    | RecoilValue<T, T>
+    | Promise<T>
+    | T
+    | ((param: P) => T | RecoilValue<T, T> | Promise<T>);
+}
+export type AtomFamilyOptions<T, P extends SerializableParam> =
+  | AtomFamilyOptionsWithDefault<T, P>
+  | AtomFamilyOptionsWithoutDefault<T, P>;
 
- /**
-  * Returns a function which returns a memoized atom for each unique parameter value.
-  */
- export function atomFamily<T, P extends SerializableParam>(
+/**
+ * Returns a function which returns a memoized atom for each unique parameter value.
+ */
+export function atomFamily<T, P extends SerializableParam>(
   options: AtomFamilyOptions<T, P>,
- ): (param: P) => RecoilState<T>;
+): (param: P) => RecoilState<T, T>;
 
- export interface ReadOnlySelectorFamilyOptions<T, P extends SerializableParam> {
+export interface ReadOnlySelectorFamilyOptions<T, P extends SerializableParam> {
   key: string;
-  get: (param: P) => (opts: {
-    get: GetRecoilValue,
-    getCallback: GetCallback,
-  }) => Promise<T> | RecoilValue<T> | T;
+  get: (
+    param: P,
+  ) => (opts: {
+    get: GetRecoilValue;
+    getCallback: GetCallback;
+  }) => Promise<T> | RecoilValue<T, T> | T;
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
   cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
   dangerouslyAllowMutability?: boolean;
- }
+}
 
- export interface ReadWriteSelectorFamilyOptions<T, P extends SerializableParam> {
+export interface ReadWriteSelectorFamilyOptions<
+  T,
+  P extends SerializableParam,
+  U,
+> {
   key: string;
-  get: (param: P) => (opts: {
-    get: GetRecoilValue,
-    getCallback: GetCallback,
-  }) => Promise<T> | RecoilValue<T> | T;
+  get: (
+    param: P,
+  ) => (opts: {
+    get: GetRecoilValue;
+    getCallback: GetCallback;
+  }) => Promise<T> | RecoilValue<T, U> | T;
   set: (
-      param: P,
+    param: P,
   ) => (
-      opts: { set: SetRecoilState; get: GetRecoilValue; reset: ResetRecoilState },
-      newValue: T | DefaultValue,
+    opts: {set: SetRecoilState; get: GetRecoilValue; reset: ResetRecoilState},
+    newValue: U | DefaultValue,
   ) => void;
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
   cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
   dangerouslyAllowMutability?: boolean;
- }
+}
+
+/**
+ * Returns a function which returns a memoized atom for each unique parameter value.
+ */
+export function selectorFamily<T, P extends SerializableParam, U>(
+  options: ReadWriteSelectorFamilyOptions<T, P, U>,
+): (param: P) => RecoilState<T, U>;
 
 /**
  * Returns a function which returns a memoized atom for each unique parameter value.
  */
 export function selectorFamily<T, P extends SerializableParam>(
-options: ReadWriteSelectorFamilyOptions<T, P>,
-): (param: P) => RecoilState<T>;
-
-/**
- * Returns a function which returns a memoized atom for each unique parameter value.
- */
-export function selectorFamily<T, P extends SerializableParam>(
-options: ReadOnlySelectorFamilyOptions<T, P>,
+  options: ReadOnlySelectorFamilyOptions<T, P>,
 ): (param: P) => RecoilValueReadOnly<T>;
 
 /**
  * Returns a selector that always has a constant value.
  */
-export function constSelector<T extends SerializableParam>(constant: T): RecoilValueReadOnly<T>;
+export function constSelector<T extends SerializableParam>(
+  constant: T,
+): RecoilValueReadOnly<T>;
 
 /**
  * Returns a selector which is always in the provided error state.
@@ -463,92 +525,128 @@ export function errorSelector(message: string): RecoilValueReadOnly<never>;
 /**
  * Casts a selector to be a read-only selector
  */
-export function readOnlySelector<T>(atom: RecoilValue<T>): RecoilValueReadOnly<T>;
+export function readOnlySelector<T>(
+  atom: RecoilValue<T, T>,
+): RecoilValueReadOnly<T>;
 
 /**
  * Returns a selector that has the value of the provided atom or selector as a Loadable.
  * This means you can use noWait() to avoid entering an error or suspense state in
  * order to manually handle those cases.
  */
-export function noWait<T>(state: RecoilValue<T>): RecoilValueReadOnly<Loadable<T>>;
+export function noWait<T, U>(
+  state: RecoilValue<T, U>,
+): RecoilValueReadOnly<Loadable<T>>;
 
- /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
- export type UnwrapRecoilValue<T> = T extends RecoilValue<infer R> ? R : never;
+export type UnwrapRecoilValue<T> = T extends RecoilValue<infer R, any>
+  ? R
+  : never;
 
- export type UnwrapRecoilValues<T extends Array<RecoilValue<any>> | { [key: string]: RecoilValue<any> }> = {
+export type UnwrapRecoilValues<
+  T extends
+    | Array<RecoilValue<any, any>>
+    | {[key: string]: RecoilValue<any, any>},
+> = {
   [P in keyof T]: UnwrapRecoilValue<T[P]>;
- };
- export type UnwrapRecoilValueLoadables<T extends Array<RecoilValue<any>> | { [key: string]: RecoilValue<any> }> = {
+};
+export type UnwrapRecoilValueLoadables<
+  T extends
+    | Array<RecoilValue<any, any>>
+    | {[key: string]: RecoilValue<any, any>},
+> = {
   [P in keyof T]: Loadable<UnwrapRecoilValue<T[P]>>;
- };
+};
 
- export function waitForNone<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForNone<
+  RecoilValues extends Array<RecoilValue<any, any>> | [RecoilValue<any, any>],
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForNone<RecoilValues extends { [key: string]: RecoilValue<any> }>(
+export function waitForNone<
+  RecoilValues extends {[key: string]: RecoilValue<any, any>},
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAny<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForAny<
+  RecoilValues extends Array<RecoilValue<any, any>> | [RecoilValue<any, any>],
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAny<RecoilValues extends { [key: string]: RecoilValue<any> }>(
-    param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
-
- export function waitForAll<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForAny<
+  RecoilValues extends {[key: string]: RecoilValue<any, any>},
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAll<RecoilValues extends { [key: string]: RecoilValue<any> }>(
+export function waitForAll<
+  RecoilValues extends Array<RecoilValue<any, any>> | [RecoilValue<any, any>],
+>(param: RecoilValues): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+
+export function waitForAll<
+  RecoilValues extends {[key: string]: RecoilValue<any, any>},
+>(param: RecoilValues): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+
+export function waitForAllSettled<
+  RecoilValues extends Array<RecoilValue<any, any>> | [RecoilValue<any, any>],
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAllSettled<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForAllSettled<
+  RecoilValues extends {[key: string]: RecoilValue<any, any>},
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAllSettled<RecoilValues extends { [key: string]: RecoilValue<any> }>(
-  param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+export type UnwrapLoadable<T> = T extends Loadable<infer R>
+  ? R
+  : T extends Promise<infer P>
+  ? P
+  : T;
+export type UnwrapLoadables<T extends any[] | {[key: string]: any}> = {
+  [P in keyof T]: UnwrapLoadable<T[P]>;
+};
 
-  export type UnwrapLoadable<T> = T extends Loadable<infer R> ? R : T extends Promise<infer P> ? P : T;
-  export type UnwrapLoadables<T extends any[] | { [key: string]: any }> = {
-    [P in keyof T]: UnwrapLoadable<T[P]>;
-  };
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export namespace RecoilLoadable {
+  /**
+   * Factory to make a Loadable object.  If a Promise is provided the Loadable will
+   * be in a 'loading' state until the Promise is either resolved or rejected.
+   */
+  function of<T>(x: T | Promise<T> | Loadable<T>): Loadable<T>;
+  /**
+   * Factory to make a Loadable object in an error state.
+   */
+  function error(x: any): ErrorLoadable<any>;
+  /**
+   * Factory to make a Loadable which is resolved when all of the Loadables provided
+   * to it are resolved or any one has an error.  The value is an array of the values
+   * of all of the provided Loadables.  This is comparable to Promise.all() for Loadables.
+   * Similar to Promise.all(), inputs may be Loadables, Promises, or literal values.
+   */
+  function all<Inputs extends any[] | [Loadable<any>]>(
+    inputs: Inputs,
+  ): Loadable<UnwrapLoadables<Inputs>>;
+  function all<Inputs extends {[key: string]: any}>(
+    inputs: Inputs,
+  ): Loadable<UnwrapLoadables<Inputs>>;
+  /**
+   * Returns true if the provided parameter is a Loadable type.
+   */
+  function isLoadable(x: any): x is Loadable<any>;
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  export namespace RecoilLoadable {
-    /**
-     * Factory to make a Loadable object.  If a Promise is provided the Loadable will
-     * be in a 'loading' state until the Promise is either resolved or rejected.
-     */
-    function of<T>(x: T | Promise<T> | Loadable<T>): Loadable<T>;
-    /**
-     * Factory to make a Loadable object in an error state.
-     */
-    function error(x: any): ErrorLoadable<any>;
-    /**
-     * Factory to make a Loadable which is resolved when all of the Loadables provided
-     * to it are resolved or any one has an error.  The value is an array of the values
-     * of all of the provided Loadables.  This is comparable to Promise.all() for Loadables.
-     * Similar to Promise.all(), inputs may be Loadables, Promises, or literal values.
-     */
-    function all<Inputs extends any[] | [Loadable<any>]>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
-    function all<Inputs extends {[key: string]: any}>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
-    /**
-     * Returns true if the provided parameter is a Loadable type.
-     */
-    function isLoadable(x: any): x is Loadable<any>;
-   }
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
- /* eslint-enable @typescript-eslint/no-explicit-any */
-
- /**
-  * Factory to produce a Recoil snapshot object with all atoms in the default state.
-  */
- export function snapshot_UNSTABLE(initializeState?: (shapshot: MutableSnapshot) => void): Snapshot;
+/**
+ * Factory to produce a Recoil snapshot object with all atoms in the default state.
+ */
+export function snapshot_UNSTABLE(
+  initializeState?: (shapshot: MutableSnapshot) => void,
+): Snapshot;


### PR DESCRIPTION
## What is this solving ?

Resolves part of https://github.com/facebookexperimental/Recoil/issues/804

> RecoilStateWritable<R, W = R> ← RecoilState<T>

This allows selectors to now specify a second parameter (`selector<T, U = T>`) where the second parameter represents the value that needs to be passed to the updater function.

Looking for some feedback if we should default the second parameter to the first one in more places - I tried to limit as much as possible so that it's harder to forget passing the second generic in the internals.

## Note

* Although some parts of https://github.com/facebookexperimental/Recoil/issues/804 still need to be agreed upon, making the types allow a second generic value doesn't have to wait.
* There seems to be some formatting changes triggered when I ran `yarn format`.
* I've done some preliminary testing but didn't test all of Recoil's export yet. If we like the direction, I'll do more thorough testing.