### PR TITLE
fix: expose Flow types again

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -121,7 +121,7 @@ async function buildPackage(target, config) {
       createErrorHandler('Failed to copy source files for Flow types')(err);
       fs.rename(
         `${BUILD_TARGET}/${target}/cjs/${config.inputFile}.flow`,
-        `${BUILD_TARGET}/${target}/cjs/${target}.js.flow`,
+        `${BUILD_TARGET}/${target}/cjs/index.js.flow`,
         createErrorHandler(`Failed to rename ${target}.js.flow`),
       );
     },


### PR DESCRIPTION
Fixes #1856 

edit: it looks like the `recoil-shared` imports are still broken with this PR.