### PR TITLE
Enable atoms to be initialized to a Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update typing for family parameters to better support Map, Set, and classes with `toJSON()`. (#1709, #1703)
 - Cleanup potential memory leak when using async selectors (#1714)
 - Fix potentially hung async selectors when shared across multiple roots that depend on atoms initialized with promises that don't resolve (#1714)
+- Atom effects can initialize or set atoms to wrapped values (#1681)
 
 ## 0.7 (2022-03-31)
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -376,7 +376,7 @@ describe('Effects', () => {
   testRecoil('initialization', () => {
     let inited = false;
     const myAtom = atom({
-      key: 'atom effect',
+      key: 'atom effect init',
       default: 'DEFAULT',
       effects: [
         ({node, trigger, setSelf}) => {
@@ -419,6 +419,34 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('loading');
     act(() => jest.runAllTimers());
     expect(c.textContent).toEqual('"RESOLVE"');
+  });
+
+  testRecoil('set to Promise', async () => {
+    let setLater;
+    const myAtom = atom({
+      key: 'atom effect set promise',
+      default: 'DEFAULT',
+      effects: [
+        ({setSelf}) => {
+          setSelf(atom.value(Promise.resolve('INIT_PROMISE')));
+          setLater = setSelf;
+        },
+      ],
+    });
+    expect(getRecoilStateLoadable(myAtom).state).toBe('hasValue');
+    await expect(getRecoilStateLoadable(myAtom).contents).resolves.toBe(
+      'INIT_PROMISE',
+    );
+    act(() => setLater(atom.value(Promise.resolve('LATER_PROMISE'))));
+    expect(getRecoilStateLoadable(myAtom).state).toBe('hasValue');
+    await expect(getRecoilStateLoadable(myAtom).contents).resolves.toBe(
+      'LATER_PROMISE',
+    );
+    act(() => setLater(() => atom.value(Promise.resolve('UPDATER_PROMISE'))));
+    expect(getRecoilStateLoadable(myAtom).state).toBe('hasValue');
+    await expect(getRecoilStateLoadable(myAtom).contents).resolves.toBe(
+      'UPDATER_PROMISE',
+    );
   });
 
   testRecoil('order of effects', () => {

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -93,7 +93,8 @@
     | T
     | DefaultValue
     | Promise<T | DefaultValue>
-    | ((param: T | DefaultValue) => T | DefaultValue),
+    | WrappedValue<T>
+    | ((param: T | DefaultValue) => T | DefaultValue | WrappedValue<T>),
   ) => void,
   resetSelf: () => void,
 


### PR DESCRIPTION
Summary:
Minor completeness for the API to allow atoms to be initialized to `Promise` types by wrapping them, similar to atom defaults.

To properly allow Promises and such as atom values we also need the ability to set atoms to Promises.  The point of this diff is to provide completeness for future work to support async atoms

Differential Revision: D34975767

