### PR TITLE
Rename boolean() checker to bool()

### DIFF
--- a/CHANGELOG-refine.md
+++ b/CHANGELOG-refine.md
@@ -3,6 +3,7 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
+- Rename boolean() export to bool() since boolean is a reserved word (#1922)
 - Export Path class for custom checkers (#1950)
 
 ## 0.1.0 (2022-06-21)

--- a/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLJSON-test.js
@@ -22,7 +22,7 @@ const {
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 const {
   array,
-  boolean,
+  bool,
   jsonDate,
   literal,
   number,
@@ -44,7 +44,7 @@ const atomNull = atom({
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
-  effects: [syncEffect({refine: boolean(), syncDefault: true})],
+  effects: [syncEffect({refine: bool(), syncDefault: true})],
 });
 const atomNumber = atom({
   key: 'number',

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -22,7 +22,7 @@ const {
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 const {
   array,
-  boolean,
+  bool,
   custom,
   date,
   literal,
@@ -49,7 +49,7 @@ const atomNull = atom({
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
-  effects: [syncEffect({refine: boolean(), syncDefault: true})],
+  effects: [syncEffect({refine: bool(), syncDefault: true})],
 });
 const atomNumber = atom({
   key: 'number',

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransitJSON-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransitJSON-test.js
@@ -19,14 +19,12 @@ const {
   flushPromisesAndTimers,
   renderElements,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
-const {array, boolean, number, object, string, tuple} = require('refine');
+const {array, bool, number, object, string, tuple} = require('refine');
 
 const atomBoolean = atom({
   key: 'boolean',
   default: true,
-  effects: [
-    syncEffect({storeKey: 'json', refine: boolean(), syncDefault: true}),
-  ],
+  effects: [syncEffect({storeKey: 'json', refine: bool(), syncDefault: true})],
 });
 const atomNumber = atom({
   key: 'number',

--- a/packages/refine/Refine_PrimitiveCheckers.js
+++ b/packages/refine/Refine_PrimitiveCheckers.js
@@ -11,6 +11,7 @@
  * @format
  * @oncall monitoring_interfaces
  */
+
 'use strict';
 
 import type {Checker} from './Refine_Checkers';
@@ -42,7 +43,8 @@ function literal<T: string | boolean | number | null | void>(
 /**
  * boolean value checker
  */
-function boolean(): Checker<boolean> {
+function bool(): Checker<boolean> {
+  // NOTE boolean is a reserved word so boolean() will not export properly in OSS
   return (value, path = new Path()) =>
     typeof value === 'boolean'
       ? success(value, [])
@@ -121,7 +123,7 @@ function stringLiterals<T: {+[string]: string}>(
   enumValues: T,
 ): Checker<$Values<T>> {
   return (value, path = new Path()) => {
-    if (!(typeof value === 'string')) {
+    if (typeof value !== 'string') {
       return failure('value must be a string', path);
     }
     const out = enumValues[value];
@@ -182,7 +184,7 @@ function jsonDate(): Checker<Date> {
 module.exports = {
   mixed,
   literal,
-  boolean,
+  bool,
   number,
   string,
   stringLiterals,

--- a/packages/refine/Refine_index.js
+++ b/packages/refine/Refine_index.js
@@ -38,7 +38,7 @@ const {
 } = require('./Refine_ContainerCheckers');
 const {jsonParser, jsonParserEnforced} = require('./Refine_JSON');
 const {
-  boolean,
+  bool,
   date,
   jsonDate,
   literal,
@@ -71,7 +71,7 @@ module.exports = {
   // Checkers - Primitives
   mixed,
   literal,
-  boolean,
+  bool,
   number,
   string,
   stringLiterals,

--- a/packages/refine/__tests__/Refine_JSON-test.js
+++ b/packages/refine/__tests__/Refine_JSON-test.js
@@ -13,14 +13,14 @@
 
 const {object} = require('../Refine_ContainerCheckers');
 const {jsonParser, jsonParserEnforced} = require('../Refine_JSON');
-const {boolean, number, string} = require('../Refine_PrimitiveCheckers');
+const {bool, number, string} = require('../Refine_PrimitiveCheckers');
 const {nullable} = require('../Refine_UtilityCheckers');
 const invariant = require('recoil-shared/util/Recoil_invariant');
 
 describe('json', () => {
   it('should correctly parse valid json', () => {
     const parse = jsonParser(
-      object({a: string(), b: nullable(number()), c: boolean()}),
+      object({a: string(), b: nullable(number()), c: bool()}),
     );
 
     const result = parse('{"a": "test", "c": true}');
@@ -33,7 +33,7 @@ describe('json', () => {
     const MESSAGE = 'IS_NULL_OR_INVALID';
 
     const parse = jsonParserEnforced(
-      object({a: string(), b: nullable(number()), c: boolean()}),
+      object({a: string(), b: nullable(number()), c: bool()}),
       MESSAGE,
     );
 

--- a/packages/refine/__tests__/Refine_Primitives-test.js
+++ b/packages/refine/__tests__/Refine_Primitives-test.js
@@ -15,7 +15,7 @@ import type {CheckerReturnType} from '../Refine_Checkers';
 
 const {assertion, coercion} = require('../Refine_API');
 const {
-  boolean,
+  bool,
   date,
   jsonDate,
   literal,
@@ -69,9 +69,9 @@ describe('literal', () => {
   });
 });
 
-describe('boolean', () => {
+describe('bool', () => {
   it('should correctly parse true', () => {
-    const coerce = boolean();
+    const coerce = bool();
     const result = coerce(true);
     invariant(result.type === 'success', 'should succeed');
 
@@ -82,14 +82,14 @@ describe('boolean', () => {
   });
 
   it('should correctly parse false', () => {
-    const coerce = boolean();
+    const coerce = bool();
     const result = coerce(false);
     invariant(result.type === 'success', 'should succeed');
     invariant(result.value === false, 'value should be false');
   });
 
   it('should correctly parse invalid', () => {
-    const coerce = boolean();
+    const coerce = bool();
     const result = coerce(1);
     invariant(result.type === 'failure', 'should fail');
   });

--- a/packages/refine/__tests__/Refine_Utilities-test.js
+++ b/packages/refine/__tests__/Refine_Utilities-test.js
@@ -15,7 +15,7 @@ import type {Checker} from '../Refine_Checkers';
 
 const {coercion} = require('../Refine_API');
 const {array, object} = require('../Refine_ContainerCheckers');
-const {boolean, number, string} = require('../Refine_PrimitiveCheckers');
+const {bool, number, string} = require('../Refine_PrimitiveCheckers');
 const {
   asType,
   constraint,
@@ -63,7 +63,7 @@ describe('or', () => {
 
 describe('union', () => {
   it('should match value when correct', () => {
-    const parser = union(string(), number(), boolean());
+    const parser = union(string(), number(), bool());
     const result = parser('test');
     invariant(result.type === 'success', 'should succeed');
     expect(result.value).toEqual('test');
@@ -171,8 +171,8 @@ describe('nullable', () => {
       b: object({
         c: nullable(number(), nullConfig),
         d: object({
-          e: boolean(),
-          f: nullable(boolean(), nullConfig),
+          e: bool(),
+          f: nullable(bool(), nullConfig),
         }),
       }),
     });


### PR DESCRIPTION
Summary:
Resolves #1922

Rename `boolean()` checker to `bool()` since `boolean` is a reserved word in JS and the export was not working for the open source build.

While this might be considered a breaking API change, we can argue it's only a semantic version patch number update since the previous export didn't actually work so this is still just a bug fix.

Differential Revision: D38800113

