### PR TITLE
Prepare release of refine as its own package

### DIFF
--- a/README-refine.md
+++ b/README-refine.md
@@ -1,19 +1,20 @@
-# Refine &middot; [![NPM Version](https://img.shields.io/npm/v/recoil-sync)](https://www.npmjs.com/package/recoil-sync) [![Node.js CI](https://github.com/facebookexperimental/Recoil/workflows/Node.js%20CI/badge.svg)](https://github.com/facebookexperimental/Recoil/actions) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookexperimental/Recoil/blob/main/LICENSE) [![Follow on Twitter](https://img.shields.io/twitter/follow/recoiljs?label=Follow%20Recoil&style=social)](https://twitter.com/recoiljs)
+# Refine &middot; [![NPM Version](https://img.shields.io/npm/v/@recoiljs/refine)](https://www.npmjs.com/package/@recoiljs/refine) [![Node.js CI](https://github.com/facebookexperimental/Recoil/workflows/Node.js%20CI/badge.svg)](https://github.com/facebookexperimental/Recoil/actions) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookexperimental/Recoil/blob/main/LICENSE) [![Follow on Twitter](https://img.shields.io/twitter/follow/recoiljs?label=Follow%20Recoil&style=social)](https://twitter.com/recoiljs)
 
 **Refine** is a type-refinement / validator combinator library for mixed / unknown values in Flow or TypeScript.
 
