### PR TITLE
Add readonly TS types for atoms and selectors to prevent mutability bugs

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -116,10 +116,14 @@
  }
  export type AtomOptions<T> = AtomOptionsWithoutDefault<T> | AtomOptionsWithDefault<T>;
 
+ type DeepReadonly<T> = {
+  readonly [P in keyof T]: DeepReadonly<T[P]>
+ };
+
  /**
   * Creates an atom, which represents a piece of writeable state
   */
- export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
+ export function atom<T>(options: AtomOptions<T>): RecoilState<DeepReadonly<T>>;
 
  export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
  export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
@@ -194,8 +198,8 @@
  /**
   * Creates a selector which represents derived state.
   */
- export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<T>;
- export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
+ export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<DeepReadonly<T>>;
+ export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<DeepReadonly<T>>;
 
  // hooks.d.ts
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -115,6 +115,9 @@
    default: RecoilValue<T> | Promise<T> | T;
  }
  export type AtomOptions<T> = AtomOptionsWithoutDefault<T> | AtomOptionsWithDefault<T>;
+ export type AtomOptionsMutable<T> = AtomOptions<T> & {
+  dangerouslyAllowMutability: true;
+ };
 
  /**
   * Will work for all types, but do not add a special case for Arrays specifically as
@@ -130,6 +133,7 @@
  /**
   * Creates an atom, which represents a piece of writeable state
   */
+ export function atom<T>(options: AtomOptionsMutable<T>): RecoilState<T>;
  export function atom<T>(options: AtomOptions<T>): RecoilState<DeepReadonly<T>>;
 
  export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
@@ -202,9 +206,19 @@
   ) => void;
  }
 
+export interface ReadOnlySelectorOptionsMutable<T> extends ReadOnlySelectorOptions<T> {
+  dangerouslyAllowMutability: true;
+}
+
+export interface ReadWriteSelectorOptionsMutable<T> extends ReadWriteSelectorOptions<T> {
+  dangerouslyAllowMutability: true;
+}
+
  /**
   * Creates a selector which represents derived state.
   */
+ export function selector<T>(options: ReadWriteSelectorOptionsMutable<T>): RecoilState<T>;
+ export function selector<T>(options: ReadOnlySelectorOptionsMutable<T>): RecoilValueReadOnly<T>;
  export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<DeepReadonly<T>>;
  export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<DeepReadonly<T>>;
 
@@ -404,17 +418,27 @@
   effects_UNSTABLE?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
  }
+
  interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam>
    extends AtomFamilyOptionsWithoutDefault<T, P> {
   default: RecoilValue<T> | Promise<T> | T | ((param: P) => T | RecoilValue<T> | Promise<T>);
  }
+
  export type AtomFamilyOptions<T, P extends SerializableParam> =
    | AtomFamilyOptionsWithDefault<T, P>
    | AtomFamilyOptionsWithoutDefault<T, P>;
 
+export type AtomFamilyOptionsMutable<T, P extends SerializableParam> = AtomFamilyOptions<T, P> & {
+  dangerouslyAllowMutability: true,
+};
+
  /**
   * Returns a function which returns a memoized atom for each unique parameter value.
   */
+  export function atomFamily<T, P extends SerializableParam>(
+   options: AtomFamilyOptionsMutable<T, P>,
+  ): (param: P) => RecoilState<T>;
+
  export function atomFamily<T, P extends SerializableParam>(
   options: AtomFamilyOptions<T, P>,
  ): (param: P) => RecoilState<DeepReadonly<T>>;
@@ -428,6 +452,10 @@
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
   cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
   dangerouslyAllowMutability?: boolean;
+ }
+
+ export interface ReadOnlySelectorFamilyOptionsMutable<T, P extends SerializableParam> extends ReadOnlySelectorFamilyOptions<T, P> {
+  dangerouslyAllowMutability: true;
  }
 
  export interface ReadWriteSelectorFamilyOptions<T, P extends SerializableParam> {
@@ -447,9 +475,17 @@
   dangerouslyAllowMutability?: boolean;
  }
 
+ export interface ReadWriteSelectorFamilyOptionsMutable<T, P extends SerializableParam> extends ReadWriteSelectorFamilyOptions<T, P> {
+  dangerouslyAllowMutability: true;
+ }
+
 /**
  * Returns a function which returns a memoized atom for each unique parameter value.
  */
