### PR TITLE
Update RecoilRootProps type for React 18 types

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -29,7 +29,11 @@
  export type RecoilRootProps = {
   initializeState?: (mutableSnapshot: MutableSnapshot) => void,
   override?: true,
- } | {override: false};
+  children: React.ReactNode,
+ } | {
+  override: false,
+  children: React.ReactNode,
+ };
 
  /**
   * Root component for managing Recoil state.  Most Recoil hooks should be

--- a/typescript/tests.ts
+++ b/typescript/tests.ts
@@ -34,6 +34,7 @@
   useRecoilState_TRANSITION_SUPPORT_UNSTABLE,
   useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE,
 } from 'recoil';
+import * as React from 'react';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -159,7 +160,7 @@ const selectorError3 = selector({
 selectorError3;
 
 // RecoilRoot
-RecoilRoot({});
+RecoilRoot({children: React.createElement('div')});
 RecoilRoot({
   initializeState: ({ set, reset }) => {
     set(myAtom, 5);
@@ -170,9 +171,16 @@ RecoilRoot({
     setUnvalidatedAtomValues({}); // $ExpectError
     set(writeableSelector, new DefaultValue());
   },
+  children: React.createElement('div'),
 });
-RecoilRoot({override: true});
-RecoilRoot({override: false});
+RecoilRoot({
+  override: true,
+  children: React.createElement('div'),
+});
+RecoilRoot({
+  override: false,
+  children: React.createElement('div'),
+});
 
 // Loadable
 function loadableTest(loadable: Loadable<number>) {


### PR DESCRIPTION
Fixes #1717

Since @types/react v18, Implicit `children` was removed from `React.FC`. This change works for @types/react v18 and earlier.
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210