### PR TITLE
Earlier selector cache lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Cleanup potential memory leak when using async selectors (#1714)
 - Fix potentially hung async selectors when shared across multiple roots that depend on atoms initialized with promises that don't resolve (#1714)
 - Atom effects can initialize or set atoms to wrapped values (#1681)
+- Selector cache lookup optimization (#)
 
 ## 0.7 (2022-03-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update typing for family parameters to better support Map, Set, and classes with `toJSON()`. (#1709, #1703)
 - Cleanup potential memory leak when using async selectors (#1714)
 - Fix potentially hung async selectors when shared across multiple roots that depend on atoms initialized with promises that don't resolve (#1714)
+- Atom effects can initialize or set atoms to wrapped values (#1681)
 
 ## 0.7 (2022-03-31)
 

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -318,32 +318,6 @@ function selector<T>(
     stores.add(store);
   }
 
-  function getCachedNodeLoadable<TT>(
-    store: Store,
-    state: TreeState,
-    nodeKey: NodeKey,
-  ): Loadable<TT> {
-    const isKeyPointingToSelector = store
-      .getState()
-      .knownSelectors.has(nodeKey);
-
-    /**
-     * It's important that we don't bypass calling getNodeLoadable for atoms
-     * as getNodeLoadable has side effects in state
-     */
-    if (isKeyPointingToSelector && state.atomValues.has(nodeKey)) {
-      return nullthrows(state.atomValues.get(nodeKey));
-    }
-
-    const loadable = getNodeLoadable(store, state, nodeKey);
-
-    if (loadable.state !== 'loading' && isKeyPointingToSelector) {
-      state.atomValues.set(nodeKey, loadable);
-    }
-
-    return loadable;
-  }
-
   /**
    * This function attaches a then() and a catch() to a promise that was
    * returned from a selector's get() (either explicitly or implicitly by
@@ -705,7 +679,7 @@ function selector<T>(
         setDepsInStore(store, state, deps, executionId);
       }
 
-      const depLoadable = getCachedNodeLoadable(store, state, depKey);
+      const depLoadable = getNodeLoadable(store, state, depKey);
 
       depValues.set(depKey, depLoadable);
 
@@ -801,24 +775,30 @@ function selector<T>(
     store: Store,
     state: TreeState,
   ): ?Loadable<T> {
-    const depsAfterCacheDone = new Set();
-    const executionInfo = getExecutionInfo(store);
+    // First, look up in the state cache
+    // If it's here, then the deps in the store should already be valid.
+    let cachedLoadable = state.atomValues.get(key);
+    if (cachedLoadable != null) {
+      return cachedLoadable;
+    }
 
-    let cachedVal;
+    // Second, look up in the selector cache and update the deps in the store
+    const depsAfterCacheLookup = new Set();
+    const executionInfo = getExecutionInfo(store);
     try {
-      cachedVal = cache.get(
+      cachedLoadable = cache.get(
         nodeKey => {
           invariant(
             typeof nodeKey === 'string',
             'Cache nodeKey is type string',
           );
 
-          return getCachedNodeLoadable(store, state, nodeKey).contents;
+          return getNodeLoadable(store, state, nodeKey).contents;
         },
         {
           onNodeVisit: node => {
             if (node.type === 'branch' && node.nodeKey !== key) {
-              depsAfterCacheDone.add(node.nodeKey);
+              depsAfterCacheLookup.add(node.nodeKey);
             }
           },
         },
@@ -829,24 +809,28 @@ function selector<T>(
       );
     }
 
-    /**
-     * Ensure store contains correct dependencies if we hit the cache so that
-     * the store deps and cache are in sync for a given state. This is important
-     * because store deps are normally updated when new executions are created,
-     * but cache hits don't trigger new executions but they still _may_ signifiy
-     * a change in deps in the store if the store deps for this state are empty
-     * or stale.
-     */
-    if (cachedVal) {
+    if (cachedLoadable) {
+      // Cache the results in the state to allow for cheaper lookup than
+      // iterating the tree cache of dependencies.
+      state.atomValues.set(key, cachedLoadable);
+
+      /**
+       * Ensure store contains correct dependencies if we hit the cache so that
+       * the store deps and cache are in sync for a given state. This is important
+       * because store deps are normally updated when new executions are created,
+       * but cache hits don't trigger new executions but they still _may_ signify
+       * a change in deps in the store if the store deps for this state are empty
+       * or stale.
+       */
       setDepsInStore(
         store,
         state,
-        depsAfterCacheDone,
+        depsAfterCacheLookup,
         executionInfo?.latestExecutionId,
       );
     }
 
-    return cachedVal;
+    return cachedLoadable;
   }
 
   /**
@@ -973,7 +957,7 @@ function selector<T>(
 
     function hasAnyDepChanged(execDepValues: DepValues): boolean {
       for (const [depKey, execLoadable] of execDepValues) {
-        if (!getCachedNodeLoadable(store, state, depKey).is(execLoadable)) {
+        if (!getNodeLoadable(store, state, depKey).is(execLoadable)) {
           return true;
         }
       }
@@ -1122,7 +1106,7 @@ function selector<T>(
           throw err('Recoil: Async selector sets are not currently supported.');
         }
 
-        const loadable = getCachedNodeLoadable(store, state, depKey);
+        const loadable = getNodeLoadable(store, state, depKey);
 
         if (loadable.state === 'hasValue') {
           return loadable.contents;

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -1242,6 +1242,48 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('"OTHER""INIT"');
   });
 
+  testRecoil(
+    'atom effect runs twice when atom is read from a snapshot and the atom is read for first time in that snapshot',
+    ({strictMode, concurrentMode}) => {
+      let numTimesEffectInit = 0;
+      let latestSetSelf = a => a;
+
+      const atomWithEffect = atom({
+        key: 'atomWithEffect',
+        default: 0,
+        effects: [
+          ({setSelf}) => {
+            latestSetSelf = setSelf;
+            setSelf(1); // to accurately reproduce minimal reproducible example based on GitHub #1107 issue
+            numTimesEffectInit++;
+          },
+        ],
+      });
+
+      const Component = () => {
+        const readSelFromSnapshot = useRecoilCallback(({snapshot}) => () => {
+          snapshot.getLoadable(atomWithEffect);
+        });
+
+        readSelFromSnapshot(); // first initialization;
+
+        return useRecoilValue(atomWithEffect); // second initialization;
+      };
+
+      const c = renderElements(<Component />);
+      expect(c.textContent).toBe('1');
+      expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
+
+      act(() => latestSetSelf(100));
+      expect(c.textContent).toBe('100');
+      expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
+
+      act(() => latestSetSelf(200));
+      expect(c.textContent).toBe('200');
+      expect(numTimesEffectInit).toBe(strictMode && concurrentMode ? 3 : 2);
+    },
+  );
+
   /**
    * See github issue #1107 item #1
    */
@@ -1257,9 +1299,7 @@ describe('Effects', () => {
         effects: [
           ({setSelf}) => {
             latestSetSelf = setSelf;
-
-            setSelf(1); // to accurately reproduce minimal reproducible example based on GitHub issue
-
+            setSelf(1); // to accurately reproduce minimal reproducible example based on GitHub #1107 issue
             numTimesEffectInit++;
           },
         ],

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -376,7 +376,7 @@ describe('Effects', () => {
   testRecoil('initialization', () => {
     let inited = false;
     const myAtom = atom({
-      key: 'atom effect',
+      key: 'atom effect init',
       default: 'DEFAULT',
       effects: [
         ({node, trigger, setSelf}) => {
@@ -419,6 +419,34 @@ describe('Effects', () => {
     expect(c.textContent).toEqual('loading');
     act(() => jest.runAllTimers());
     expect(c.textContent).toEqual('"RESOLVE"');
+  });
+
+  testRecoil('set to Promise', async () => {
+    let setLater;
+    const myAtom = atom({
+      key: 'atom effect set promise',
+      default: 'DEFAULT',
+      effects: [
+        ({setSelf}) => {
+          setSelf(atom.value(Promise.resolve('INIT_PROMISE')));
+          setLater = setSelf;
+        },
+      ],
+    });
+    expect(getRecoilStateLoadable(myAtom).state).toBe('hasValue');
+    await expect(getRecoilStateLoadable(myAtom).contents).resolves.toBe(
+      'INIT_PROMISE',
+    );
+    act(() => setLater(atom.value(Promise.resolve('LATER_PROMISE'))));
+    expect(getRecoilStateLoadable(myAtom).state).toBe('hasValue');
+    await expect(getRecoilStateLoadable(myAtom).contents).resolves.toBe(
+      'LATER_PROMISE',
+    );
+    act(() => setLater(() => atom.value(Promise.resolve('UPDATER_PROMISE'))));
+    expect(getRecoilStateLoadable(myAtom).state).toBe('hasValue');
+    await expect(getRecoilStateLoadable(myAtom).contents).resolves.toBe(
+      'UPDATER_PROMISE',
+    );
   });
 
   testRecoil('order of effects', () => {

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -93,7 +93,8 @@
     | T
     | DefaultValue
     | Promise<T | DefaultValue>
-    | ((param: T | DefaultValue) => T | DefaultValue),
+    | WrappedValue<T>
+    | ((param: T | DefaultValue) => T | DefaultValue | WrappedValue<T>),
   ) => void,
   resetSelf: () => void,
 


### PR DESCRIPTION
Summary:
More red lines!

While supporting some users I realized an opportunity to simplify the selector implementation slightly and optimize cache lookups to happen earlier.  Previously, selectors would not cache their own value in the store state, only their dependencies.  So, repeated lookups of a selector would require looking up in the more expensive selector tree cache.  This optimization fixes that.  It also makes `Snapshot` clones more robust by always cloning the `TreeState` to avoid snapshot selector lookup aching to inadvertently affect the parent store, which may cause atoms to skip initialization now that we are more aggresively caching.

* Performance test of reading 100 selectors 100 times each took 1/3rd the time.
* Performance test of reading 100 selectors with 100 dependencies 100 times each took 1/3rd the time.

Differential Revision: D35492328