-Refine is currently bundled as part of the [Recoil Sync](https://recoiljs.org/docs/recoil-sync/introduction) package.
+Refine is currently released as [@recoiljs/refine](https://www.npmjs.com/package/@recoiljs/refine) on NPM.
 
-Please see the [**Refine Documentation**](https://recoiljs.org/docs/refine/Introduction).  To get started learning about Refine, check out the documentation on the core concepts of [Utilities](https://recoiljs.org/docs/refine/api/Utilities) and [Checkers](https://recoiljs.org/docs/refine/api/Checkers).
+Please see the [**Refine Documentation**](https://recoiljs.org/docs/refine/Introduction). To get started learning about Refine, check out the documentation on the core concepts of [Utilities](https://recoiljs.org/docs/refine/api/Utilities) and [Checkers](https://recoiljs.org/docs/refine/api/Checkers).
 
 ## Why would I want to use Refine?
+
 - Refine is useful when your code encounters `unknown` TypeScript type or `mixed` Flow type values and you need to [assert those values have a specific static type](https://recoiljs.org/docs/refine/Introduction#type-refinement-example).
 - Refine provides an API for building type-refinement helper functions which can validate that an unknown value conforms to an expected type.
 - Refine can validate input values and [upgrade from previous versions](https://recoiljs.org/docs/refine/Introduction#backward-compatible-example).
 
 ## Type Refinement Example
 
-Coerce unknown types to a strongly typed variable.  [`assertion()`](https://recoiljs.org/docs/refine/api/Utilities#assertion) will throw if the input doesn't match the expected type while [`coercion()`](https://recoiljs.org/docs/refine/api/Utilities#coercion) will return `null`.
+Coerce unknown types to a strongly typed variable. [`assertion()`](https://recoiljs.org/docs/refine/api/Utilities#assertion) will throw if the input doesn't match the expected type while [`coercion()`](https://recoiljs.org/docs/refine/api/Utilities#coercion) will return `null`.
 
 ```jsx
 const myObjectChecker = object({
@@ -46,15 +47,12 @@ const obj2: {str: string} = coercion(myChecker('hello'));
 const obj3: {str: string} = coercion(myChecker(123));
 ```
 
-
 ## JSON Parser Example
 
 Refine wraps `JSON` to provide a built-in strongly typed parser.
 
 ```jsx
-const myParser = jsonParser(
-    array(object({num: number()}))
-);
+const myParser = jsonParser(array(object({num: number()})));
 
 const result = myParser('[{"num": 1}, {"num": 2}]');
 
@@ -68,7 +66,7 @@ if (result != null) {
 
 ## Usage in Recoil Sync
 
-The **Recoil Sync** library leverages **Refine** for type refinement, input validation, and upgrading types for backward compatibility.  See the [`recoil-sync` docs](https://recoiljs.org/docs/recoil-sync/introduction) for more details.
+The **Recoil Sync** library leverages **Refine** for type refinement, input validation, and upgrading types for backward compatibility. See the [`recoil-sync` docs](https://recoiljs.org/docs/recoil-sync/introduction) for more details.
 
 ## Installation
 

--- a/packages/recoil-sync/package-for-release.json
+++ b/packages/recoil-sync/package-for-release.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil-sync",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.1",
   "description": "recoil-sync provides an add-on library to help synchronize Recoil state with external systems",
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -10,7 +10,8 @@
   "repository": "https://github.com/facebookexperimental/Recoil.git",
   "license": "MIT",
   "dependencies": {
-    "transit-js": "^0.8.874"
+    "transit-js": "^0.8.874",
+    "@recoiljs/refine": "0.1.1-alpha.1"
   },
   "peerDependencies": {
     "recoil": ">=0.7.3"

--- a/packages/recoil-sync/package-for-release.json
+++ b/packages/recoil-sync/package-for-release.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "transit-js": "^0.8.874",
-    "@recoiljs/refine": "0.1.1-alpha.1"
+    "@recoiljs/refine": "0.1.0-alpha.1"
   },
   "peerDependencies": {
     "recoil": ">=0.7.3"

--- a/packages/recoil-sync/package-for-release.json
+++ b/packages/recoil-sync/package-for-release.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil-sync",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.0-alpha.1",
   "description": "recoil-sync provides an add-on library to help synchronize Recoil state with external systems",
   "main": "cjs/index.js",
   "module": "es/index.js",

--- a/packages/refine/package-for-release.json
+++ b/packages/refine/package-for-release.json
@@ -1,0 +1,16 @@
+{
+  "name": "@recoiljs/refine",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "0.1.1-alpha.1",
+  "description": "A type-refinement / validator combinator library for mixed / unknown values in Flow or TypeScript",
+  "main": "cjs/index.js",
+  "module": "es/index.js",
+  "react-native": "native/index.js",
+  "unpkg": "umd/index.js",
+  "types": "index.d.ts",
+  "files": ["umd", "es", "cjs", "native", "index.d.ts"],
+  "repository": "https://github.com/facebookexperimental/Recoil.git",
+  "license": "MIT"
+}

--- a/packages/refine/package-for-release.json
+++ b/packages/refine/package-for-release.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.0-alpha.1",
   "description": "A type-refinement / validator combinator library for mixed / unknown values in Flow or TypeScript",
   "main": "cjs/index.js",
   "module": "es/index.js",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -9,10 +9,7 @@
  */
 
 import {rollup} from 'rollup';
-import {
-  createInputOption,
-  createOutputOption,
-} from './rollup-configs.mjs';
+import {createInputOption, createOutputOption} from './rollup-configs.mjs';
 import {exec} from 'child_process';
 import * as fs from 'fs';
 import {projectRootDir} from './project-root-dir.mjs';
@@ -30,6 +27,15 @@ const PACKAGES = {
       dev: ['umd'],
       prod: ['es-browsers', 'umd-prod'],
       native: ['native'],
+    },
+  },
+  refine: {
+    inputFile: 'Refine_index.js',
+    umdName: 'Refine',
+    builds: {
+      common: ['cjs', 'es'],
+      dev: ['umd'],
+      prod: ['es-browsers', 'umd-prod'],
     },
   },
   'recoil-sync': {
@@ -64,7 +70,7 @@ if (target === 'all' || target == null) {
 }
 
 async function buildAll() {
-  console.log('Building all packages...');
+  console.log('Building all packages...\n');
   for (const [target, config] of Object.entries(PACKAGES)) {
     await buildPackage(target, config);
   }
@@ -76,7 +82,10 @@ async function buildPackage(target, config) {
     await buildRollup(
       `recoil (${buildType})`,
       createInputOption(buildType, target, config.inputFile),
-      packageTypes.map(type => createOutputOption(type, target, config.umdName)));
+      packageTypes.map(type =>
+        createOutputOption(type, target, config.umdName),
+      ),
+    );
   }
 
   console.log('Copying files...');
@@ -111,7 +120,9 @@ async function buildPackage(target, config) {
     `${projectRootDir}/typescript/${target}.d.ts`,
     `${BUILD_TARGET}/${target}/index.d.ts`,
     fs.constants.COPYFILE_FICLONE,
-    createErrorHandler(`Failed to copy ${target}.d.ts for TypeScript index.d.ts`),
+    createErrorHandler(
+      `Failed to copy ${target}.d.ts for TypeScript index.d.ts`,
+    ),
   );
 
   console.log('Generating Flow type files...');
@@ -126,7 +137,7 @@ async function buildPackage(target, config) {
       );
     },
   );
-  console.log(`Successfully built ${target}!`);
+  console.log(`Successfully built ${target}!\n`);
 }
 
 async function buildRollup(name, inputOptions, outputOptionsList) {


### PR DESCRIPTION
As titled...

Alpha version released as
- refine: https://www.npmjs.com/package/@recoiljs/refine/v/0.1.1-alpha.1
- recoil-sync: https://www.npmjs.com/package/recoil-sync/v/0.1.1-alpha.1

Will need to update docs later