### PR TITLE
Add variables to mapResponse()

### DIFF
--- a/packages/recoil-relay/RecoilRelay_graphQLSelector.js
+++ b/packages/recoil-relay/RecoilRelay_graphQLSelector.js
@@ -64,7 +64,7 @@ function graphQLSelector<
     | Query<TVariables, TData, TRawResponse>
     | GraphQLSubscription<TVariables, TData, TRawResponse>,
   variables?: TVariables | (({get: GetRecoilValue}) => ?TVariables),
-  mapResponse?: (TData, {get: GetRecoilValue}) => T,
+  mapResponse?: (TData, {get: GetRecoilValue, variables: TVariables}) => T,
   // The default value to use if variables returns null
   default?: T,
   mutations?: {

--- a/packages/recoil-relay/__tests__/RecoilRelay_graphQLSelector-test.js
+++ b/packages/recoil-relay/__tests__/RecoilRelay_graphQLSelector-test.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 const {
@@ -60,8 +61,12 @@ testRecoil('Sanity Query', async () => {
     environment,
     query: testFeedbackQuery,
     variables: ({get}) => ({id: 'ID-' + get(myAtom)}),
-    mapResponse: ({feedback}, {get}) =>
-      `${feedback?.id ?? ''}:${get(myAtom)}-${feedback?.seen_count ?? ''}`,
+    mapResponse: ({feedback}, {get, variables}) => {
+      expect(variables).toEqual({id: 'ID-' + get(myAtom)});
+      return `${feedback?.id ?? ''}:${get(myAtom)}-${
+        feedback?.seen_count ?? ''
+      }`;
+    },
     mutations: {
       mutation: testFeedbackMutation,
       variables: count => ({

--- a/packages/recoil-relay/__tests__/RecoilRelay_graphQLSelectorFamily-test.js
+++ b/packages/recoil-relay/__tests__/RecoilRelay_graphQLSelectorFamily-test.js
@@ -219,7 +219,12 @@ testRecoil('mapResponse', async () => {
     environment: mockEnvironmentKey,
     query: testFeedbackQuery,
     variables: id => ({id}),
-    mapResponse: data => data.feedback?.seen_count,
+    mapResponse:
+      (data, {variables}) =>
+      id => {
+        expect(variables).toEqual({id});
+        return data.feedback?.seen_count;
+      },
   });
 
   const c = renderElements(<ReadsAtom atom={query('ID')} />);


### PR DESCRIPTION
Summary: Based on migrating some usage of `graphQLRecoilQuery()` there are several usages where it would be convenient to access the computed variables during `mapResponse()`.  This isn't strictly necessary since you could always get and compute it again, but that would be redundant.

Differential Revision: D36393944

