### PR TITLE
Display atom and selector key when an error occurs

### DIFF
--- a/packages/recoil/recoil_values/Recoil_selectorFamily.js
+++ b/packages/recoil/recoil_values/Recoil_selectorFamily.js
@@ -31,6 +31,7 @@ import type {
 const cacheFromPolicy = require('../caches/Recoil_cacheFromPolicy');
 const {setConfigDeletionHandler} = require('../core/Recoil_Node');
 const selector = require('./Recoil_selector');
+const err = require('recoil-shared/util/Recoil_err');
 const stableStringify = require('recoil-shared/util/Recoil_stableStringify');
 
 // Keep in mind the parameter needs to be serializable as a cahche key
@@ -112,8 +113,16 @@ function selectorFamily<T, Params: Parameter>(
   });
 
   return (params: Params) => {
-    const cachedSelector = selectorCache.get(params);
-
+    // Throw an error with selector key so that it is clear which
+    // selector is causing an error
+    let cachedSelector;
+    try {
+      cachedSelector = selectorCache.get(params);
+    } catch (error) {
+      throw err(
+        `Problem with cache lookup for selector ${options.key}: ${error.message}`,
+      );
+    }
     if (cachedSelector != null) {
       return cachedSelector;
     }

--- a/packages/recoil/recoil_values/__tests__/Recoil_selectorFamily-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selectorFamily-test.js
@@ -305,3 +305,13 @@ testRecoil('selectorFamily - evaluate to RecoilValue', () => {
   expect(getValue(mySelector('a'))).toEqual('A');
   expect(getValue(mySelector('b'))).toEqual('B');
 });
+
+testRecoil('selectorFamily - invalid parameter error message', () => {
+  const mySelector = selectorFamily({
+    key: 'function in parameter',
+    get: () => () => {},
+  });
+  expect(() => getValue(mySelector({foo: () => {}}))).toThrow(
+    'function in parameter',
+  );
+});


### PR DESCRIPTION
Summary:
- Functions are not allowed to be return values for selectors or atoms
- Error message is not clear on which selectorFamily or atomFamily is being affected.
- Display key in error message.

Differential Revision: D34701531