+export function selectorFamily<T, P extends SerializableParam>(
+options: ReadWriteSelectorFamilyOptionsMutable<T, P>,
+): (param: P) => RecoilState<T>;
+
 export function selectorFamily<T, P extends SerializableParam>(
 options: ReadWriteSelectorFamilyOptions<T, P>,
 ): (param: P) => RecoilState<DeepReadonly<T>>;
@@ -457,6 +493,10 @@ options: ReadWriteSelectorFamilyOptions<T, P>,
 /**
  * Returns a function which returns a memoized atom for each unique parameter value.
  */
+export function selectorFamily<T, P extends SerializableParam>(
+options: ReadOnlySelectorFamilyOptionsMutable<T, P>,
+): (param: P) => RecoilValueReadOnly<T>;
+
 export function selectorFamily<T, P extends SerializableParam>(
 options: ReadOnlySelectorFamilyOptions<T, P>,
 ): (param: P) => RecoilValueReadOnly<DeepReadonly<T>>;

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -447,6 +447,56 @@ isRecoilValue(mySelector1);
     get: () => myObj.b.d,
   });
 
+  const myArrSelFam = selectorFamily({
+    key: 'myArrSel',
+    get: (a: string) => () => myArr,
+  });
+
+  const myObjSelFam = selectorFamily({
+    key: 'myObjSel',
+    get: (a: string) => () => myObj,
+  });
+
+  const myMapSelFam = selectorFamily({
+    key: 'myMapSel',
+    get: (a: string) => () => myMap,
+  });
+
+  const mySetSelFam = selectorFamily({
+    key: 'mySetSel',
+    get: (a: string) => () => mySet,
+  });
+
+  const myFnSelFam = selectorFamily({
+    key: 'myFnSel',
+    get: (a: string) => () => myObj.b.d,
+  });
+
+  const myArrAtomFam = atomFamily({
+    key: 'myArrSel',
+    default: (a: string) => myArr,
+  });
+
+  const myObjAtomFam = atomFamily({
+    key: 'myObjSel',
+    default: (a: string) => myObj,
+  });
+
+  const myMapAtomFam = atomFamily({
+    key: 'myMapSel',
+    default: (a: string) => myMap,
+  });
+
+  const mySetAtomFam = atomFamily({
+    key: 'mySetSel',
+    default: (a: string) => mySet,
+  });
+
+  const myFnAtomFam = atomFamily({
+    key: 'myFnSel',
+    default: (a: string) => myObj.b.d,
+  });
+
   const arr1 = useRecoilValue(myArrAtom);
   const obj1 = useRecoilValue(myObjAtom);
   const map1 = useRecoilValue(myMapAtom);
@@ -506,6 +556,332 @@ isRecoilValue(mySelector1);
   set2.add(''); // $ExpectError
 
   set2.forEach(() => {});
