### PR TITLE
Cleanup some FlowFixMe and enable RecoilValue's for family parameters

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,8 +39,8 @@ jobs:
       if: matrix.os == 'windows-latest'
     - run: yarn install
     - run: yarn flow
-    - run: yarn test
     - run: yarn test:typescript
+    - run: yarn test
     - run: yarn lint
     - run: yarn build
     - run: yarn pack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Atom effects can initialize or set atoms to wrapped values (#1681)
 - Add `parentStoreID_UNSTABLE` to atom effects.  This will match up with the store that the current store was cloned from, such as the host `<RecoilRoot>` store for `useRecoilCallback()` snapshots. (#1744)
+- Enable atoms and selectors to be used in family parameters (#1740)
 
 ## 0.7.2 (2022-04-13)
 

--- a/packages/recoil/caches/Recoil_CacheImplementationType.js
+++ b/packages/recoil/caches/Recoil_CacheImplementationType.js
@@ -11,9 +11,9 @@
 'use strict';
 
 export interface CacheImplementation<K, V> {
-  +get: K => ?V;
-  +set: (K, V) => void;
-  +delete: K => void;
-  +clear: () => void;
-  +size: () => number;
+  get(K): ?V;
+  set(K, V): void;
+  delete(K): void;
+  clear(): void;
+  size(): number;
 }

--- a/packages/recoil/caches/Recoil_TreeCache.js
+++ b/packages/recoil/caches/Recoil_TreeCache.js
@@ -35,7 +35,8 @@ class ChangedPathError extends Error {}
 class TreeCache<T = mixed> {
   _name: ?string;
   _numLeafs: number;
-  _root: TreeCacheNode<T> | null;
+  // $FlowIssue[unclear-type]
+  _root: TreeCacheNode<any> | null;
 
   _onHit: $NonMaybeType<Options<T>['onHit']>;
   _onSet: $NonMaybeType<Options<T>['onSet']>;
@@ -54,7 +55,8 @@ class TreeCache<T = mixed> {
     return this._numLeafs;
   }
 
-  root(): TreeCacheNode<T> | null {
+  // $FlowIssue[unclear-type]
+  root(): TreeCacheNode<any> | null {
     return this._root;
   }
 
@@ -71,7 +73,8 @@ class TreeCache<T = mixed> {
     }
 
     // Iterate down the tree based on the current node values until we hit a leaf
-    let node = this._root;
+    // $FlowIssue[unclear-type]
+    let node: ?TreeCacheNode<any> = this._root;
     while (node) {
       handlers?.onNodeVisit(node);
       if (node.type === 'leaf') {
@@ -79,7 +82,6 @@ class TreeCache<T = mixed> {
         return node;
       }
       const nodeValue = this._mapNodeValue(getNodeValue(node.nodeKey));
-      // $FlowFixMe[incompatible-type]
       node = node.branches.get(nodeValue);
     }
     return undefined;

--- a/packages/recoil/caches/Recoil_TreeCacheImplementationType.js
+++ b/packages/recoil/caches/Recoil_TreeCacheImplementationType.js
@@ -62,10 +62,10 @@ export type SetHandlers<T> = {
  * are used internally by the selector.
  */
 export interface TreeCacheImplementation<T> {
-  +get: (NodeValueGet, handlers?: GetHandlers<T>) => ?T;
-  +set: (NodeCacheRoute, T, handlers?: SetHandlers<T>) => void;
-  +delete: (TreeCacheLeaf<T>) => boolean;
-  +clear: () => void;
-  +root: () => ?TreeCacheNode<T>;
-  +size: () => number;
+  get(NodeValueGet, handlers?: GetHandlers<T>): ?T;
+  set(NodeCacheRoute, T, handlers?: SetHandlers<T>): void;
+  delete(TreeCacheLeaf<T>): boolean;
+  clear(): void;
+  root(): ?TreeCacheNode<T>;
+  size(): number;
 }

--- a/packages/recoil/caches/Recoil_cacheFromPolicy.js
+++ b/packages/recoil/caches/Recoil_cacheFromPolicy.js
@@ -58,13 +58,10 @@ function getCache<K, V>(
 ): CacheImplementation<K, V> {
   switch (eviction) {
     case 'keep-all':
-      // $FlowFixMe[method-unbinding]
       return new MapCache<K, V>({mapKey});
     case 'lru':
-      // $FlowFixMe[method-unbinding]
       return new LRUCache<K, V>({mapKey, maxSize: nullthrows(maxSize)});
     case 'most-recent':
-      // $FlowFixMe[method-unbinding]
       return new LRUCache<K, V>({mapKey, maxSize: 1});
   }
 

--- a/packages/recoil/caches/Recoil_treeCacheFromPolicy.js
+++ b/packages/recoil/caches/Recoil_treeCacheFromPolicy.js
@@ -59,7 +59,6 @@ function getTreeCache<T>(
 ): TreeCacheImplementation<T> {
   switch (eviction) {
     case 'keep-all':
-      // $FlowFixMe[method-unbinding]
       return new TreeCache<T>({name, mapNodeValue});
     case 'lru':
       return treeCacheLRU<T>({

--- a/packages/recoil/caches/Recoil_treeCacheLRU.js
+++ b/packages/recoil/caches/Recoil_treeCacheLRU.js
@@ -43,7 +43,6 @@ function treeCacheLRU<T>({
     },
   });
 
-  // $FlowFixMe[method-unbinding]
   return cache;
 }
 

--- a/packages/recoil/core/Recoil_AtomicUpdates.js
+++ b/packages/recoil/core/Recoil_AtomicUpdates.js
@@ -50,7 +50,7 @@ class TransactionInterfaceImpl {
   // eslint-disable-next-line fb-www/extra-arrow-initializer
   get = <T>(recoilValue: RecoilValue<T>): T => {
     if (this._changes.has(recoilValue.key)) {
-      // $FlowFixMe[incompatible-return]
+      // $FlowIssue[incompatible-return]
       return this._changes.get(recoilValue.key);
     }
     if (!isAtom(recoilValue)) {

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -293,8 +293,7 @@ if (__DEV__) {
 function initialStoreState_DEPRECATED(store, initializeState): StoreState {
   const initial: StoreState = makeEmptyStoreState();
   initializeState({
-    // $FlowFixMe[escaped-generic]
-    set: (atom, value) => {
+    set: <T>(atom: RecoilValue<T>, value: T) => {
       const state = initial.currentTree;
       const writes = setNodeValue(store, state, atom.key, value);
       const writtenNodes = new Set(writes.keys());

--- a/packages/recoil/core/Recoil_RecoilValue.js
+++ b/packages/recoil/core/Recoil_RecoilValue.js
@@ -18,6 +18,9 @@ class AbstractRecoilValue<+T> {
   constructor(newKey: NodeKey) {
     this.key = newKey;
   }
+  toJSON(): {key: string} {
+    return {key: this.key};
+  }
 }
 
 class RecoilState<T> extends AbstractRecoilValue<T> {}

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -247,9 +247,8 @@ class Snapshot {
   // eslint-disable-next-line fb-www/extra-arrow-initializer
   getInfo_UNSTABLE: <T>(RecoilValue<T>) => RecoilValueInfo<T> = <T>({
     key,
-  }: RecoilValue<T>) => {
+  }: RecoilValue<T>): RecoilValueInfo<T> => {
     this.checkRefCount_INTERNAL();
-    // $FlowFixMe[escaped-generic]
     return peekNodeInfo(this._store, this._store.getState().currentTree, key);
   };
 

--- a/packages/recoil/core/__tests__/Recoil_RecoilRoot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_RecoilRoot-test.js
@@ -55,7 +55,6 @@ describe('initializeState', () => {
       key: 'RecoilRoot - initializeState - atom',
       default: 'DEFAULT',
     });
-    // $FlowFixMe[incompatible-call] added when improving typing for this parameters
     const mySelector = constSelector(myAtom);
 
     function initializeState({set, getLoadable}) {
@@ -269,10 +268,10 @@ describe('initializeState', () => {
     const [ReadsWritesAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);
 
     const initializeState = jest.fn(({set}) => set(myAtom, 'INIT'));
-    let forceUpdate: $FlowFixMe = () => {
+    let forceUpdate: () => void = () => {
       throw new Error('not rendered');
     };
-    let setRootKey: $FlowFixMe = _ => {
+    let setRootKey: number => void = _ => {
       throw new Error('');
     };
     function MyRoot() {

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -145,7 +145,6 @@ testRecoil(
     let expectedSnapshotID = null;
 
     const myAtom = atom({key: 'Snapshot ID atom', default: 0});
-    // $FlowFixMe[incompatible-call] added when improving typing for this parameters
     const mySelector = constSelector(myAtom); // For read-only testing below
 
     const transactionObserver = ({snapshot}) => {
@@ -225,7 +224,6 @@ testRecoil('Read default loadable from snapshot', () => {
   expect(atomLoadable.state).toEqual('hasValue');
   expect(atomLoadable.contents).toEqual('DEFAULT');
 
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   const mySelector = constSelector(myAtom);
   const selectorLoadable = snapshot.getLoadable(mySelector);
   expect(selectorLoadable.state).toEqual('hasValue');
@@ -238,7 +236,6 @@ testRecoil('Read async selector from snapshot', async () => {
   const otherB = freshSnapshot();
 
   const [asyncSel, resolve] = asyncSelector();
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   const nestSel = constSelector(asyncSel);
 
   expect(snapshot.getLoadable(asyncSel).state).toEqual('loading');
@@ -268,7 +265,6 @@ testRecoil('Sync map of snapshot', () => {
     key: 'Snapshot Map Sync',
     default: 'DEFAULT',
   });
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   const mySelector = constSelector(myAtom);
 
   const atomLoadable = snapshot.getLoadable(myAtom);
@@ -600,7 +596,7 @@ describe('Atom effects', () => {
       ],
     });
 
-    let setMount: $FlowFixMe = _ => {
+    let setMount: boolean => void = () => {
       throw new Error('Test Error');
     };
     function Component() {

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -60,7 +60,7 @@ function handleLoadable<T>(
       storeRef.current.getState().suspendedComponentResolvers.add(resolve);
     });
 
-    // $FlowFixMe Flow(prop-missing) for integrating with tools that inspect thrown promises @fb-only
+    // $FlowExpectedError Flow(prop-missing) for integrating with tools that inspect thrown promises @fb-only
     // @fb-only: promise.displayName = `Recoil State: ${recoilValue.key}`;
 
     throw promise;

--- a/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_PublicHooks-test.js
@@ -435,8 +435,7 @@ describe('Render counts', () => {
 
       const Component = (jest.fn(function ReadFromSelector({id}) {
         return useRecoilValue(selectAFakeId(id));
-        // $FlowFixMe[unclear-type]
-      }): Function);
+      }): ({id: number}) => React.Node);
 
       let increment;
 
@@ -861,7 +860,7 @@ testRecoil(
     function testWithOrder(order) {
       const anAtom = counterAtom();
 
-      let q: Array<$FlowFixMe> = [];
+      let q: Array<[string, () => mixed]> = [];
       let seen = false;
       const original = Queue.enqueueExecution;
       try {

--- a/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useGotoRecoilSnapshot-test.js
@@ -61,7 +61,6 @@ testRecoil('Goto mapped snapshot', async () => {
   });
   const [ReadsAndWritesAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);
 
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   const mySelector = constSelector(myAtom);
 
   const updatedSnapshot = snapshot.map(({set}) => {
@@ -110,7 +109,6 @@ testRecoil('Goto callback snapshot', () => {
   });
   const [ReadsAndWritesAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);
 
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   const mySelector = constSelector(myAtom);
 
   let cb;

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilCallback-test.js
@@ -61,7 +61,7 @@ const testRecoil = getRecoilTestFn(() => {
 
 testRecoil('Reads Recoil values', async () => {
   const anAtom = atom({key: 'atom1', default: 'DEFAULT'});
-  let pTest: ?Promise<$FlowFixMeEmpty> = Promise.reject(
+  let pTest: ?Promise<mixed> = Promise.reject(
     new Error("Callback didn't resolve"),
   );
   let cb;
@@ -110,7 +110,7 @@ testRecoil('Can read Recoil values without throwing', async () => {
 testRecoil('Sets Recoil values (by queueing them)', async () => {
   const anAtom = atom({key: 'atom3', default: 'DEFAULT'});
   let cb;
-  let pTest: ?Promise<$FlowFixMeEmpty> = Promise.reject(
+  let pTest: ?Promise<mixed> = Promise.reject(
     new Error("Callback didn't resolve"),
   );
 
@@ -228,8 +228,8 @@ testRecoil('Reads from a snapshot created at callback call time', async () => {
 
   // But does not see an update flushed while the cb is in progress:
   seenValue = null;
-  let resumeCallback: (() => $FlowFixMeEmpty) | ((result: mixed) => void) =
-    () => invariant(false, 'must be initialized');
+  let resumeCallback: () => void = () =>
+    invariant(false, 'must be initialized');
   delay = () => {
     return new Promise(resolve => {
       resumeCallback = resolve;
@@ -393,14 +393,14 @@ testRecoil('Updates are batched', () => {
 
   invariant(store, 'store should be initialized');
   const originalReplaceState = store.replaceState;
-  // $FlowFixMe[cannot-write]
+  // $FlowExpectedError[cannot-write]
   store.replaceState = jest.fn(originalReplaceState);
 
   expect(store.replaceState).toHaveBeenCalledTimes(0);
   act(() => cb());
   expect(store.replaceState).toHaveBeenCalledTimes(1);
 
-  // $FlowFixMe[cannot-write]
+  // $FlowExpectedError[cannot-write]
   store.replaceState = originalReplaceState;
 });
 

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilSnapshot-test.js
@@ -62,7 +62,6 @@ testRecoil('useRecoilSnapshot - subscribe to updates', ({strictMode}) => {
   const [ReadsAndWritesAtom, setAtom, resetAtom] =
     componentThatReadsAndWritesAtom(myAtom);
 
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   const mySelector = constSelector(myAtom);
 
   const snapshots = [];
@@ -109,7 +108,7 @@ testRecoil('useRecoilSnapshot - goto snapshots', ({strictMode}) => {
   const [ReadsAndWritesAtomA, setAtomA] =
     componentThatReadsAndWritesAtom(atomA);
 
-  const atomB = atom({
+  const atomB = atom<string | number>({
     key: 'useRecoilSnapshot - goto B',
     default: 'DEFAULT',
   });
@@ -150,7 +149,6 @@ testRecoil('useRecoilSnapshot - goto snapshots', ({strictMode}) => {
   act(() => gotoSnapshot(snapshots[0]));
   expect(c.textContent).toEqual('"DEFAULT""DEFAULT"');
 
-  // $FlowFixMe[incompatible-call]
   act(() => gotoSnapshot(snapshots[2].map(({set}) => set(atomB, 3))));
   expect(c.textContent).toEqual('13');
 });
@@ -384,7 +382,7 @@ describe('Snapshot Retention', () => {
       ],
     });
 
-    let setMount: $FlowFixMe = _ => {
+    let setMount: boolean => void = () => {
       throw new Error('Test Error');
     };
     function UseRecoilSnapshot() {

--- a/packages/recoil/recoil_values/Recoil_selector.js
+++ b/packages/recoil/recoil_values/Recoil_selector.js
@@ -77,6 +77,7 @@ import type {
   GetRecoilValue,
   ResetRecoilState,
   SetRecoilState,
+  ValueOrUpdater,
 } from './Recoil_callbackTypes';
 
 const {
@@ -806,8 +807,7 @@ function selector<T>(
   ): ?Loadable<T> {
     // First, look up in the state cache
     // If it's here, then the deps in the store should already be valid.
-    let cachedLoadable: ?(Loadable<$FlowFixMe> | Loadable<T>) =
-      state.atomValues.get(key);
+    let cachedLoadable: ?Loadable<T> = state.atomValues.get(key);
     if (cachedLoadable != null) {
       return cachedLoadable;
     }
@@ -815,7 +815,6 @@ function selector<T>(
     // Second, look up in the selector cache and update the deps in the store
     const depsAfterCacheLookup = new Set();
     try {
-      // $FlowFixMe[incompatible-type]
       cachedLoadable = cache.get(
         nodeKey => {
           invariant(
@@ -1148,7 +1147,7 @@ function selector<T>(
 
       function setRecoilState<S>(
         recoilState: RecoilState<S>,
-        valueOrUpdater: S | DefaultValue | ((S, GetRecoilValue) => S),
+        valueOrUpdater: ValueOrUpdater<S>,
       ) {
         if (syncSelectorSetFinished) {
           throw err('Recoil: Async selector sets are not currently supported.');
@@ -1176,7 +1175,6 @@ function selector<T>(
       }
 
       const ret = set(
-        // $FlowFixMe[incompatible-call]
         {set: setRecoilState, get: getRecoilValue, reset: resetRecoilState},
         newValue,
       );

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -1149,7 +1149,7 @@ describe('Effects', () => {
       ],
     });
 
-    let setMount: $FlowFixMe = _ => {
+    let setMount: boolean => void = _ => {
       throw new Error('Test Error');
     };
     const [ReadWriteAtom, setAtom] = componentThatReadsAndWritesAtom(myAtom);

--- a/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atomFamily-test.js
@@ -192,15 +192,10 @@ testRecoil('Works with date as parameter', () => {
     key: 'dateFamily',
     default: _date => 0,
   });
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   expect(get(dateAtomFamily(new Date(2021, 2, 25)))).toBe(0);
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   expect(get(dateAtomFamily(new Date(2021, 2, 26)))).toBe(0);
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   set(dateAtomFamily(new Date(2021, 2, 25)), 1);
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   expect(get(dateAtomFamily(new Date(2021, 2, 25)))).toBe(1);
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   expect(get(dateAtomFamily(new Date(2021, 2, 26)))).toBe(0);
 });
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -89,15 +89,15 @@ function getError(recoilValue): Error {
 
 function setValue(recoilState, value) {
   setRecoilValue(store, recoilState, value);
-  // $FlowFixMe[unsafe-addition]
-  // $FlowFixMe[cannot-write]
+  // $FlowExpectedError[unsafe-addition]
+  // $FlowExpectedError[cannot-write]
   store.getState().currentTree.version++;
 }
 
 function resetValue(recoilState) {
   setRecoilValue(store, recoilState, new DefaultValue());
-  // $FlowFixMe[unsafe-addition]
-  // $FlowFixMe[cannot-write]
+  // $FlowExpectedError[unsafe-addition]
+  // $FlowExpectedError[cannot-write]
   store.getState().currentTree.version++;
 }
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_selectorFamily-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selectorFamily-test.js
@@ -114,10 +114,8 @@ testRecoil('selectorFamily - date parameter', () => {
   });
 
   set(myAtom, 1);
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   expect(getValue(mySelector(new Date(2021, 2, 25))).getDate()).toBe(26);
   set(myAtom, 2);
-  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
   expect(getValue(mySelector(new Date(2021, 2, 25))).getDate()).toBe(27);
 });
 

--- a/packages/recoil/recoil_values/__tests__/Recoil_selectorHooks-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selectorHooks-test.js
@@ -156,21 +156,17 @@ function additionSelector(
   return [sel, fn];
 }
 
-// flowlint-next-line unclear-type:off
-function asyncSelectorThatPushesPromisesOntoArray(dep: RecoilValue<any>) {
-  const promises = [];
-  const sel = selector({
+function asyncSelectorThatPushesPromisesOntoArray<T, S>(
+  dep: RecoilValue<S>,
+): [RecoilValue<T>, $ReadOnlyArray<[(T) => void, (mixed) => void]>] {
+  const promises: Array<[(T) => void, (mixed) => void]> = [];
+  const sel = selector<T>({
     key: `selector${nextID++}`,
     get: ({get}) => {
       get(dep);
-      let resolve:
-        | ((_: number | $TEMPORARY$string<'hello'>) => $FlowFixMeEmpty)
-        // $FlowFixMe[speculation-ambiguous]
-        | ((result: Promise<$FlowFixMe> | $FlowFixMe) => void) = _ =>
-        invariant(false, 'bug in test code'); // make flow happy with initialization
-      let reject: (error: $FlowFixMe) => void = _ =>
-        invariant(false, 'bug in test code');
-      const p = new Promise((res, rej) => {
+      let resolve: T => void = () => invariant(false, 'bug in test code'); // make flow happy with initialization
+      let reject: mixed => void = () => invariant(false, 'bug in test code');
+      const p = new Promise<T>((res, rej) => {
         resolve = res;
         reject = rej;
       });
@@ -1580,7 +1576,7 @@ describe('Async Selectors', () => {
         key: 'notifiesAllStores/snapshots/a',
         get: () => 'foo',
       });
-      let resolve: $FlowFixMe = _ => {
+      let resolve: string => void = () => {
         throw new Error('error in test');
       };
       const selectorB = selector({

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -233,8 +233,7 @@ const errorThrowingAsyncSelector: <T, S>(
 
 const resolvingAsyncSelector: <T>(T) => RecoilValue<T> = <T>(
   value: T,
-  // $FlowFixMe[incompatible-type]
-): RecoilValueReadOnly<T> | RecoilValueReadOnly<mixed> =>
+): RecoilValueReadOnly<T> =>
   selector({
     key: `ResolvingSelector${id++}`,
     get: () => Promise.resolve(value),
@@ -249,11 +248,11 @@ const loadingAsyncSelector: () => RecoilValueReadOnly<void> = () =>
 function asyncSelector<T, S>(
   dep?: RecoilValue<S>,
 ): [RecoilValue<T>, (T) => void, (Error) => void] {
-  let resolve: (() => void) | ((result: Promise<T> | T) => void) = () =>
+  let resolve: (result: Promise<T> | T) => void = () =>
     invariant(false, 'bug in test code'); // make flow happy with initialization
-  let reject: (() => void) | ((error: $FlowFixMe) => void) = () =>
+  let reject: (error: mixed) => void = () =>
     invariant(false, 'bug in test code');
-  const promise = new Promise((res, rej) => {
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
   });
@@ -266,7 +265,6 @@ function asyncSelector<T, S>(
       return promise;
     },
   });
-  // $FlowFixMe[incompatible-return]
   return [sel, resolve, reject];
 }
 

--- a/packages/shared/util/Recoil_deepFreezeValue.js
+++ b/packages/shared/util/Recoil_deepFreezeValue.js
@@ -78,7 +78,7 @@ function deepFreezeValue(value: mixed) {
 
   Object.freeze(value); // Make all properties read-only
   for (const key in value) {
-    // $FlowFixMe[method-unbinding] added when improving typing for this parameters
+    // $FlowIssue[method-unbinding] added when improving typing for this parameters
     if (Object.prototype.hasOwnProperty.call(value, key)) {
       const prop = value[key];
       // Prevent infinite recurssion for circular references.

--- a/packages/shared/util/Recoil_mergeMaps.js
+++ b/packages/shared/util/Recoil_mergeMaps.js
@@ -14,18 +14,15 @@
 function mergeMaps<TKey, TValue>(
   ...maps: $ReadOnlyArray<$ReadOnlyMap<TKey, TValue>>
 ): Map<TKey, TValue> {
-  const result = new Map();
+  const result = new Map<TKey, TValue>();
   for (let i = 0; i < maps.length; i++) {
     const iterator = maps[i].keys();
     let nextKey;
     while (!(nextKey = iterator.next()).done) {
-      // $FlowFixMe[incompatible-call] - map/iterator knows nothing about flow types
+      // $FlowIssue[incompatible-call] - map/iterator knows nothing about flow types
       result.set(nextKey.value, maps[i].get(nextKey.value));
     }
   }
-  /* $FlowFixMe[incompatible-return] (>=0.66.0 site=www,mobile) This comment
-   * suppresses an error found when Flow v0.66 was deployed. To see the error
-   * delete this comment and run Flow. */
   return result;
 }
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -374,6 +374,7 @@
 
   key: NodeKey;
   constructor(newKey: NodeKey);
+  toJSON(): {key: string};
  }
 
  declare class AbstractRecoilValueReadonly<T> {
@@ -381,6 +382,7 @@
 
   key: NodeKey;
   constructor(newKey: NodeKey);
+  toJSON(): {key: string};
  }
 
  export class RecoilState<T> extends AbstractRecoilValue<T> {}


### PR DESCRIPTION
Summary:
Cleanup some `$FlowFixMe`'s

Update `RecoilValue`'s so they can be used in family parameters

Differential Revision: D35688664

