### PR TITLE
Enable recoil-sync unit tests in GitHub

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,8 +25,6 @@ module.exports = {
     '/packages-ext/',
     '/__generated__/',
     '/mock-graphql/',
-    // Temporarily skip recoil-sync until we enable transit-js dependency
-    '/packages/recoil-sync',
   ],
   setupFiles: ['./setupJestMock.js'],
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "deploy-nightly": "yarn build && node scripts/deploy_nightly_build.js"
   },
   "dependencies": {
-    "hamt_plus": "1.0.2"
+    "hamt_plus": "1.0.2",
+    "transit-js": "^0.8.874"
   },
   "peerDependencies": {
     "react": ">=16.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Recoil - A state management library for React",
   "main": "cjs/index.js",
   "module": "es/index.js",

--- a/packages/recoil-sync/__tests__/RecoilSync-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync-test.js
@@ -978,12 +978,7 @@ test('Persist on read - async', async () => {
 });
 
 test('Sync based on component props', async () => {
-  function SyncWithProps(
-    props: $TEMPORARY$object<{
-      eggs: $TEMPORARY$string<'EGGS'>,
-      spam: $TEMPORARY$string<'SPAM'>,
-    }>,
-  ) {
+  function SyncWithProps(props: {eggs: string, spam: string}) {
     useRecoilSync({
       read: itemKey => (itemKey in props ? props[itemKey] : new DefaultValue()),
     });

--- a/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
@@ -5,7 +5,10 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
+
+import type {LocationOption} from '../RecoilSync_URL';
 
 const {act} = require('ReactTestUtils');
 const {atom} = require('Recoil');
@@ -34,14 +37,7 @@ describe('Test URL Persistence', () => {
     history.replaceState(null, '', '/path/page.html?foo=bar#anchor');
   });
 
-  function testWriteToURL(
-    loc:
-      | $TEMPORARY$object<{param?: string, part: 'queryParams'}>
-      | $TEMPORARY$object<{part: 'hash'}>
-      | $TEMPORARY$object<{part: 'href'}>
-      | $TEMPORARY$object<{part: 'search'}>,
-    remainder: () => void,
-  ) {
+  function testWriteToURL(loc: LocationOption, remainder: () => void) {
     const atomA = atom({
       key: nextKey(),
       default: 'DEFAULT',

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -5,6 +5,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 const {act} = require('ReactTestUtils');
@@ -109,7 +110,7 @@ test('Many items to one atom', async () => {
   expect(container.textContent).toBe('{"foo":1}');
 
   // Test subscribe to URL updates
-  gotoURL([[loc, {foo: 1, bar: 2}]]);
+  await gotoURL([[loc, {foo: 1, bar: 2}]]);
   expect(container.textContent).toBe('{"bar":2,"foo":1}');
 
   // Test mutating atoms will update URL
@@ -170,7 +171,7 @@ test('One item to multiple atoms', async () => {
   expect(container.textContent).toBe('1null');
 
   // Test subscribe to URL updates
-  gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
+  await gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
   expect(container.textContent).toBe('12');
 
   // Test mutating atoms will update URL
@@ -237,7 +238,7 @@ test('One item to atom family', async () => {
   expect(container.textContent).toBe('1null');
 
   // Test subscribe to URL updates
-  gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
+  await gotoURL([[loc, {compound: {foo: 1, bar: 2}}]]);
   expect(container.textContent).toBe('12');
 
   // Test mutating atoms will update URL

--- a/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
@@ -5,7 +5,10 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
+
+import type {LocationOption} from '../RecoilSync_URL';
 
 const {atom} = require('Recoil');
 
@@ -67,15 +70,12 @@ const atomObject = atom({
 });
 const atomDate = atom({
   key: 'date',
-  default: new Date('October 26, 1985'),
+  default: new Date('7:00 GMT October 26, 1985'),
   effects: [syncEffect({refine: jsonDate(), syncDefault: true})],
 });
 
 async function testJSON(
-  loc:
-    | $TEMPORARY$object<{param?: string, part: 'queryParams'}>
-    | $TEMPORARY$object<{part: 'hash'}>
-    | $TEMPORARY$object<{part: 'search'}>,
+  loc: LocationOption,
   contents: string,
   beforeURL: string,
   afterURL: string,

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -5,7 +5,10 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
+
+import type {LocationOption} from '../RecoilSync_URL';
 
 const {atom, selector} = require('Recoil');
 
@@ -82,7 +85,7 @@ const atomMap = atom({
 });
 const atomDate = atom({
   key: 'date',
-  default: new Date('October 26, 1985'),
+  default: new Date('7:00 GMT October 26, 1985'),
   effects: [syncEffect({refine: date(), syncDefault: true})],
 });
 const atomUser = atom({
@@ -111,10 +114,7 @@ const HANDLERS = [
 ];
 
 async function testTransit(
-  loc:
-    | $TEMPORARY$object<{param?: string, part: 'queryParams'}>
-    | $TEMPORARY$object<{part: 'hash'}>
-    | $TEMPORARY$object<{part: 'search'}>,
+  loc: LocationOption,
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
   atoms,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5905,6 +5905,11 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+transit-js@^0.8.874:
+  version "0.8.874"
+  resolved "https://registry.yarnpkg.com/transit-js/-/transit-js-0.8.874.tgz#37b27d6632bd796567c359220297c862e3988bbb"
+  integrity sha512-IDJJGKRzUbJHmN0P15HBBa05nbKor3r2MmG6aSt0UxXIlJZZKcddTk67/U7WyAeW9Hv/VYI02IqLzolsC4sbPA==
+
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"


### PR DESCRIPTION
Summary: Enable the `recoil-sync` unit tests in the GitHub CI actions.  Add the `transit-js` dependency as part of the merged `package.json` which is now only used for development now that we have added `package-for-release.json` for the actual release of the individual packages.

Differential Revision: D36957102

