### PR TITLE
Resolve $FlowFixMeEmpty blocking open source Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,6 +19,7 @@ module.system=node
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
+suppress_type=$FlowFixMeEmpty
 suppress_type=$FlowOSSFixMe
 
 module.name_mapper='React' -> '<PROJECT_ROOT>/node_modules/react'

--- a/packages/recoil/caches/Recoil_TreeCache.js
+++ b/packages/recoil/caches/Recoil_TreeCache.js
@@ -231,7 +231,7 @@ class TreeCache<T = mixed> {
     this._root = null;
   }
 
-  invalidCacheError(): $FlowFixMeEmpty {
+  invalidCacheError(): ChangedPathError {
     const CHANGED_PATH_ERROR_MESSAGE = isFastRefreshEnabled()
       ? 'Possible Fast Refresh module reload detected.  ' +
         'This may also be caused by an selector returning inconsistent values. ' +

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -8,7 +8,9 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
+
 import type {Loadable} from '../../adt/Recoil_Loadable';
 import type {RecoilValue} from '../../core/Recoil_RecoilValue';
 import type {RecoilState} from 'Recoil';
@@ -90,33 +92,14 @@ function getError(recoilValue): Error {
   return error;
 }
 
-function setValue(
-  recoilState:
-    | RecoilState<string>
-    | $IMPORTED_TYPE$_RecoilState_1<null>
-    | $IMPORTED_TYPE$_RecoilState_1<$FlowFixMeEmpty>
-    | $IMPORTED_TYPE$_RecoilState_1<number>
-    | $IMPORTED_TYPE$_RecoilState_1<$TEMPORARY$string<'DEFAULT'>>
-    | $IMPORTED_TYPE$_RecoilState_1<$TEMPORARY$string<'a'>>
-    | $IMPORTED_TYPE$_RecoilState_1<boolean>,
-  value:
-    | boolean
-    | number
-    | string
-    | $TEMPORARY$string<'ERROR'>
-    | $TEMPORARY$string<'SET'>
-    | $TEMPORARY$string<'SET2'>
-    | $TEMPORARY$string<'b'>,
-) {
+function setValue<T>(recoilState: RecoilState<T>, value: T) {
   setRecoilValue(store, recoilState, value);
   // $FlowExpectedError[unsafe-addition]
   // $FlowExpectedError[cannot-write]
   store.getState().currentTree.version++;
 }
 
-function resetValue(
-  recoilState: $IMPORTED_TYPE$_RecoilState_1<$TEMPORARY$string<'DEFAULT'>>,
-) {
+function resetValue<T>(recoilState: RecoilState<T>) {
   setRecoilValue(store, recoilState, new DefaultValue());
   // $FlowExpectedError[unsafe-addition]
   // $FlowExpectedError[cannot-write]


### PR DESCRIPTION
Summary:
Resolve some `$FlowFixMeEmpty` annotations that were added in codemods that are breaking open source Flow for GitHub CI testing.

Also add `$FlowFixMeEmpty` as a supressing type for open source to avoid future code-mods breaking CI testing.

Differential Revision: D38561891

