### PR TITLE
Parameterize mutations with graphQLSelectorFamily()

### DIFF
--- a/packages/recoil-relay/RecoilRelay_graphQLSelector.js
+++ b/packages/recoil-relay/RecoilRelay_graphQLSelector.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {GetRecoilValue, RecoilState} from 'Recoil';
@@ -54,6 +55,7 @@ function graphQLSelector<
   TMutationRawResponse = void,
 >({
   variables,
+  mutations,
   ...options
 }: {
   environment: IEnvironment | EnvironmentKey,
@@ -77,6 +79,7 @@ function graphQLSelector<
         ? undefined
         : () => cbs =>
             typeof variables === 'function' ? variables(cbs) : variables,
+    mutations: mutations == null ? undefined : {...mutations},
   })();
 }
 

--- a/packages/recoil-relay/__tests__/RecoilRelay_graphQLSelectorFamily-test.js
+++ b/packages/recoil-relay/__tests__/RecoilRelay_graphQLSelectorFamily-test.js
@@ -411,8 +411,8 @@ describe('mutations', () => {
       mapResponse: data => data.feedback?.seen_count,
       mutations: {
         mutation: testFeedbackMutation,
-        variables: count => ({
-          data: {feedback_id: 'ID', actor_id: count?.toString()},
+        variables: count => id => ({
+          data: {feedback_id: id, actor_id: count?.toString()},
         }),
       },
     });


### PR DESCRIPTION
Summary:
Allow write-through mutations with `graphQLSelectorFamily()` to be parameterized with the family's parameter.

```
    const query = graphQLSelectorFamily({
      key: 'graphql query write-through cache',
      environment: mockEnvironmentKey,
      query: testFeedbackQuery,
      default: 'DEFAULT',
      variables: id => ({id}),
      mapResponse: data => data.feedback?.seen_count,
      mutations: {
        mutation: testFeedbackMutation,
        variables: count => id => ({
          data: {feedback_id: id, actor_id: count?.toString()},
        }),
      },
    });
```

Reviewed By: mondaychen

Differential Revision: D36334595

