### PR TITLE
Simplify API by only exporting component interface

### DIFF
--- a/packages/recoil-sync/RecoilSync.js
+++ b/packages/recoil-sync/RecoilSync.js
@@ -8,7 +8,9 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
+
 import type {AtomEffect, Loadable, RecoilState, StoreID} from 'Recoil';
 import type {RecoilValueInfo} from 'Recoil_FunctionalCore';
 import type {RecoilValue} from 'Recoil_RecoilValue';
@@ -483,9 +485,15 @@ function useRecoilSync({
   );
 }
 
-function RecoilSync(props: RecoilSyncOptions): React.Node {
+function RecoilSync({
+  children,
+  ...props
+}: {
+  ...RecoilSyncOptions,
+  children: React.Node,
+}): React.Node {
   useRecoilSync(props);
-  return null;
+  return children;
 }
 
 ///////////////////////

--- a/packages/recoil-sync/RecoilSync_URL.js
+++ b/packages/recoil-sync/RecoilSync_URL.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {
@@ -139,6 +140,7 @@ export type BrowserInterface = {
   listenChangeURL?: (handler: () => void) => () => void,
 };
 export type RecoilURLSyncOptions = {
+  children: React.Node,
   storeKey?: StoreKey,
   location: LocationOption,
   serialize: mixed => string,
@@ -156,13 +158,14 @@ const DEFAULT_BROWSER_INTERFACE = {
   },
 };
 
-function useRecoilURLSync({
+function RecoilURLSync({
   storeKey,
   location: loc,
   serialize,
   deserialize,
   browserInterface,
-}: RecoilURLSyncOptions): void {
+  children,
+}: RecoilURLSyncOptions): React.Node {
   const {getURL, replaceURL, pushURL, listenChangeURL} = {
     ...DEFAULT_BROWSER_INTERFACE,
     ...(browserInterface ?? {}),
@@ -252,11 +255,8 @@ function useRecoilURLSync({
   );
 
   useRecoilSync({storeKey, read, write, listen});
-}
 
-function RecoilURLSync(props: RecoilURLSyncOptions): React.Node {
-  useRecoilURLSync(props);
-  return null;
+  return children;
 }
 
 ///////////////////////
@@ -298,7 +298,6 @@ function urlSyncEffect<T>({
 }
 
 module.exports = {
-  useRecoilURLSync,
   RecoilURLSync,
   urlSyncEffect,
 };

--- a/packages/recoil-sync/RecoilSync_URLJSON.js
+++ b/packages/recoil-sync/RecoilSync_URLJSON.js
@@ -8,11 +8,12 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {RecoilURLSyncOptions} from './RecoilSync_URL';
 
-const {useRecoilURLSync} = require('./RecoilSync_URL');
+const {RecoilURLSync} = require('./RecoilSync_URL');
 const React = require('react');
 const {useCallback} = require('react');
 const err = require('recoil-shared/util/Recoil_err');
@@ -26,7 +27,7 @@ export type RecoilURLSyncJSONOptions = $Rest<
   },
 >;
 
-function useRecoilURLSyncJSON(options: RecoilURLSyncJSONOptions): void {
+function RecoilURLSyncJSON(options: RecoilURLSyncJSONOptions): React.Node {
   if (options.location.part === 'href') {
     throw err('"href" location is not supported for JSON encoding');
   }
@@ -38,12 +39,8 @@ function useRecoilURLSyncJSON(options: RecoilURLSyncJSONOptions): void {
     [],
   );
   const deserialize = useCallback(x => JSON.parse(x), []);
-  useRecoilURLSync({...options, serialize, deserialize});
+
+  return <RecoilURLSync {...{...options, serialize, deserialize}} />;
 }
 
-function RecoilURLSyncJSON(props: RecoilURLSyncJSONOptions): React.Node {
-  useRecoilURLSyncJSON(props);
-  return null;
-}
-
-module.exports = {useRecoilURLSyncJSON, RecoilURLSyncJSON};
+module.exports = {RecoilURLSyncJSON};

--- a/packages/recoil-sync/RecoilSync_URLTransit.js
+++ b/packages/recoil-sync/RecoilSync_URLTransit.js
@@ -8,13 +8,14 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {RecoilURLSyncOptions} from './RecoilSync_URL';
 
 const {DefaultValue} = require('Recoil');
 
-const {useRecoilURLSync} = require('./RecoilSync_URL');
+const {RecoilURLSync} = require('./RecoilSync_URL');
 const React = require('react');
 const {useCallback, useMemo} = require('react');
 const err = require('recoil-shared/util/Recoil_err');
@@ -72,16 +73,16 @@ const BUILTIN_HANDLERS = [
   },
 ];
 
-function useRecoilURLSyncTransit({
-  handlers: handlersProp = [],
+function RecoilURLSyncTransit({
+  handlers: handlersProp,
   ...options
-}: RecoilURLSyncTransitOptions): void {
+}: RecoilURLSyncTransitOptions): React.Node {
   if (options.location.part === 'href') {
     throw err('"href" location is not supported for Transit encoding');
   }
 
   const handlers = useMemo(
-    () => [...BUILTIN_HANDLERS, ...handlersProp],
+    () => [...BUILTIN_HANDLERS, ...(handlersProp ?? [])],
     [handlersProp],
   );
 
@@ -126,12 +127,7 @@ function useRecoilURLSyncTransit({
   );
   const deserialize = useCallback(x => reader.read(x), [reader]);
 
-  useRecoilURLSync({...options, serialize, deserialize});
+  return <RecoilURLSync {...{...options, serialize, deserialize}} />;
 }
 
-function RecoilURLSyncTransit(props: RecoilURLSyncTransitOptions): React.Node {
-  useRecoilURLSyncTransit(props);
-  return null;
-}
-
-module.exports = {useRecoilURLSyncTransit, RecoilURLSyncTransit};
+module.exports = {RecoilURLSyncTransit};

--- a/packages/recoil-sync/RecoilSync_index.js
+++ b/packages/recoil-sync/RecoilSync_index.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {
@@ -31,20 +32,10 @@ import type {
   TransitHandler,
 } from './RecoilSync_URLTransit';
 
-const {RecoilSync, syncEffect, useRecoilSync} = require('./RecoilSync');
-const {
-  RecoilURLSync,
-  urlSyncEffect,
-  useRecoilURLSync,
-} = require('./RecoilSync_URL');
-const {
-  RecoilURLSyncJSON,
-  useRecoilURLSyncJSON,
-} = require('./RecoilSync_URLJSON');
-const {
-  RecoilURLSyncTransit,
-  useRecoilURLSyncTransit,
-} = require('./RecoilSync_URLTransit');
+const {RecoilSync, syncEffect} = require('./RecoilSync');
+const {RecoilURLSync, urlSyncEffect} = require('./RecoilSync_URL');
+const {RecoilURLSyncJSON} = require('./RecoilSync_URLJSON');
+const {RecoilURLSyncTransit} = require('./RecoilSync_URLTransit');
 
 export type {
   // Keys
@@ -71,14 +62,10 @@ export type {
 
 module.exports = {
   // Core Recoil Sync
-  useRecoilSync,
   RecoilSync,
   syncEffect,
 
   // Recoil Sync URL
-  useRecoilURLSync,
-  useRecoilURLSyncJSON,
-  useRecoilURLSyncTransit,
   RecoilURLSync,
   RecoilURLSyncJSON,
   RecoilURLSyncTransit,

--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -5,11 +5,12 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {BrowserInterface, LocationOption} from '../RecoilSync_URL';
 
-const {useRecoilURLSync} = require('../RecoilSync_URL');
+const {RecoilURLSync} = require('../RecoilSync_URL');
 const React = require('react');
 const {useCallback} = require('react');
 const {
@@ -25,10 +26,12 @@ function TestURLSync({
   storeKey,
   location,
   browserInterface,
+  children = null,
 }: {
   storeKey?: string,
   location: LocationOption,
   browserInterface?: BrowserInterface,
+  children?: React.Node,
 }): React.Node {
   const serialize = useCallback(
     items => {
@@ -53,14 +56,19 @@ function TestURLSync({
     },
     [location.part],
   );
-  useRecoilURLSync({
-    storeKey,
-    location,
-    serialize,
-    deserialize,
-    browserInterface,
-  });
-  return null;
+
+  return (
+    <RecoilURLSync
+      {...{
+        storeKey,
+        location,
+        serialize,
+        deserialize,
+        browserInterface,
+      }}>
+      {children}
+    </RecoilURLSync>
+  );
 }
 
 function encodeState(obj: {...}) {

--- a/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URL-test.js
@@ -57,12 +57,11 @@ describe('Test URL Persistence', () => {
     const [AtomB, setB] = componentThatReadsAndWritesAtom(atomB);
     const [IgnoreAtom, setIgnore] = componentThatReadsAndWritesAtom(ignoreAtom);
     const container = renderElements(
-      <>
-        <TestURLSync location={loc} />
+      <TestURLSync location={loc}>
         <AtomA />
         <AtomB />
         <IgnoreAtom />
-      </>,
+      </TestURLSync>,
     );
 
     expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');
@@ -178,12 +177,11 @@ describe('Test URL Persistence', () => {
     );
 
     const container = renderElements(
-      <>
-        <TestURLSync location={loc} />
+      <TestURLSync location={loc}>
         <ReadsAtom atom={atomA} />
         <ReadsAtom atom={atomB} />
         <ReadsAtom atom={atomC} />
-      </>,
+      </TestURLSync>,
     );
 
     expect(container.textContent).toBe('"A""B""DEFAULT"');
@@ -261,12 +259,11 @@ describe('Test URL Persistence', () => {
     );
 
     const container = renderElements(
-      <>
-        <TestURLSync location={loc} />
+      <TestURLSync location={loc}>
         <ReadsAtom atom={atomA} />
         <ReadsAtom atom={atomB} />
         <ReadsAtom atom={atomC} />
-      </>,
+      </TestURLSync>,
     );
 
     expect(container.textContent).toBe('"DEFAULT""123"123');
@@ -392,11 +389,10 @@ describe('Test URL Persistence', () => {
     });
 
     const container = renderElements(
-      <>
-        <TestURLSync location={loc} />
+      <TestURLSync location={loc}>
         <ReadsAtom atom={atomA} />
         <ReadsAtom atom={atomB} />
-      </>,
+      </TestURLSync>,
     );
 
     await flushPromisesAndTimers();

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -44,10 +44,9 @@ test('Upgrade item ID', async () => {
 
   const [Atom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(myAtom);
   const container = renderElements(
-    <>
-      <RecoilURLSyncJSON location={loc} />
+    <RecoilURLSyncJSON location={loc}>
       <Atom />
-    </>,
+    </RecoilURLSyncJSON>,
   );
 
   // Test that we can load based on old key
@@ -100,10 +99,9 @@ test('Many items to one atom', async () => {
 
   const [Atom, setAtom, resetAtom] = componentThatReadsAndWritesAtom(myAtom);
   const container = renderElements(
-    <>
-      <RecoilURLSyncJSON location={loc} />
+    <RecoilURLSyncJSON location={loc}>
       <Atom />
-    </>,
+    </RecoilURLSyncJSON>,
   );
 
   // Test initialize value from URL
@@ -160,11 +158,10 @@ test('One item to multiple atoms', async () => {
   const [Foo, setFoo, resetFoo] = componentThatReadsAndWritesAtom(fooAtom);
   const [Bar, setBar, resetBar] = componentThatReadsAndWritesAtom(barAtom);
   const container = renderElements(
-    <>
-      <RecoilURLSyncJSON location={loc} />
+    <RecoilURLSyncJSON location={loc}>
       <Foo />
       <Bar />
-    </>,
+    </RecoilURLSyncJSON>,
   );
 
   // Test initialize value from URL
@@ -227,11 +224,10 @@ test('One item to atom family', async () => {
     myAtoms('bar'),
   );
   const container = renderElements(
-    <>
-      <RecoilURLSyncJSON location={loc} />
+    <RecoilURLSyncJSON location={loc}>
       <Foo />
       <Bar />
-    </>,
+    </RecoilURLSyncJSON>,
   );
 
   // Test initialize value from URL

--- a/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLInterface-test.js
@@ -5,6 +5,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 const {act} = require('ReactTestUtils');
@@ -72,12 +73,11 @@ test('Push URLs in mock history', async () => {
   const [AtomB, setB, resetB] = componentThatReadsAndWritesAtom(atomB);
   const [AtomC, setC] = componentThatReadsAndWritesAtom(atomC);
   const container = renderElements(
-    <>
-      <TestURLSync location={loc} browserInterface={mockBrowserURL} />
+    <TestURLSync location={loc} browserInterface={mockBrowserURL}>
       <AtomA />
       <AtomB />
       <AtomC />
-    </>,
+    </TestURLSync>,
   );
 
   expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');

--- a/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
@@ -83,8 +83,7 @@ async function testJSON(
   history.replaceState(null, '', beforeURL);
 
   const container = renderElements(
-    <>
-      <RecoilURLSyncJSON location={loc} />
+    <RecoilURLSyncJSON location={loc}>
       <ReadsAtom atom={atomUndefined} />
       <ReadsAtom atom={atomNull} />
       <ReadsAtom atom={atomBoolean} />
@@ -93,7 +92,7 @@ async function testJSON(
       <ReadsAtom atom={atomArray} />
       <ReadsAtom atom={atomObject} />
       <ReadsAtom atom={atomDate} />
-    </>,
+    </RecoilURLSyncJSON>,
   );
   expect(container.textContent).toBe(contents);
   await flushPromisesAndTimers();

--- a/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLListen-test.js
@@ -5,6 +5,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 const {act} = require('ReactTestUtils');

--- a/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLPush-test.js
@@ -5,6 +5,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 const {act} = require('ReactTestUtils');
@@ -46,12 +47,11 @@ test('Push URLs in browser history', async () => {
   const [AtomB, setB, resetB] = componentThatReadsAndWritesAtom(atomB);
   const [AtomC, setC] = componentThatReadsAndWritesAtom(atomC);
   const container = renderElements(
-    <>
-      <TestURLSync location={loc} />
+    <TestURLSync location={loc}>
       <AtomA />
       <AtomB />
       <AtomC />
-    </>,
+    </TestURLSync>,
   );
 
   expect(container.textContent).toBe('"DEFAULT""DEFAULT""DEFAULT"');

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -125,12 +125,11 @@ async function testTransit(
   history.replaceState(null, '', beforeURL);
 
   const container = renderElements(
-    <>
-      <RecoilURLSyncTransit location={loc} handlers={HANDLERS} />
+    <RecoilURLSyncTransit location={loc} handlers={HANDLERS}>
       {atoms.map(testAtom => (
         <ReadsAtom atom={testAtom} />
       ))}
-    </>,
+    </RecoilURLSyncTransit>,
   );
   expect(container.textContent).toBe(contents);
   await flushPromisesAndTimers();

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransitJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransitJSON-test.js
@@ -5,6 +5,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 const {atom} = require('Recoil');
@@ -68,18 +69,17 @@ async function testURL(contents: string, beforeURL: string, afterURL: string) {
   history.replaceState(null, '', beforeURL);
 
   const container = renderElements(
-    <>
-      <RecoilURLSyncTransit
-        storeKey="transit"
-        location={{part: 'queryParams', param: 'transit'}}
-      />
-      <RecoilURLSyncJSON storeKey="json" location={{part: 'queryParams'}} />
-      <ReadsAtom atom={atomBoolean} />
-      <ReadsAtom atom={atomNumber} />
-      <ReadsAtom atom={atomString} />
-      <ReadsAtom atom={atomArray} />
-      <ReadsAtom atom={atomObject} />
-    </>,
+    <RecoilURLSyncTransit
+      storeKey="transit"
+      location={{part: 'queryParams', param: 'transit'}}>
+      <RecoilURLSyncJSON storeKey="json" location={{part: 'queryParams'}}>
+        <ReadsAtom atom={atomBoolean} />
+        <ReadsAtom atom={atomNumber} />
+        <ReadsAtom atom={atomString} />
+        <ReadsAtom atom={atomArray} />
+        <ReadsAtom atom={atomObject} />
+      </RecoilURLSyncJSON>
+    </RecoilURLSyncTransit>,
   );
   expect(container.textContent).toBe(contents);
   await flushPromisesAndTimers();

--- a/typescript/recoil-sync-test.ts
+++ b/typescript/recoil-sync-test.ts
@@ -20,13 +20,13 @@ import {
   StoreKey,
 
   // Core Recoil Sync
-  useRecoilSync,
+  RecoilSync,
   syncEffect,
 
   // Recoil Sync URL
-  useRecoilURLSync,
-  useRecoilURLSyncJSON,
-  useRecoilURLSyncTransit,
+  RecoilURLSync,
+  RecoilURLSyncJSON,
+  RecoilURLSyncTransit,
   urlSyncEffect,
 } from 'recoil-sync';
 import {
@@ -40,25 +40,25 @@ const storeKey: StoreKey = 'str';
 
 const DEFAULT_VALUE = new DefaultValue();
 
-// useRecoilSync()
-useRecoilSync(); // $ExpectError
-useRecoilSync({bad: 'BAD'}); // $ExpectError
-useRecoilSync({storeKey});
-useRecoilSync({storeKey: 0}); // $ExpectError
-useRecoilSync({read: (x: ItemKey) => undefined});
-useRecoilSync({read: (x: ItemKey) => 'any'});
-useRecoilSync({read: (x: ItemKey) => DEFAULT_VALUE});
-useRecoilSync({read: (x: ItemKey) => Promise.resolve('any')});
-useRecoilSync({read: (x: ItemKey) => RecoilLoadable.of('any')});
-useRecoilSync({read: (x: number) => 'BAD'}); // $ExpectError
-useRecoilSync({write: ({diff, allItems}) => {
+// <RecoilSync>
+RecoilSync(); // $ExpectError
+RecoilSync({bad: 'BAD'}); // $ExpectError
+RecoilSync({storeKey});
+RecoilSync({storeKey: 0}); // $ExpectError
+RecoilSync({read: (x: ItemKey) => undefined});
+RecoilSync({read: (x: ItemKey) => 'any'});
+RecoilSync({read: (x: ItemKey) => DEFAULT_VALUE});
+RecoilSync({read: (x: ItemKey) => Promise.resolve('any')});
+RecoilSync({read: (x: ItemKey) => RecoilLoadable.of('any')});
+RecoilSync({read: (x: number) => 'BAD'}); // $ExpectError
+RecoilSync({write: ({diff, allItems}) => {
   const diffMap: Map<ItemKey, unknown> = diff;
   const allItemsMap: Map<ItemKey, unknown> = allItems;
   const bad1: Map<ItemKey, string> = allItems; // $ExpectError
   const bad2: string = allItems; // $ExpectError
 }});
-useRecoilSync({write: ({bad}) => {}}); // $ExpectError
-useRecoilSync({listen: ({updateItem, updateAllKnownItems}) => {
+RecoilSync({write: ({bad}) => {}}); // $ExpectError
+RecoilSync({listen: ({updateItem, updateAllKnownItems}) => {
   updateItem(); // $ExpectError
   updateItem(0); // $ExpectError
   updateItem(itemKey); // $ExpectError
@@ -103,9 +103,10 @@ syncEffect({ // $ExpectType AtomEffect<number>
   },
 });
 
-// useRecoilURLSync()
-useRecoilURLSync(); // $ExpectError
-useRecoilURLSync({
+// <RecoilURLSync>
+RecoilURLSync(); // $ExpectError
+RecoilURLSync({
+  children: null,
   storeKey,
   location: {part: 'queryParams'},
   serialize: String,
@@ -129,35 +130,40 @@ urlSyncEffect({ // $ExpectType AtomEffect<number>
   history: 'push',
 });
 
-// useRecoilURLSyncJSON()
-useRecoilURLSyncJSON(); // $ExpectError
-useRecoilURLSyncJSON({
+// <RecoilURLSyncJSON>
+RecoilURLSyncJSON(); // $ExpectError
+RecoilURLSyncJSON({
+  children: null,
   storeKey,
   location: {part: 'queryParams'},
   serialize: String, // $ExpectError
   deserialize: (x: string) => x,
 });
-useRecoilURLSyncJSON({
+RecoilURLSyncJSON({
+  children: null,
   storeKey,
   location: {part: 'queryParams'},
 });
 
-// useRecoilURLSyncTransit()
+// <RecoilURLSyncTransit>
 class MyClass {
   prop: number;
 }
-useRecoilURLSyncTransit(); // $ExpectError
-useRecoilURLSyncTransit({
+RecoilURLSyncTransit(); // $ExpectError
+RecoilURLSyncTransit({
+  children: null,
   storeKey,
   location: {part: 'queryParams'},
   serialize: String, // $ExpectError
   deserialize: (x: string) => x,
 });
-useRecoilURLSyncTransit({
+RecoilURLSyncTransit({
+  children: null,
   storeKey,
   location: {part: 'queryParams'},
 });
-useRecoilURLSyncTransit({
+RecoilURLSyncTransit({
+  children: null,
   storeKey,
   location: {part: 'queryParams'},
   handlers: [

--- a/typescript/recoil-sync.d.ts
+++ b/typescript/recoil-sync.d.ts
@@ -11,7 +11,7 @@
 
  import * as React from 'react';
  import {
-   DefaultValue, Loadable, AtomEffect,
+   DefaultValue, Loadable, AtomEffect, RecoilState,
  } from 'recoil';
  import {
    Checker,
@@ -25,14 +25,14 @@
  export type ItemKey = string;
  export type StoreKey = string;
 
- // useRecoilSync() - read
+ // <RecoilSync> - read
  export type ReadItem = (itemKey: ItemKey) =>
  | DefaultValue
  | Promise<DefaultValue | unknown>
  | Loadable<DefaultValue | unknown>
  | unknown;
 
- // useRecoilSync() - write
+ // <RecoilSync> - write
  export type ItemDiff = Map<ItemKey, DefaultValue | unknown>;
  export type ItemSnapshot = Map<ItemKey, DefaultValue | unknown>;
  export interface WriteInterface {
@@ -41,7 +41,7 @@
  }
  export type WriteItems = (state: WriteInterface) => void;
 
- // useRecoilSync() - listen
+ // <RecoilSync> - listen
  export type UpdateItem = (itemKey: ItemKey, newValue: DefaultValue | unknown) => void;
  export type UpdateAllKnownItems = (items: ItemSnapshot) => void;
  export interface ListenInterface {
@@ -50,16 +50,14 @@
  }
  export type ListenToItems = (callbacks: ListenInterface) => void | (() => void);
 
- // useRecoilSync()
+ // <RecoilSync>
  export interface RecoilSyncOptions {
+   children?: React.ReactNode;
    storeKey?: StoreKey;
    write?: WriteItems;
    read?: ReadItem;
    listen?: ListenToItems;
  }
- export function useRecoilSync(opt: RecoilSyncOptions): void;
-
- // <RecoilSync/>
  export const RecoilSync: React.FC<RecoilSyncOptions>;
 
  // syncEffect() - read
@@ -97,7 +95,7 @@
  // RecoilSync_URL
  ////////////////////////
 
- // useRecoilURLSync()
+ // <RecoilURLSync>
  export type LocationOption =
    | {part: 'href'}
    | {part: 'hash'}
@@ -112,6 +110,7 @@
  }
 
  export interface RecoilURLSyncOptions {
+   children: React.ReactNode;
    storeKey?: StoreKey;
    location: LocationOption;
    serialize: (data: unknown) => string;
@@ -119,9 +118,6 @@
    browserInterface?: BrowserInterface;
  }
 
- export function useRecoilURLSync(opt: RecoilURLSyncOptions): void;
-
- // <RecoilURLSync/>
  export const RecoilURLSync: React.FC<RecoilURLSyncOptions>;
 
  // urlSyncEffect()
@@ -133,7 +129,6 @@
 
  // JSON
  export type RecoilURLSyncJSONOptions = Omit<Omit<RecoilURLSyncOptions, 'serialize'>, 'deserialize'>;
- export function useRecoilURLSyncJSON(opt: RecoilURLSyncJSONOptions): void;
  export const RecoilURLSyncJSON: React.FC<RecoilURLSyncJSONOptions>;
 
  // Transit
@@ -146,5 +141,4 @@
  export interface RecoilURLSyncTransitOptions extends Omit<Omit<RecoilURLSyncOptions, 'serialize'>, 'deserialize'> {
    handlers?: ReadonlyArray<TransitHandler<any, any>>;
  }
- export function useRecoilURLSyncTransit(opt: RecoilURLSyncTransitOptions): void;
  export const RecoilURLSyncTransit: React.FC<RecoilURLSyncTransitOptions>;


### PR DESCRIPTION
Summary: Simplify the recoil-sync API: Only export the `<RecoilSync>` component interface and not the `useRecoilSync()` hook interface.  They were equivalent, however the semantics were that it only syncs with atoms that were accessed after the hook was called.  Using a component with children helps to clarify and enforce these semantics while avoiding publishing redundant interfaces.

Differential Revision: D37029906

