### PR TITLE
Fix nodenext module support from TypeScript 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,15 @@
   "module": "es/recoil.js",
   "react-native": "native/recoil.js",
   "unpkg": "umd/recoil.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "browser": "./es/recoil.js",
+      "umd": "./umd/recoil.js",
+      "import": "./es/recoil.mjs",
+      "require": "./cjs/recoil.js"
+    }
+  },
   "files": [
     "umd",
     "es",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,7 @@
   "module": "es/recoil.js",
   "react-native": "native/recoil.js",
   "unpkg": "umd/recoil.js",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "browser": "./es/recoil.js",
-      "umd": "./umd/recoil.js",
-      "import": "./es/recoil.mjs",
-      "require": "./cjs/recoil.js"
-    }
-  },
+  "types": "index.d.ts",
   "files": [
     "umd",
     "es",


### PR DESCRIPTION
* as per https://github.com/microsoft/TypeScript/issues/48235#issuecomment-1067363731