### PR TITLE
Fix useRecoilSnapshot() with Fast Refresh

### DIFF
--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {Loadable} from '../adt/Recoil_Loadable';

--- a/packages/recoil/hooks/Recoil_SnapshotHooks.js
+++ b/packages/recoil/hooks/Recoil_SnapshotHooks.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  * @format
  */
+
 'use strict';
 
 import type {PersistenceType} from '../core/Recoil_Node';
@@ -196,7 +197,13 @@ function useRecoilSnapshot(): Snapshot {
       releaseRef.current = null;
     }
 
-    return release;
+    return () => {
+      // Defer the release.  If "Fast Refresh"" is used then the component may
+      // re-render with the same state.  The previous cleanup will then run and
+      // then the new effect will run. We don't want the snapshot to be released
+      // by that cleanup before the new effect has a chance to retain it again.
+      window.setTimeout(release, 0);
+    };
   }, [snapshot]);
 
   // Retain snapshot until above effect is run.


### PR DESCRIPTION
Summary:
Fix support for `useRecoilSnapshot()` when Fast Refresh.  (Note this is dev-only)

React's "Fast Refresh" will detect changes to source and re-load and re-render components with the new implementation.  However, it appears to call the new render, then the previous effects cleanup handler, then the new effects.  This seems strange and caused the snapshot to be released before the new effect retained it.  Don't expect behviour change from React, so workaround is to defer the release with `setTimeout()` so the new effect after the fast refresh has a chance to retain it before the old effect cleanup releases it.

Differential Revision: D37475404

