### PR TITLE
Update TypeScript tests for TypeScript 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-## 0.7 (2022-03-25)
+## 0.7 (2022-03-31)
 
 ### New Features
 - The `default` value is now optional for `atom()` and `atomFamily()`.  If not provided the atom will initialize to a pending state. (#1639)

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -290,15 +290,27 @@ useRecoilCallback(({ snapshot, set, reset, refresh, gotoSnapshot, transact_UNSTA
   snapshot; // $ExpectType Snapshot
   snapshot.getID(); // $ExpectType SnapshotID
   await snapshot.getPromise(mySelector1); // $ExpectType number
-  const loadable = snapshot.getLoadable(mySelector1); // $ExpectType Loadable<number>
+  const loadable: Loadable<number> = snapshot.getLoadable(mySelector1);
 
   gotoSnapshot(snapshot);
 
   gotoSnapshot(3); // $ExpectError
   gotoSnapshot(myAtom); // $ExpectError
 
-  loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
   loadable.contents; // $ExpectType any
+  switch (loadable.state) {
+    case 'hasValue':
+      loadable.contents; // $ExpectType number
+      break;
+    case 'hasError':
+      loadable.contents; // $ExpectType any
+      break;
+    case 'loading':
+      loadable.contents; // $ExpectType Promise<number>
+      break;
+  }
 
   set(myAtom, 5);
   set(myAtom, 'hello'); // $ExpectError
@@ -340,8 +352,9 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
       previousSnapshot.getPromise(mySelector2); // $ExpectType Promise<string>
 
       for (const node of Array.from(snapshot.getNodes_UNSTABLE({isModified: true}))) {
-        const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
-        loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
+          const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
       }
     },
   );


### PR DESCRIPTION
Summary:
It appears that TypeScript can produce inconsistent ordering for union types across versions while `$ExpectType` requires a consistent ordering.  (https://github.com/microsoft/TypeScript/issues/17944) This can cause our TypeScript tests to break when run across multiple TypeScript versions.

Update the tests to be more robust to work across versions.

Differential Revision: D35266493

