### PR TITLE
Add parentStoreID_UNSTABLE to atom effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 **_Add new changes here as they land_**
 
 - Atom effects can initialize or set atoms to wrapped values (#1681)
+- Add `parentStoreID_UNSTABLE` to atom effects.  This will match up with the store that the current store was cloned from, such as the host `<RecoilRoot>` store for `useRecoilCallback()` snapshots. (#1744)
 
 ## 0.7.2 (2022-04-13)
 

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -333,7 +333,7 @@ function initialStoreState_DEPRECATED(store, initializeState): StoreState {
 // but state initialization only happens once the first time.
 function initialStoreState(initializeState): StoreState {
   // Initialize a snapshot and get its store
-  const snapshot = freshSnapshot().map(initializeState);
+  const snapshot = freshSnapshot(initializeState);
   const storeState = snapshot.getStore_INTERNAL().getState();
 
   // Counteract the snapshot auto-release

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -78,9 +78,10 @@ class Snapshot {
   _store: Store;
   _refCount: number = 1;
 
-  constructor(storeState: StoreState) {
+  constructor(storeState: StoreState, parentStoreID?: StoreID) {
     this._store = {
       storeID: getNextStoreID(),
+      parentStoreID,
       getState: () => storeState,
       replaceState: replacer => {
         // no batching, so nextTree is never active
@@ -339,7 +340,7 @@ const [memoizedCloneSnapshot, invalidateMemoizedSnapshot] =
         version === 'latest'
           ? storeState.nextTree ?? storeState.currentTree
           : nullthrows(storeState.previousTree);
-      return new Snapshot(cloneStoreState(store, treeState));
+      return new Snapshot(cloneStoreState(store, treeState), store.storeID);
     },
     (store, version) =>
       String(version) +
@@ -373,6 +374,7 @@ class MutableSnapshot extends Snapshot {
         snapshot.getStore_INTERNAL().getState().currentTree,
         true,
       ),
+      snapshot.getStoreID(),
     );
     this._batch = batch;
   }

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -125,6 +125,7 @@ export type StoreState = {
 // It is constant within a given Recoil root.
 export type Store = $ReadOnly<{
   storeID: StoreID,
+  parentStoreID?: StoreID,
   getState: () => StoreState,
   replaceState: ((TreeState) => TreeState) => void,
   getGraph: StateID => Graph,

--- a/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
+++ b/packages/recoil/core/__tests__/Recoil_Snapshot-test.js
@@ -644,4 +644,25 @@ describe('Atom effects', () => {
       testSnapshot.getStoreID(),
     );
   });
+
+  testRecoil('Parent StoreID', () => {
+    const myAtom = atom({
+      key: 'snapshot effects parentStoreID',
+      effects: [
+        ({storeID, parentStoreID_UNSTABLE, setSelf}) => {
+          setSelf({storeID, parentStoreID: parentStoreID_UNSTABLE});
+        },
+      ],
+    });
+
+    const testSnapshot = freshSnapshot();
+    const mappedSnapshot = testSnapshot.map(() => {});
+
+    expect(mappedSnapshot.getLoadable(myAtom).getValue().storeID).toBe(
+      mappedSnapshot.getStoreID(),
+    );
+    expect(mappedSnapshot.getLoadable(myAtom).getValue().parentStoreID).toBe(
+      testSnapshot.getStoreID(),
+    );
+  });
 });

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -125,6 +125,7 @@ type NewValueOrUpdater<T> =
 export type AtomEffect<T> = ({
   node: RecoilState<T>,
   storeID: StoreID,
+  parentStoreID_UNSTABLE?: StoreID,
   trigger: Trigger,
 
   // Call synchronously to initialize value or async to change it later
@@ -436,6 +437,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
           const cleanup = effect({
             node,
             storeID: store.storeID,
+            parentStoreID_UNSTABLE: store.parentStoreID,
             trigger,
             setSelf: setSelf(effect),
             resetSelf: resetSelf(effect),

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -1549,6 +1549,29 @@ describe('Effects', () => {
     expect(effectStoreID).not.toEqual(undefined);
     expect(effectStoreID).toEqual(rootStoreID);
   });
+
+  testRecoil('parentStoreID matches <RecoilRoot>', async () => {
+    const myAtom = atom({
+      key: 'atom effect - parentStoreID',
+      effects: [
+        ({parentStoreID_UNSTABLE, setSelf}) => {
+          setSelf(parentStoreID_UNSTABLE);
+        },
+      ],
+    });
+
+    let prefetch;
+    function PrefetchComponent() {
+      const storeID = useRecoilStoreID();
+      prefetch = useRecoilCallback(({snapshot}) => () => {
+        const parentStoreID = snapshot.getLoadable(myAtom).getValue();
+        expect(storeID).toBe(parentStoreID);
+      });
+    }
+
+    renderElements(<PrefetchComponent />);
+    act(prefetch);
+  });
 });
 
 testRecoil('object is frozen when stored in atom', async () => {

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -90,6 +90,7 @@
  export type AtomEffect<T> = (param: {
   node: RecoilState<T>,
   storeID: StoreID,
+  parentStoreID_UNSTABLE?: StoreID,
   trigger: 'set' | 'get',
 
   // Call synchronously to initialize value or async to change it later


### PR DESCRIPTION
Summary: Add `parentStoreID_UNSTABLE` to atom effects.  This can be helpful if you are matching up Store IDs when an atom is initialized from a snapshot that was cloned from `<RecoilRoot>` or mapped from another snapshot.  That is common when using `useRecoilCallback()`.  The snapshot provided in that callback will be a clone and have a unique `StoreID`, but the `parentStoreID_UNSTABLE` would match with the `StoreID` from the creating components `<RecoilRoot>` store as measured by `useRecoilStoreID()`.

Differential Revision: D35110419

