### PR TITLE
[docs] Fix typo in RecoilURLSyncTransit example

### DIFF
--- a/docs/docs/recoil-sync/api/RecoilURLSyncTransit.md
+++ b/docs/docs/recoil-sync/api/RecoilURLSyncTransit.md
@@ -66,6 +66,6 @@ function MyApp() {
 const ViewState = atom<ViewState>({
   key: 'ViewState',
   default: new ViewState(true, [1, 2]),
-  effects: [syncEffect({ storeKey: 'transit-url', refine: viewStateChecker() })],
+  effects: [syncEffect({ storeKey: 'transit-url', refine: viewStateChecker })],
 });
 ```


### PR DESCRIPTION
Resolves #1918 