### PR TITLE
[docs/korean] fix typo and  highlighted words

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/selectors.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/selectors.md
@@ -64,7 +64,7 @@ function TodoList() {
 }
 ```
 
-UI는 `toDoListFilterState`의 기본값인 `"Show All"`과 동일하다. 필터를 변경하려면 우리는 `TodoListFilter` 컴포넌트를 구현해야 한다.
+UI는 `todoListFilterState`의 기본값인 `"Show All"`과 동일하다. 필터를 변경하려면 우리는 `TodoListFilter` 컴포넌트를 구현해야 한다.
 
 ```jsx
 function TodoListFilters() {

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/selectors.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/selectors.md
@@ -64,7 +64,7 @@ function TodoList() {
 }
 ```
 
-UI는 `toDoListFilterState`의 기본값인 `Show All`과 동일하다. 필터를 변경하려면 우리는 `TodoListFilter` 컴포넌트를 구현해야 한다.
+UI는 `toDoListFilterState`의 기본값인 `"Show All"`과 동일하다. 필터를 변경하려면 우리는 `TodoListFilter` 컴포넌트를 구현해야 한다.
 
 ```jsx
 function TodoListFilters() {

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/selectors.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/basic-tutorial/selectors.md
@@ -64,7 +64,7 @@ function TodoList() {
 }
 ```
 
-UI는 'toListFilterState'의 기본값인 'Show All'과 동일하다. 필터를 변경하려면 우리는 `TodoListFilter` 컴포넌트를 구현해야 한다.
+UI는 `toDoListFilterState`의 기본값인 `Show All`과 동일하다. 필터를 변경하려면 우리는 `TodoListFilter` 컴포넌트를 구현해야 한다.
 
 ```jsx
 function TodoListFilters() {


### PR DESCRIPTION
Hello, I'm looking at the [Recoil Selectors page](https://recoiljs.org/ko/docs/basic-tutorial/selectors/),  but There's a typo and I think there's no emphasis on words, so I'm posting PR.

1. fix typo: toListFilterState -> todoListFilterState
                  Add double quotes to show All -> "show All' (This is because double quotes are added to the English document.)
2. Emphasize words(state, option) : 'todoListFilterState' , 'Show All'   (Because it is highlighted in the English document.)