### PR TITLE
Tweak advanced graphQLMutationEffect() interface and mark unstable

### DIFF
--- a/packages/recoil-relay/RecoilRelay_graphQLMutationEffect.js
+++ b/packages/recoil-relay/RecoilRelay_graphQLMutationEffect.js
@@ -56,18 +56,18 @@ function graphQLMutationEffect<
   environment: environmentOpt,
   mutation,
   variables,
-  updater,
-  optimisticUpdater,
-  optimisticResponse,
-  uploadables,
+  updater_UNSTABLE: updater,
+  optimisticUpdater_UNSTABLE: optimisticUpdater,
+  optimisticResponse_UNSTABLE: optimisticResponse,
+  uploadables_UNSTABLE: uploadables,
 }: {
   environment: IEnvironment | EnvironmentKey,
   mutation: Mutation<TVariables, TResponse, TRawResponse>,
   variables: T => TVariables | null,
-  updater?: SelectorStoreUpdater<TResponse>,
-  optimisticUpdater?: SelectorStoreUpdater<TResponse>,
-  optimisticResponse?: TResponse,
-  uploadables?: UploadableMap,
+  updater_UNSTABLE?: SelectorStoreUpdater<TResponse>,
+  optimisticUpdater_UNSTABLE?: SelectorStoreUpdater<TResponse>,
+  optimisticResponse_UNSTABLE?: T => TResponse,
+  uploadables_UNSTABLE?: UploadableMap,
 }): AtomEffect<T> {
   let currentMutationID = 0;
   return ({node, onSet, setSelf, storeID, parentStoreID_UNSTABLE}) => {
@@ -100,7 +100,7 @@ function graphQLMutationEffect<
           },
           updater,
           optimisticUpdater,
-          optimisticResponse,
+          optimisticResponse: optimisticResponse?.(newValue),
           uploadables,
         });
       }

--- a/packages/recoil-relay/__tests__/RecoilRelay_graphQLMutationEffect-test.js
+++ b/packages/recoil-relay/__tests__/RecoilRelay_graphQLMutationEffect-test.js
@@ -113,12 +113,12 @@ testRecoil('Updaters', async () => {
 
   const optimisticUpdater = jest.fn((store, data) => {
     expect(data?.feedback_like?.feedback?.id).toEqual('ID');
-    expect(data?.feedback_like?.liker?.id).toEqual('OPTIMISTIC_ACTOR');
+    expect(data?.feedback_like?.liker?.id).toEqual('OPTIMISTIC_SET');
 
     const feedback = store.get('ID');
     expect(feedback?.getValue('id')).toBe('ID');
-    const liker = store.get('OPTIMISTIC_ACTOR');
-    expect(liker?.getValue('id')).toBe('OPTIMISTIC_ACTOR');
+    const liker = store.get('OPTIMISTIC_SET');
+    expect(liker?.getValue('id')).toBe('OPTIMISTIC_SET');
   });
 
   const myAtom = atom({
@@ -129,14 +129,14 @@ testRecoil('Updaters', async () => {
         environment,
         mutation: testFeedbackMutation,
         variables: actor_id => ({data: {feedback_id: 'ID', actor_id}}),
-        updater,
-        optimisticUpdater,
-        optimisticResponse: {
+        updater_UNSTABLE: updater,
+        optimisticUpdater_UNSTABLE: optimisticUpdater,
+        optimisticResponse_UNSTABLE: actor_id => ({
           feedback_like: {
             feedback: {id: 'ID'},
-            liker: {id: 'OPTIMISTIC_ACTOR', __typename: 'Actor'},
+            liker: {id: 'OPTIMISTIC_' + actor_id, __typename: 'Actor'},
           },
-        },
+        }),
       }),
     ],
   });

--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -8,13 +8,14 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
-import type {StoreID} from './Recoil_Keys';
+
+import type {NodeKey, StateID, StoreID} from './Recoil_Keys';
 import type {MutableSource} from './Recoil_ReactMode';
 import type {RecoilValue} from './Recoil_RecoilValue';
 import type {MutableSnapshot} from './Recoil_Snapshot';
 import type {Store, StoreRef, StoreState, TreeState} from './Recoil_State';
-import type {NodeKey, StateID} from 'Recoil_Keys';
 
 // @fb-only: const RecoilusagelogEvent = require('RecoilusagelogEvent');
 // @fb-only: const RecoilUsageLogFalcoEvent = require('RecoilUsageLogFalcoEvent');

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -8,13 +8,14 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
+
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {DefaultValue} from '../core/Recoil_Node';
 import type {RecoilState, RecoilValue} from '../core/Recoil_RecoilValue';
 import type {ComponentSubscription} from '../core/Recoil_RecoilValueInterface';
-import type {NodeKey} from '../core/Recoil_State';
-import type {StoreRef} from 'Recoil_State';
+import type {NodeKey, StoreRef} from '../core/Recoil_State';
 
 const {batchUpdates} = require('../core/Recoil_Batching');
 const {DEFAULT_VALUE} = require('../core/Recoil_Node');

--- a/packages/recoil/recoil_values/Recoil_WaitFor.js
+++ b/packages/recoil/recoil_values/Recoil_WaitFor.js
@@ -8,13 +8,15 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
+
 import type {Loadable} from '../adt/Recoil_Loadable';
 import type {
   RecoilValue,
   RecoilValueReadOnly,
 } from '../core/Recoil_RecoilValue';
-import type {GetRecoilValue} from 'Recoil_callbackTypes';
+import type {GetRecoilValue} from './Recoil_callbackTypes';
 
 const {
   loadableWithError,

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {Store} from '../../recoil/core/Recoil_State';
@@ -329,7 +330,7 @@ const testGKs =
   (
     testDescription: string,
     assertionsFn: AssertionsFn,
-    {gks: additionalGKs = []}: TestOptions = {...null},
+    {gks: additionalGKs = []}: TestOptions = {gks: []},
   ) => {
     function runTests({
       strictMode,


### PR DESCRIPTION
Summary: Parameterize the `optimisticResponse` option to be a callback based on the new data as otherwise it's not very useful.  Suffix the optimisitic updater stuff with `_UNSTABLE` to indicate this part of the API is not finalized.

Differential Revision: D36531800

