### PR TITLE
Typing fixes for 0.7

### DIFF
--- a/eslint-rules/no-fb-only.js
+++ b/eslint-rules/no-fb-only.js
@@ -48,7 +48,7 @@ module.exports = {
             if (match) {
               context.report({
                 message:
-                  `Usage of "${descriptor}". Please consider depenedncy injecting this condition ` +
+                  `Usage of "${descriptor}". Please consider dependency injecting this condition ` +
                   `instead. See "${__filename}" for more details`,
                 loc: {
                   start: {line: lineNumber + 1, column: 0},

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -63,7 +63,12 @@ export type AtomFamilyOptions<T, P: Parameter> =
         | Loadable<T>
         | WrappedValue<T>
         | T
-        | (P => T | RecoilValue<T> | Promise<T>),
+        | (P =>
+            | T
+            | RecoilValue<T>
+            | Promise<T>
+            | Loadable<T>
+            | WrappedValue<T>),
     }>
   | AtomFamilyOptionsWithoutDefault<T, P>;
 
@@ -118,7 +123,7 @@ function atomFamily<T, P: Parameter>(
       | Loadable<T>
       | WrappedValue<T>
       | T
-      | (P => T | RecoilValue<T> | Promise<T>) =
+      | (P => T | RecoilValue<T> | Promise<T> | Loadable<T> | WrappedValue<T>) =
       'default' in options
         ? // $FlowIssue[prop-missing] No way to refine in Flow that property is not defined
           // $FlowIssue[incompatible-type] No way to refine in Flow that property is not defined

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -411,7 +411,7 @@ interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
     | Loadable<T>
     | WrappedValue<T>
     | T
-    | ((param: P) => T | RecoilValue<T> | Promise<T>);
+    | ((param: P) => T | RecoilValue<T> | Promise<T> | Loadable<T> | WrappedValue<T>);
   }
   export type AtomFamilyOptions<T, P extends SerializableParam> =
     | AtomFamilyOptionsWithDefault<T, P>
@@ -440,7 +440,7 @@ interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
   get: (param: P) => (opts: {
     get: GetRecoilValue,
     getCallback: GetCallback,
-  }) => Promise<T> | RecoilValue<T> | T;
+  }) => Promise<T> | Loadable<T> | WrappedValue<T> | RecoilValue<T> | T;
   set: (
       param: P,
   ) => (

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -426,6 +426,13 @@ isRecoilValue(mySelector1);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const myAtomFamilyWithoutDefault: (number: number) => RecoilState<number> =
     atomFamily<number, number>({key: 'MyAtomFamilyWithoutDefault'});
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const myAsyncAtomFamily: (number: number) => RecoilState<number> =
+    atomFamily<number, number>({
+      key: 'MyAsyncAtomFamily',
+      default: (param: number) => Promise.resolve(param),
+    });
 }
 
 /**


### PR DESCRIPTION
Summary: Some fix-ups for TypeScript and Flow typings for 0.7

Differential Revision: D35070577

