### PR TITLE
Add unit test for reading a rejected promise from storage

### DIFF
--- a/CHANGELOG-recoil.md
+++ b/CHANGELOG-recoil.md
@@ -3,7 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-- Fix useRecoilSnapshot() with React's Fast Refresh during development (#1891)
+- Fix useRecoilSnapshot() with React's Fast Refresh during development (#1891, #1943)
 
 ## 0.7.4 (2022-06-21)
 

--- a/packages/recoil-relay/RecoilRelay_Environments.js
+++ b/packages/recoil-relay/RecoilRelay_Environments.js
@@ -8,6 +8,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 import type {Snapshot, StoreID} from 'Recoil';
@@ -65,16 +66,16 @@ function registerRelayEnvironment(
   // production the environment registered should never change.
   const pendingCleanup = cleanupHandlers.get(storeID)?.get(environmentKey);
   if (pendingCleanup != null) {
-    clearTimeout(pendingCleanup);
+    window.clearTimeout(pendingCleanup);
     cleanupHandlers.get(storeID)?.delete(environmentKey);
   }
   return () => {
-    const cleanupHandle = setTimeout(() => {
+    const cleanupHandle = window.setTimeout(() => {
       environmentStore.get(storeID)?.delete(environmentKey);
     }, 0);
     const oldHandler = cleanupHandlers.get(storeID)?.get(environmentKey);
     if (oldHandler != null) {
-      clearTimeout(oldHandler);
+      window.clearTimeout(oldHandler);
     }
     if (!cleanupHandlers.has(storeID)) {
       cleanupHandlers.set(storeID, new Map());

--- a/packages/recoil/core/Recoil_Snapshot.js
+++ b/packages/recoil/core/Recoil_Snapshot.js
@@ -140,7 +140,8 @@ class Snapshot {
    */
   autoRelease_INTERNAL(): void {
     if (!isSSR) {
-      window.setTimeout(() => this._release(), 0);
+      // Use timeout of 10 to workaround Firefox issue: https://github.com/facebookexperimental/Recoil/issues/1936
+      window.setTimeout(() => this._release(), 10);
     }
   }
 
@@ -195,7 +196,8 @@ class Snapshot {
   }
 
   // We want to allow the methods to be destructured and used as accessors
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  /* eslint-disable fb-www/extra-arrow-initializer */
+
   getLoadable: <T>(RecoilValue<T>) => Loadable<T> = <T>(
     recoilValue: RecoilValue<T>,
   ): Loadable<T> => {
@@ -203,8 +205,6 @@ class Snapshot {
     return getRecoilValueAsLoadable(this._store, recoilValue);
   };
 
-  // We want to allow the methods to be destructured and used as accessors
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   getPromise: <T>(RecoilValue<T>) => Promise<T> = <T>(
     recoilValue: RecoilValue<T>,
   ): Promise<T> => {
@@ -212,8 +212,6 @@ class Snapshot {
     return this.getLoadable(recoilValue).toPromise();
   };
 
-  // We want to allow the methods to be destructured and used as accessors
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   getNodes_UNSTABLE: (
     {
       isModified?: boolean,
@@ -245,7 +243,6 @@ class Snapshot {
 
   // Report the current status of a node.
   // This peeks the current state and does not affect the snapshot state at all
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   getInfo_UNSTABLE: <T>(RecoilValue<T>) => RecoilValueInfo<T> = <T>({
     key,
   }: RecoilValue<T>): RecoilValueInfo<T> => {
@@ -253,7 +250,6 @@ class Snapshot {
     return peekNodeInfo(this._store, this._store.getState().currentTree, key);
   };
 
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   map: ((MutableSnapshot) => void) => Snapshot = mapper => {
     this.checkRefCount_INTERNAL();
     const mutableSnapshot = new MutableSnapshot(this, batchUpdates);
@@ -261,7 +257,6 @@ class Snapshot {
     return mutableSnapshot;
   };
 
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   asyncMap: ((MutableSnapshot) => Promise<void>) => Promise<Snapshot> =
     async mapper => {
       this.checkRefCount_INTERNAL();
@@ -273,6 +268,8 @@ class Snapshot {
       mutableSnapshot.autoRelease_INTERNAL();
       return mutableSnapshot;
     };
+
+  /* eslint-enable fb-www/extra-arrow-initializer */
 }
 
 function cloneStoreState(
@@ -379,8 +376,6 @@ class MutableSnapshot extends Snapshot {
     this._batch = batch;
   }
 
-  // We want to allow the methods to be destructured and used as accessors
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   set: SetRecoilState = <T>(
     recoilState: RecoilState<T>,
     newValueOrUpdater: ValueOrUpdater<T>,
@@ -397,8 +392,6 @@ class MutableSnapshot extends Snapshot {
     });
   };
 
-  // We want to allow the methods to be destructured and used as accessors
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   reset: ResetRecoilState = <T>(recoilState: RecoilState<T>) => {
     this.checkRefCount_INTERNAL();
     const store = this.getStore_INTERNAL();
@@ -409,8 +402,6 @@ class MutableSnapshot extends Snapshot {
     });
   };
 
-  // We want to allow the methods to be destructured and used as accessors
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   setUnvalidatedAtomValues_DEPRECATED: (Map<NodeKey, mixed>) => void = (
     values: Map<NodeKey, mixed>,
   ) => {

--- a/packages/recoil/hooks/Recoil_SnapshotHooks.js
+++ b/packages/recoil/hooks/Recoil_SnapshotHooks.js
@@ -202,7 +202,8 @@ function useRecoilSnapshot(): Snapshot {
       // re-render with the same state.  The previous cleanup will then run and
       // then the new effect will run. We don't want the snapshot to be released
       // by that cleanup before the new effect has a chance to retain it again.
-      window.setTimeout(release, 0);
+      // Use timeout of 10 to workaround Firefox issue: https://github.com/facebookexperimental/Recoil/issues/1936
+      window.setTimeout(release, 10);
     };
   }, [snapshot]);
 

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -308,7 +308,7 @@ function flushPromisesAndTimers(): Promise<void> {
   return act(
     () =>
       new Promise(resolve => {
-        setTimeout(resolve, 100);
+        window.setTimeout(resolve, 100);
         jest.runAllTimers();
       }),
   );


### PR DESCRIPTION
Summary:
Add a unit test to confirm we can support getting a rejected `Promise` when reading from storage.

Added for supporting #1933

Differential Revision: D38601417

