### PR TITLE
Update version for 0.1 release

### DIFF
--- a/CHANGELOG-recoil-relay.md
+++ b/CHANGELOG-recoil-relay.md
@@ -3,6 +3,6 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-## 0.1.0 (2022-06)
+## 0.1.0 (2022-06-2)
 
 Initial open source release

--- a/CHANGELOG-recoil-sync.md
+++ b/CHANGELOG-recoil-sync.md
@@ -3,6 +3,6 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-## 0.1.0 (2022-06)
+## 0.1.0 (2022-06-21)
 
 Initial open source release

--- a/CHANGELOG-recoil.md
+++ b/CHANGELOG-recoil.md
@@ -3,8 +3,10 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-- Cleanup memory leak when using atoms with selector defaults. (#1821, #1840, #1844)
+## 0.7.4 (2022-06-21)
+
 - Fix missing flow types (#1857)
+- Cleanup memory leak when using atoms with selector defaults. (#1821, #1840, #1844)
 
 ## 0.7.3 (2022-06-01)
 

--- a/CHANGELOG-refine.md
+++ b/CHANGELOG-refine.md
@@ -5,6 +5,6 @@
 
 # Version numbers based on host Recoil Sync package
 
-## 0.1.0 (2022-06)
+## 0.1.0 (2022-06-21)
 
 Initial open source release

--- a/packages/recoil-sync/package-for-release.json
+++ b/packages/recoil-sync/package-for-release.json
@@ -1,6 +1,6 @@
 {
   "name": "recoil-sync",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0",
   "description": "recoil-sync provides an add-on library to help synchronize Recoil state with external systems",
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "transit-js": "^0.8.874",
-    "@recoiljs/refine": "0.1.0-alpha.1"
+    "@recoiljs/refine": "0.1.0"
   },
   "peerDependencies": {
     "recoil": ">=0.7.3"

--- a/packages/refine/package-for-release.json
+++ b/packages/refine/package-for-release.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0",
   "description": "A type-refinement / validator combinator library for mixed / unknown values in Flow or TypeScript",
   "main": "cjs/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
Summary:
Update versions for `0.1.0` release of `recoil-sync` and `recoiljs/refine`.

Update dates in changelog.

Differential Revision: D37285561

