### PR TITLE
fix: Correct typo in no-fb-only.js

### DIFF
--- a/eslint-rules/no-fb-only.js
+++ b/eslint-rules/no-fb-only.js
@@ -48,7 +48,7 @@ module.exports = {
             if (match) {
               context.report({
                 message:
-                  `Usage of "${descriptor}". Please consider depenedncy injecting this condition ` +
+                  `Usage of "${descriptor}". Please consider dependency injecting this condition ` +
                   `instead. See "${__filename}" for more details`,
                 loc: {
                   start: {line: lineNumber + 1, column: 0},


### PR DESCRIPTION
I found a typo in [no-fb-only.js](https://github.com/facebookexperimental/Recoil/blob/main/eslint-rules/no-fb-only.js) and corrected it.