### PR TITLE
Cleanup async selectors shared across multiple roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
+- Avoid dev-mode console error with React 18 when using shared selectors across multiple `<RecoilRoot>`'s. (#1810)
 - Update typing for family parameters to better support Map, Set, and classes with `toJSON()`. (#1709, #1703)
 
 ## 0.7 (2022-03-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
+- Update typing for family parameters to better support Map, Set, and classes with `toJSON()`. (#1709, #1703)
+
 ## 0.7 (2022-03-31)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-## 0.7 (2022-03-25)
+## 0.7 (2022-03-31)
 
 ### New Features
 - The `default` value is now optional for `atom()` and `atomFamily()`.  If not provided the atom will initialize to a pending state. (#1639)

--- a/packages/recoil/recoil_values/Recoil_atomFamily.js
+++ b/packages/recoil/recoil_values/Recoil_atomFamily.js
@@ -25,13 +25,15 @@ const stableStringify = require('recoil-shared/util/Recoil_stableStringify');
 
 type Primitive = void | null | boolean | number | string;
 interface HasToJSON {
-  toJSON: () => string;
+  toJSON(): Parameter;
 }
 export type Parameter =
   | Primitive
   | HasToJSON
   | $ReadOnlyArray<Parameter>
-  | $ReadOnly<{[string]: Parameter}>;
+  | $ReadOnly<{[string]: Parameter}>
+  | $ReadOnlySet<Parameter>
+  | $ReadOnlyMap<Parameter, Parameter>;
 
 // flowlint unclear-type:off
 export type ParameterizedScopeRules<P> = $ReadOnlyArray<

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -106,11 +106,14 @@ const {
 } = require('../core/Recoil_RecoilValueInterface');
 const {retainedByOptionWithDefault} = require('../core/Recoil_Retention');
 const {recoilCallback} = require('../hooks/Recoil_useRecoilCallback');
+const concatIterables = require('recoil-shared/util/Recoil_concatIterables');
 const deepFreezeValue = require('recoil-shared/util/Recoil_deepFreezeValue');
 const err = require('recoil-shared/util/Recoil_err');
+const filterIterable = require('recoil-shared/util/Recoil_filterIterable');
 const gkx = require('recoil-shared/util/Recoil_gkx');
 const invariant = require('recoil-shared/util/Recoil_invariant');
 const isPromise = require('recoil-shared/util/Recoil_isPromise');
+const mapIterable = require('recoil-shared/util/Recoil_mapIterable');
 const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
 const {
   startPerfBlock,
@@ -961,66 +964,36 @@ function selector<T>(
     state: TreeState,
   ): ?ExecutionInfo<T> {
     // Sort the pending executions so that our current store is checked first.
-    // This is particularly important so we always return a consistent
-    // execution for evaluating a selector with multiple attempts in a store.
-    const pendingExecutions =
-      executionInfoMap.size > 1
-        ? [
-            ...(executionInfoMap.has(store)
-              ? [[store, nullthrows(executionInfoMap.get(store))]]
-              : []),
-            ...Array.from(executionInfoMap.entries()).filter(
-              ([s]) => s !== store,
-            ),
-          ]
-        : Array.from(executionInfoMap);
+    const pendingExecutions = concatIterables([
+      executionInfoMap.has(store)
+        ? [nullthrows(executionInfoMap.get(store))]
+        : [],
+      mapIterable(
+        filterIterable(executionInfoMap, ([s]) => s !== store),
+        ([, execInfo]) => execInfo,
+      ),
+    ]);
 
-    const [, executionInfo] =
-      pendingExecutions.find(([execStore, execInfo]) => {
-        return (
-          execInfo.latestLoadable != null &&
-          execInfo.latestExecutionId != null &&
-          !haveAsyncDepsChanged(execStore, state)
-        );
-      }) ?? [];
-
-    return executionInfo;
-  }
-
-  const mapOfCheckedVersions = new Map();
-
-  function haveAsyncDepsChanged(store: Store, state: TreeState): boolean {
-    const executionInfo = getExecutionInfo(store);
-
-    const oldDepValues =
-      executionInfo?.depValuesDiscoveredSoFarDuringAsyncWork ?? new Map();
-
-    const cachedDepValuesCheckedForThisVersion = Array(
-      (mapOfCheckedVersions.get(state.version) ?? new Map()).entries(),
-    );
-
-    const isCachedVersionSame =
-      mapOfCheckedVersions.has(state.version) &&
-      cachedDepValuesCheckedForThisVersion.length === oldDepValues.size &&
-      cachedDepValuesCheckedForThisVersion.every(([nodeKey, nodeVal]) => {
-        return oldDepValues.get(nodeKey) === nodeVal;
-      });
-
-    if (
-      oldDepValues == null ||
-      state.version === executionInfo?.stateVersion ||
-      isCachedVersionSame
-    ) {
+    function anyDepChanged(oldDepValues: DepValues): boolean {
+      for (const [depKey, oldLoadable] of oldDepValues) {
+        if (!getCachedNodeLoadable(store, state, depKey).is(oldLoadable)) {
+          return true;
+        }
+      }
       return false;
     }
 
-    mapOfCheckedVersions.set(state.version, new Map(oldDepValues));
-
-    return Array.from(oldDepValues).some(([nodeKey, oldVal]) => {
-      const loadable = getCachedNodeLoadable(store, state, nodeKey);
-
-      return loadable.contents !== oldVal.contents;
-    });
+    for (const execInfo of pendingExecutions) {
+      if (
+        // If this execution is on the same version of state, then it's valid
+        state.version === execInfo.stateVersion ||
+        // If the deps for the execution match our current state, then it's valid
+        !anyDepChanged(execInfo.depValuesDiscoveredSoFarDuringAsyncWork)
+      ) {
+        return execInfo;
+      }
+    }
+    return undefined;
   }
 
   function getExecutionInfo(store: Store): ?ExecutionInfo<T> {

--- a/packages/recoil/recoil_values/Recoil_selectorFamily.js
+++ b/packages/recoil/recoil_values/Recoil_selectorFamily.js
@@ -40,11 +40,13 @@ const stableStringify = require('recoil-shared/util/Recoil_stableStringify');
 // using Recoil_stableStringify
 type Primitive = void | null | boolean | number | string;
 interface HasToJSON {
-  toJSON: () => string;
+  toJSON(): Parameter;
 }
 export type Parameter =
   | Primitive
   | HasToJSON
+  | $ReadOnlySet<Parameter>
+  | $ReadOnlyMap<Parameter, Parameter>
   | $ReadOnlyArray<Parameter>
   | $ReadOnly<{...}>;
 // | $ReadOnly<{[string]: Parameter}>; // TODO Better enforce object is serializable

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -390,11 +390,14 @@
 
  // bigint not supported yet
  type Primitive = undefined | null | boolean | number | symbol | string;
+ interface HasToJSON { toJSON(): SerializableParam; }
 
  export type SerializableParam =
   | Primitive
-  | {toJSON: () => string}
+  | HasToJSON
   | ReadonlyArray<SerializableParam>
+  | ReadonlySet<SerializableParam>
+  | ReadonlyMap<SerializableParam, SerializableParam>
   | Readonly<{[key: string]: SerializableParam}>;
 
 interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -290,15 +290,27 @@ useRecoilCallback(({ snapshot, set, reset, refresh, gotoSnapshot, transact_UNSTA
   snapshot; // $ExpectType Snapshot
   snapshot.getID(); // $ExpectType SnapshotID
   await snapshot.getPromise(mySelector1); // $ExpectType number
-  const loadable = snapshot.getLoadable(mySelector1); // $ExpectType Loadable<number>
+  const loadable: Loadable<number> = snapshot.getLoadable(mySelector1);
 
   gotoSnapshot(snapshot);
 
   gotoSnapshot(3); // $ExpectError
   gotoSnapshot(myAtom); // $ExpectError
 
-  loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
   loadable.contents; // $ExpectType any
+  switch (loadable.state) {
+    case 'hasValue':
+      loadable.contents; // $ExpectType number
+      break;
+    case 'hasError':
+      loadable.contents; // $ExpectType any
+      break;
+    case 'loading':
+      loadable.contents; // $ExpectType Promise<number>
+      break;
+  }
 
   set(myAtom, 5);
   set(myAtom, 'hello'); // $ExpectError
@@ -340,8 +352,9 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
       previousSnapshot.getPromise(mySelector2); // $ExpectType Promise<string>
 
       for (const node of Array.from(snapshot.getNodes_UNSTABLE({isModified: true}))) {
-        const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
-        loadable.state; // $ExpectType "hasValue" | "loading" | "hasError"
+          const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
       }
     },
   );

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -487,11 +487,17 @@ isRecoilValue(mySelector1);
   });
   mySelectorFamArray([1, 2, 3]);
 
+  class MySerializableClass {
+    toJSON() {
+      return 'test';
+    }
+  }
   const myJsonSerializableSelectorFam = selectorFamily({
     key: 'mySelectorFam1',
-    get: (param: {from: Date, to: Date}) => () => (+param.from) - (+param.to),
+    get: (param: {date: Date, class: MySerializableClass}) => () =>
+      (param.date.toString() + JSON.stringify(param.class.toJSON())),
   });
-  myJsonSerializableSelectorFam({ from: new Date(), to: new Date() });
+  myJsonSerializableSelectorFam({ date: new Date(), class: new MySerializableClass() });
 
   const callbackSelectorFamily = selectorFamily({
     key: 'CallbackSelector',
@@ -508,7 +514,7 @@ isRecoilValue(mySelector1);
   cb('hi'); // $ExpectError
   cb(2); // $ExpectType
 
-  const selectorFamilyError1 = selector({ // $ExpectError
+  const selectorFamilyError1 = selectorFamily({ // $ExpectError
     key: 'SelectorFamilyError1',
     // Missing get()
   });
@@ -521,7 +527,7 @@ isRecoilValue(mySelector1);
   });
   selectorFamilyError2;
 
-  const selectorFamilyError3 = selector({
+  const selectorFamilyError3 = selectorFamily({
     key: 'SelectorFamilyError3',
     get: () => ({badCallback}) => null, // $ExpectError
   });
@@ -542,8 +548,11 @@ isRecoilValue(mySelector1);
   useRecoilValue(mySel3); // $ExpectType number[]
   useRecoilValue(mySel4); // $ExpectType { a: number; b: string; }
 
-  constSelector(new Map()); // $ExpectError
-  constSelector(new Set()); // $ExpectError
+  constSelector(new Map([['k', 'v']])); // $ExpectType RecoilValueReadOnly<Map<string, string>>
+  constSelector(new Set(['str'])); // $ExpectType RecoilValueReadOnly<Set<string>>
+
+  class MyClass {}
+  constSelector(new MyClass()); // $ExpectError
 }
 
 /**


### PR DESCRIPTION
Summary:
Cleanup the logic used for sharing executions of async selectors shared across multiple Recoil stores.

* Remove potential memory leak from cached dep values.
* Fix hanging selectors when reading cached dep values for checking if dep values changed.
* When checking if an execution from another store is valid, compare the value of the dep for the execution with the current value in the current store instead of the execution's store.
* Slight optimization if there are many roots or dependencies by using iterables instead of materializing arrays.

Differential Revision: D35426975