+
+  fn1(10);
+
+  const arr3 = useRecoilValue(myArrSelFam(''));
+  const obj3 = useRecoilValue(myObjSelFam(''));
+  const map3 = useRecoilValue(myMapSelFam(''));
+  const set3 = useRecoilValue(mySetSelFam(''));
+  const fn3 = useRecoilValue(myFnSelFam(''));
+
+  arr3[0].a = 10; // $ExpectError
+  arr3.push(1); // $ExpectError
+  arr3.reverse(); // $ExpectError
+  arr3.sort(); // $ExpectError
+
+  arr3.every(() => {}); // OK because immutable
+  arr3.filter(() => {}); // OK because immutable
+
+  obj3.a = 2; // $ExpectError
+  obj3.b.c = 100;  // $ExpectError
+
+  obj3.b.d(10);
+
+  obj3.b.d = () => {}; // $ExpectError
+  map3.set('a', 1); // $ExpectError
+
+  map3.get(''); // OK because immutable
+
+  map3.size;
+
+  set3.add(''); // $ExpectError
+
+  set3.forEach(() => {});
+
+  fn1(10);
+
+  const arr4 = useRecoilValue(myArrAtomFam(''));
+  const obj4 = useRecoilValue(myObjAtomFam(''));
+  const map4 = useRecoilValue(myMapAtomFam(''));
+  const set4 = useRecoilValue(mySetAtomFam(''));
+  const fn4 = useRecoilValue(myFnAtomFam(''));
+
+  arr4[0].a = 10; // $ExpectError
+  arr4.push(1); // $ExpectError
+  arr4.reverse(); // $ExpectError
+  arr4.sort(); // $ExpectError
+
+  arr4.every(() => {}); // OK because immutable
+  arr4.filter(() => {}); // OK because immutable
+
+  obj4.a = 2; // $ExpectError
+  obj4.b.c = 100;  // $ExpectError
+
+  obj4.b.d(10);
+
+  obj4.b.d = () => {}; // $ExpectError
+  map4.set('a', 1); // $ExpectError
+
+  map4.get(''); // OK because immutable
+
+  map4.size;
+
+  set4.add(''); // $ExpectError
+
+  set4.forEach(() => {});
+
+  fn1(10);
+}
+
+/**
+ * recoil values are mutable when dangerouslyAllowMutability is set
+ */
+ {
+  const myArr = [{a: 10}];
+  const myObj = {
+    a: 10,
+    b: {
+      c: 10,
+      d: (a: number) => a,
+    },
+  };
+  const myMap = new Map([['', 1]]);
+  const mySet = new Set(['']);
+
+  const myArrAtom = atom({
+    key: 'myArrAtom',
+    default: myArr,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myObjAtom = atom({
+    key: 'myObjAtom',
+    default: myObj,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myMapAtom = atom({
+    key: 'myMapAtom',
+    default: myMap,
+    dangerouslyAllowMutability: true,
+  });
+
+  const mySetAtom = atom({
+    key: 'mySetAtom',
+    default: mySet,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myFnAtom = atom({
+    key: 'myFnAtom',
+    default: myObj.b.d,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myArrSel = selector({
+    key: 'myArrSel',
+    get: () => myArr,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myObjSel = selector({
+    key: 'myObjSel',
+    get: () => myObj,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myMapSel = selector({
+    key: 'myMapSel',
+    get: () => myMap,
+    dangerouslyAllowMutability: true,
+  });
+
+  const mySetSel = selector({
+    key: 'mySetSel',
+    get: () => mySet,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myFnSel = selector({
+    key: 'myFnSel',
+    get: () => myObj.b.d,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myArrSelFam = selectorFamily({
+    key: 'myArrSel',
+    get: (a: string) => () => myArr,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myObjSelFam = selectorFamily({
+    key: 'myObjSel',
+    get: (a: string) => () => myObj,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myMapSelFam = selectorFamily({
+    key: 'myMapSel',
+    get: (a: string) => () => myMap,
+    dangerouslyAllowMutability: true,
+  });
+
+  const mySetSelFam = selectorFamily({
+    key: 'mySetSel',
+    get: (a: string) => () => mySet,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myFnSelFam = selectorFamily({
+    key: 'myFnSel',
+    get: (a: string) => () => myObj.b.d,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myArrAtomFam = atomFamily({
+    key: 'myArrSel',
+    default: (a: string) => myArr,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myObjAtomFam = atomFamily({
+    key: 'myObjSel',
+    default: (a: string) => myObj,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myMapAtomFam = atomFamily({
+    key: 'myMapSel',
+    default: (a: string) => myMap,
+    dangerouslyAllowMutability: true,
+  });
+
+  const mySetAtomFam = atomFamily({
+    key: 'mySetSel',
+    default: (a: string) => mySet,
+    dangerouslyAllowMutability: true,
+  });
+
+  const myFnAtomFam = atomFamily({
+    key: 'myFnSel',
+    default: (a: string) => myObj.b.d,
+    dangerouslyAllowMutability: true,
+  });
+
+  const arr1 = useRecoilValue(myArrAtom);
+  const obj1 = useRecoilValue(myObjAtom);
+  const map1 = useRecoilValue(myMapAtom);
+  const set1 = useRecoilValue(mySetAtom);
+  const fn1 = useRecoilValue(myFnAtom);
+
+  arr1[0].a = 10;
+  arr1.push({ a: 1 });
+  arr1.reverse();
+  arr1.sort();
+
+  arr1.every(() => {});
+  arr1.filter(() => {});
+
+  obj1.a = 2;
+  obj1.b.c = 100;
+
+  obj1.b.d(10);
+  obj1.b.d = () => 5;
+
+  map1.set('a', 1);
+
+  map1.get('');
+  map1.size;
+
+  set1.add('');
+
+  set1.forEach(() => {});
+
+  fn1(10);
+
+  const arr2 = useRecoilValue(myArrSel);
+  const obj2 = useRecoilValue(myObjSel);
+  const map2 = useRecoilValue(myMapSel);
+  const set2 = useRecoilValue(mySetSel);
+  const fn2 = useRecoilValue(myFnSel);
+
+  arr2[0].a = 10;
+  arr2.push({ a: 1 });
+  arr2.reverse();
+  arr2.sort();
+
+  arr2.every(() => {});
+  arr2.filter(() => {});
+
+  obj2.a = 2;
+  obj2.b.c = 100;
+
+  obj2.b.d(10);
+  obj2.b.d = () => 5;
+
+  map2.set('a', 1);
+
+  map2.get('');
+  map2.size;
+
+  set2.add('');
+
+  set2.forEach(() => {});
+
+  fn1(10);
+
+  const arr3 = useRecoilValue(myArrSelFam(''));
+  const obj3 = useRecoilValue(myObjSelFam(''));
+  const map3 = useRecoilValue(myMapSelFam(''));
+  const set3 = useRecoilValue(mySetSelFam(''));
+  const fn3 = useRecoilValue(myFnSelFam(''));
+
+  arr3[0].a = 10;
+  arr3.push({a: 1});
+  arr3.reverse();
+  arr3.sort();
+
+  arr3.every(() => {});
+  arr3.filter(() => {});
+
+  obj3.a = 2;
+  obj3.b.c = 100;
+
+  obj3.b.d(10);
+
+  obj3.b.d = () => 4;
+  map3.set('a', 1);
+
+  map3.get('');
+
+  map3.size;
+
+  set3.add('');
+
+  set3.forEach(() => {});
+
+  fn1(10);
+
+  const arr4 = useRecoilValue(myArrAtomFam(''));
+  const obj4 = useRecoilValue(myObjAtomFam(''));
+  const map4 = useRecoilValue(myMapAtomFam(''));
+  const set4 = useRecoilValue(mySetAtomFam(''));
+  const fn4 = useRecoilValue(myFnAtomFam(''));
+
+  arr4[0].a = 10;
+  arr4.push({a: 1});
+  arr4.reverse();
+  arr4.sort();
+
+  arr4.every(() => {});
+  arr4.filter(() => {});
+
+  obj4.a = 2;
+  obj4.b.c = 100;
+
+  obj4.b.d(10);
+
+  obj4.b.d = () => 4;
+  map4.set('a', 1);
+
+  map4.get('');
+
+  map4.size;
+
+  set4.add('');
+
+  set4.forEach(() => {});
 
   fn1(10);
 }

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -34,6 +34,7 @@
   useRecoilState_TRANSITION_SUPPORT_UNSTABLE,
   useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE,
 } from 'recoil';
+import { number } from 'refine';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -114,7 +115,7 @@ const callbackSelector = selector({
     });
   }
 });
-useRecoilValue(callbackSelector); // $ExpectType DeepReadonly<() => Promise<number>>
+useRecoilValue(callbackSelector); // $ExpectType () => Promise<number>
 
 const selectorError1 = selector({ // $ExpectError
   key: 'SelectorError1',
@@ -386,6 +387,15 @@ isRecoilValue(mySelector1);
  */
  {
   const myArr = [{a: 10}];
+  const myObj = {
+    a: 10,
+    b: {
+      c: 10,
+      d: (a: number) => a,
+    },
+  };
+  const myMap = new Map([['', 1]]);
+  const mySet = new Set(['']);
 
   const myArrAtom = atom({
     key: 'myArrAtom',
@@ -394,23 +404,110 @@ isRecoilValue(mySelector1);
 
   const myObjAtom = atom({
     key: 'myObjAtom',
-    default: {
-      a: 10,
-      b: {
-        c: 10,
-      },
-    },
+    default: myObj,
+  });
+
+  const myMapAtom = atom({
+    key: 'myMapAtom',
+    default: myMap,
+  });
+
+  const mySetAtom = atom({
+    key: 'mySetAtom',
+    default: mySet,
+  });
+
+  const myFnAtom = atom({
+    key: 'myFnAtom',
+    default: myObj.b.d,
+  });
+
+  const myArrSel = selector({
+    key: 'myArrSel',
+    get: () => myArr,
+  });
+
+  const myObjSel = selector({
+    key: 'myObjSel',
+    get: () => myObj,
+  });
+
+  const myMapSel = selector({
+    key: 'myMapSel',
+    get: () => myMap,
+  });
+
+  const mySetSel = selector({
+    key: 'mySetSel',
+    get: () => mySet,
+  });
+
+  const myFnSel = selector({
+    key: 'myFnSel',
+    get: () => myObj.b.d,
   });
 
   const arr1 = useRecoilValue(myArrAtom);
   const obj1 = useRecoilValue(myObjAtom);
+  const map1 = useRecoilValue(myMapAtom);
+  const set1 = useRecoilValue(mySetAtom);
+  const fn1 = useRecoilValue(myFnAtom);
 
   arr1[0].a = 10; // $ExpectError
   arr1.push(1); // $ExpectError
   arr1.reverse(); // $ExpectError
   arr1.sort(); // $ExpectError
+
+  arr1.every(() => {}); // OK because immutable
+  arr1.filter(() => {}); // OK because immutable
+
   obj1.a = 2; // $ExpectError
   obj1.b.c = 100;  // $ExpectError
+
+  obj1.b.d(10);
+  obj1.b.d = () => {}; // $ExpectError
+
+  map1.set('a', 1); // $ExpectError
+
+  map1.get(''); // OK because immutable
+  map1.size;
+
+  set1.add(''); // $ExpectError
+
+  set1.forEach(() => {});
+
+  fn1(10);
+
+  const arr2 = useRecoilValue(myArrSel);
+  const obj2 = useRecoilValue(myObjSel);
+  const map2 = useRecoilValue(myMapSel);
+  const set2 = useRecoilValue(mySetSel);
+  const fn2 = useRecoilValue(myFnSel);
+
+  arr2[0].a = 10; // $ExpectError
+  arr2.push(1); // $ExpectError
+  arr2.reverse(); // $ExpectError
+  arr2.sort(); // $ExpectError
+
+  arr2.every(() => {}); // OK because immutable
+  arr2.filter(() => {}); // OK because immutable
+
+  obj2.a = 2; // $ExpectError
+  obj2.b.c = 100;  // $ExpectError
+
+  obj2.b.d(10);
+  obj2.b.d = () => {}; // $ExpectError
+
+  map2.set('a', 1); // $ExpectError
+
+  map2.get(''); // OK because immutable
+  map2.size;
+
+  set2.add(''); // $ExpectError
+
+  set2.forEach(() => {});
+
+  fn1(10);
 }
 
 /**

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -114,7 +114,7 @@ const callbackSelector = selector({
     });
   }
 });
-useRecoilValue(callbackSelector); // $ExpectType () => Promise<number>
+useRecoilValue(callbackSelector); // $ExpectType DeepReadonly<() => Promise<number>>
 
 const selectorError1 = selector({ // $ExpectError
   key: 'SelectorError1',
@@ -380,6 +380,38 @@ isRecoilValue(4);
 isRecoilValue(myAtom);
 isRecoilValue(null);
 isRecoilValue(mySelector1);
+
+/**
+ * recoil values are read-only
+ */
+ {
+  const myArr = [{a: 10}];
+
+  const myArrAtom = atom({
+    key: 'myArrAtom',
+    default: myArr,
+  });
+
+  const myObjAtom = atom({
+    key: 'myObjAtom',
+    default: {
+      a: 10,
+      b: {
+        c: 10,
+      },
+    },
+  });
+
+  const arr1 = useRecoilValue(myArrAtom);
+  const obj1 = useRecoilValue(myObjAtom);
+
+  arr1[0].a = 10; // $ExpectError
+  arr1.push(1); // $ExpectError
+  arr1.reverse(); // $ExpectError
+  arr1.sort(); // $ExpectError
+  obj1.a = 2; // $ExpectError
+  obj1.b.c = 100;  // $ExpectError
+}
 
 /**
  * ================ UTILS ================


### PR DESCRIPTION
Because we perform a deep freeze to recoil values, mutating those values at runtime (during dev) causes our code to throw, which can lead to confusing errors. In my case, I was calling `arr.sort()` and `arr.reverse()` in a component, and because that mutates the underlying array my app was crashing in dev. 

After this change the result of reading atom/sel values from hooks will not allow for mutation of the returned values. This conflicts when `dangerouslyAllowMutability` is enabled, but that can be fixed in userland by having a wrapper over the hooks to expose mutable types (I think the TS types should match the default behavior of disallowing mutations by default).