### PR TITLE
Fix lint issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-relay": "^1.8.3",
     "eslint-plugin-rulesdir": "^0.2.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "flow-bin": "^0.164.0",
     "flow-copy-source": "^2.0.9",
     "flow-interfaces-chrome": "^0.6.0",

--- a/packages-ext/recoil-devtools/src/pages/Popup/PopupSidebar.js
+++ b/packages-ext/recoil-devtools/src/pages/Popup/PopupSidebar.js
@@ -7,6 +7,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 import type {TransactionType} from '../../types/DevtoolsTypes';
@@ -38,18 +39,22 @@ function Sidebar(): React.MixedElement {
   const connection = useContext(ConnectionContext);
   const [selected, setSelected] = useSelectedTransaction();
   const [filter] = useFilter();
-  const allTransactions: TransactionType[] =
-    connection?.transactions?.getArray() ?? [];
+  const allTransactions: ?Array<TransactionType> =
+    connection?.transactions?.getArray();
   const transactions = useMemo(() => {
-    if (filter !== '') {
-      return allTransactions.filter(tx =>
-        tx.modifiedValues.some(
-          node => node.name.toLowerCase().indexOf(filter.toLowerCase()) !== -1,
-        ),
-      );
+    if (allTransactions == null) {
+      return [];
     }
-    return allTransactions;
+    return filter !== ''
+      ? allTransactions.filter(tx =>
+          tx.modifiedValues.some(
+            node =>
+              node.name.toLowerCase().indexOf(filter.toLowerCase()) !== -1,
+          ),
+        )
+      : allTransactions;
   }, [filter, allTransactions]);
+
   return (
     <aside style={styles.sidebar}>
       {transactions.map((tx, _index) => (

--- a/packages-ext/recoil-devtools/src/utils/sankey/Sankey.js
+++ b/packages-ext/recoil-devtools/src/utils/sankey/Sankey.js
@@ -7,6 +7,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 import type {Events, Styles} from './CV2_D3';
@@ -87,7 +88,7 @@ type Props<N, L> = $ReadOnly<{
 const functor: <T>(any) => T = <T>(x: T) =>
   // $FlowFixMe[escaped-generic]
   // $FlowFixMe[incompatible-type]
-  typeof x === 'function' ? x : <T>() => x;
+  typeof x === 'function' ? x : () => x;
 
 /**
  * @explorer-desc

--- a/packages-ext/recoil-devtools/src/utils/sankey/SankeyGraphLayout.js
+++ b/packages-ext/recoil-devtools/src/utils/sankey/SankeyGraphLayout.js
@@ -5,6 +5,7 @@
  * @format
  * @oncall obviz
  */
+
 'use strict';
 
 import type {LayoutFunction} from './Sankey';
@@ -487,11 +488,11 @@ const flowGraphLayout = <N, L>(
   };
 
   return ({graph, positionRange}) => {
-    limitNodes(graph, layoutOptions.nodeLimit);
-    const depthDomain = flowLayoutNodeDepths(graph, layoutOptions);
+    limitNodes(graph, layoutOptionsConfig.nodeLimit);
+    const depthDomain = flowLayoutNodeDepths(graph, layoutOptionsConfig);
     const positionDomain = layoutPositions(
       graph,
-      layoutOptions,
+      layoutOptionsConfig,
       positionRange[1],
     );
     return {graph, positionDomain, depthDomain};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,6 +2631,18 @@ eslint-plugin-rulesdir@^0.2.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.0.tgz#0d729e3f11bcb1a18d9b724a29a6d1a082ac2d62"
   integrity sha512-PPQPCsPkzF3upl1862swPA1bmDAAHKHmJJ4JTHJ11JCVCU4sycB0K5LLA/Rwr6r4VbnpScvUvHV4hqfdjvFmhQ==
 
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"


### PR DESCRIPTION
Summary:
Some changes since the last release have caused lint errors when using `yarn lint` in open source.  Clean up the reported issues:

* Add referenced `eslint-plugin-unused-imports`
* Fix memoization of transactions
* Remove unecessary type parameter
* Fix misuse of `layoutOptionsConfig` for graph defaults

Differential Revision: D38639615

