### PR TITLE
Refine - remove 'native' from package.json

### DIFF
--- a/packages/refine/package-for-release.json
+++ b/packages/refine/package-for-release.json
@@ -7,10 +7,9 @@
   "description": "A type-refinement / validator combinator library for mixed / unknown values in Flow or TypeScript",
   "main": "cjs/index.js",
   "module": "es/index.js",
-  "react-native": "native/index.js",
   "unpkg": "umd/index.js",
   "types": "index.d.ts",
-  "files": ["umd", "es", "cjs", "native", "index.d.ts"],
+  "files": ["umd", "es", "cjs", "index.d.ts"],
   "repository": "https://github.com/facebookexperimental/Recoil.git",
   "license": "MIT"
 }


### PR DESCRIPTION
There is no `native` folder in the release but it was referred to in the package file, which causes errors for react-native.