### PR TITLE
Better typing for maps, sets, and classes to be used in family parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
+- Update typing for family parameters to better support Map, Set, and classes with `toJSON()`. (#1709, #1703)
+
 ## 0.7 (2022-03-31)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-## 0.7 (2022-03-25)
+## 0.7 (2022-03-31)
 
 ### New Features
 - The `default` value is now optional for `atom()` and `atomFamily()`.  If not provided the atom will initialize to a pending state. (#1639)

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -25,13 +25,15 @@ const stableStringify = require('recoil-shared/util/Recoil_stableStringify');
 
 type Primitive = void | null | boolean | number | string;
 interface HasToJSON {
-  toJSON: () => string;
+  toJSON(): Parameter;
 }
 export type Parameter =
   | Primitive
   | HasToJSON
   | $ReadOnlyArray<Parameter>
-  | $ReadOnly<{[string]: Parameter}>;
+  | $ReadOnly<{[string]: Parameter}>
+  | $ReadOnlySet<Parameter>
+  | $ReadOnlyMap<Parameter, Parameter>;
 
 // flowlint unclear-type:off
 export type ParameterizedScopeRules<P> = $ReadOnlyArray<

--- a/packages/recoil/recoil_values/Recoil_selectorFamily.js
+++ b/packages/recoil/recoil_values/Recoil_selectorFamily.js
@@ -40,11 +40,13 @@ const stableStringify = require('recoil-shared/util/Recoil_stableStringify');
 // using Recoil_stableStringify
 type Primitive = void | null | boolean | number | string;
 interface HasToJSON {
-  toJSON: () => string;
+  toJSON(): Parameter;
 }
 export type Parameter =
   | Primitive
   | HasToJSON
+  | $ReadOnlySet<Parameter>
+  | $ReadOnlyMap<Parameter, Parameter>
   | $ReadOnlyArray<Parameter>
   | $ReadOnly<{...}>;
 // | $ReadOnly<{[string]: Parameter}>; // TODO Better enforce object is serializable

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -390,11 +390,14 @@
 
  // bigint not supported yet
  type Primitive = undefined | null | boolean | number | symbol | string;
+ interface HasToJSON { toJSON(): SerializableParam; }
 
  export type SerializableParam =
   | Primitive
-  | {toJSON: () => string}
+  | HasToJSON
   | ReadonlyArray<SerializableParam>
+  | ReadonlySet<SerializableParam>
+  | ReadonlyMap<SerializableParam, SerializableParam>
   | Readonly<{[key: string]: SerializableParam}>;
 
 interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -290,15 +290,27 @@ useRecoilCallback(({ snapshot, set, reset, refresh, gotoSnapshot, transact_UNSTA
   snapshot; // $ExpectType Snapshot
   snapshot.getID(); // $ExpectType SnapshotID
   await snapshot.getPromise(mySelector1); // $ExpectType number
-  const loadable = snapshot.getLoadable(mySelector1); // $ExpectType Loadable<number>
+  const loadable: Loadable<number> = snapshot.getLoadable(mySelector1);
 
   gotoSnapshot(snapshot);
 
   gotoSnapshot(3); // $ExpectError
   gotoSnapshot(myAtom); // $ExpectError
 
-  loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
   loadable.contents; // $ExpectType any
+  switch (loadable.state) {
+    case 'hasValue':
+      loadable.contents; // $ExpectType number
+      break;
+    case 'hasError':
+      loadable.contents; // $ExpectType any
+      break;
+    case 'loading':
+      loadable.contents; // $ExpectType Promise<number>
+      break;
+  }
 
   set(myAtom, 5);
   set(myAtom, 'hello'); // $ExpectError
@@ -340,8 +352,9 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
       previousSnapshot.getPromise(mySelector2); // $ExpectType Promise<string>
 
       for (const node of Array.from(snapshot.getNodes_UNSTABLE({isModified: true}))) {
-        const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
-        loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
+          const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
       }
     },
   );

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -487,11 +487,17 @@ isRecoilValue(mySelector1);
   });
   mySelectorFamArray([1, 2, 3]);
 
+  class MySerializableClass {
+    toJSON() {
+      return 'test';
+    }
+  }
   const myJsonSerializableSelectorFam = selectorFamily({
     key: 'mySelectorFam1',
-    get: (param: {from: Date, to: Date}) => () => (+param.from) - (+param.to),
+    get: (param: {date: Date, class: MySerializableClass}) => () =>
+      (param.date.toString() + JSON.stringify(param.class.toJSON())),
   });
-  myJsonSerializableSelectorFam({ from: new Date(), to: new Date() });
+  myJsonSerializableSelectorFam({ date: new Date(), class: new MySerializableClass() });
 
   const callbackSelectorFamily = selectorFamily({
     key: 'CallbackSelector',
@@ -508,7 +514,7 @@ isRecoilValue(mySelector1);
   cb('hi'); // $ExpectError
   cb(2); // $ExpectType
 
-  const selectorFamilyError1 = selector({ // $ExpectError
+  const selectorFamilyError1 = selectorFamily({ // $ExpectError
     key: 'SelectorFamilyError1',
     // Missing get()
   });
@@ -521,7 +527,7 @@ isRecoilValue(mySelector1);
   });
   selectorFamilyError2;
 
-  const selectorFamilyError3 = selector({
+  const selectorFamilyError3 = selectorFamily({
     key: 'SelectorFamilyError3',
     get: () => ({badCallback}) => null, // $ExpectError
   });
@@ -542,8 +548,11 @@ isRecoilValue(mySelector1);
   useRecoilValue(mySel3); // $ExpectType number[]
   useRecoilValue(mySel4); // $ExpectType { a: number; b: string; }
 
-  constSelector(new Map()); // $ExpectError
-  constSelector(new Set()); // $ExpectError
+  constSelector(new Map([['k', 'v']])); // $ExpectType RecoilValueReadOnly<Map<string, string>>
+  constSelector(new Set(['str'])); // $ExpectType RecoilValueReadOnly<Set<string>>
+
+  class MyClass {}
+  constSelector(new MyClass()); // $ExpectError
 }
 
 /**


### PR DESCRIPTION
Summary:
Fix the typing to explicitly allow `Map<>` and `Set<>`.

Fix the typing for `atomFamily()` and `selectorFamily()` parameters to better allow for objects that are class instances that have a `toJSON()` method to be used, as they are serializable.

Previously it required `toJSON()` to return a `string`, but it could really return any serializable primitive or object.

Previously it used the arrow syntax for the `toJSON()` method which requires that the method is bound to the instance for dereferencing `this` during execution.  That should not be a requirement, though, as we always call it relative to the instance itself.  This change allows custom user classes to be used.  For example:

```
class MyClass {
  _name: string;

  constructor(name: string) {
    this._name = name;
  }

  toJSON(): string {
    return this._name;
  }
}
```

There is no functional change with this diff, only type fixes.

Differential Revision: D35233518

