### PR TITLE
Run GitHub TypeScript tests first

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,8 +39,8 @@ jobs:
       if: matrix.os == 'windows-latest'
     - run: yarn install
     - run: yarn flow
-    - run: yarn test
     - run: yarn test:typescript
+    - run: yarn test
     - run: yarn lint
     - run: yarn build
     - run: yarn pack


### PR DESCRIPTION
Summary: Run the TypeScript tests before the more expensive unit tests for lower latency feedback for TypeScript errors when exporting diffs to GitHub.

Reviewed By: mondaychen

Differential Revision: D35657926

