### PR TITLE
Export Path class for custom checkers

### DIFF
--- a/CHANGELOG-refine.md
+++ b/CHANGELOG-refine.md
@@ -3,7 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
-# Version numbers based on host Recoil Sync package
+- Export Path class for custom checkers (#1950)
 
 ## 0.1.0 (2022-06-21)
 

--- a/packages/refine/Refine_index.js
+++ b/packages/refine/Refine_index.js
@@ -8,6 +8,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 export type {AssertionFunction, CoercionFunction} from './Refine_API';
@@ -18,11 +19,11 @@ export type {
   CheckResult,
   CheckSuccess,
   CheckerReturnType,
-  Path,
 } from './Refine_Checkers';
 export type {OptionalPropertyChecker} from './Refine_ContainerCheckers';
 
 const {assertion, coercion} = require('./Refine_API');
+const {Path} = require('./Refine_Checkers');
 const {
   array,
   dict,
@@ -65,6 +66,7 @@ module.exports = {
   coercion,
   jsonParser,
   jsonParserEnforced,
+  Path,
 
   // Checkers - Primitives
   mixed,


### PR DESCRIPTION
Summary:
Resolves #1950

Refine previously exported the `Path` type, but now actually export the `Path` class for custom checkers.

Differential Revision: D38753941

