### PR TITLE
Fix nightly build

### DIFF
--- a/scripts/deploy_nightly_build.js
+++ b/scripts/deploy_nightly_build.js
@@ -29,7 +29,7 @@ execSync(`git clone -b ${DEST_BRANCH} ${repository} ${DEST_FOLDER} --depth 1`, {
 });
 
 console.log('Copying sources...');
-execSync(`cp -r build/recoil ${DEST_FOLDER}`, {cwd});
+execSync(`cp -r build/recoil/* ${DEST_FOLDER}`, {cwd});
 
 console.log('Committing and pushing...');
 execSync(


### PR DESCRIPTION
Summary:
Fix nightly branch to copy the build direclty into the root of the branch instead of a `recoil` subdirectory.

This was a regression from porting over to the new build scripts.

Reviewed By: mondaychen

Differential Revision: D37015898

