### PR TITLE
Update TypeScript for bool() rename

### DIFF
--- a/typescript/refine-test.ts
+++ b/typescript/refine-test.ts
@@ -11,7 +11,7 @@
 
 import {
   CheckerReturnType,
-  boolean,
+  bool,
   stringLiterals,
   string,
   number,
@@ -62,7 +62,7 @@ import {
  *
  */
 {
-  const rboolean = boolean()({});
+  const rboolean = bool()({});
   if (rboolean.type === 'success') {
     const v: boolean = rboolean.value;
   }
@@ -92,7 +92,7 @@ import {
     const v: string | number = rsorn.value;
   }
 
-  const rsunionn = union(string(), number(), boolean())({});
+  const rsunionn = union(string(), number(), bool())({});
   if (rsunionn.type === 'success') {
     const v: string | number | boolean = rsunionn.value;
   }
@@ -188,7 +188,10 @@ import {
 {
   const rmap = map(array(string()), dict(number()))({});
   if (rmap.type === 'success') {
-    const v: ReadonlyMap<readonly string[], Readonly<{[key: string]: number}>> = rmap.value;
+    const v: ReadonlyMap<
+      readonly string[],
+      Readonly<{[key: string]: number}>
+    > = rmap.value;
   }
 }
 
@@ -212,8 +215,8 @@ import {
 
   const rmatch = match(
     asType(number(), n => n.toString()),
-    asType(boolean(), b => b.toString()),
-    string()
+    asType(bool(), b => b.toString()),
+    string(),
   )({});
 
   if (rmatch.type === 'success') {
@@ -222,7 +225,9 @@ import {
 
   class Custom {}
 
-  const isCustomClass = custom(value => value instanceof Custom ? value : null);
+  const isCustomClass = custom(value =>
+    value instanceof Custom ? value : null,
+  );
   const rcustomclass = isCustomClass({});
 
   if (rcustomclass.type === 'success') {

--- a/typescript/refine.d.ts
+++ b/typescript/refine.d.ts
@@ -15,7 +15,9 @@ type CheckerResult<V> = V extends Checker<infer Result>
   ? OptionalResult
   : never;
 
-export type CheckerReturnType<V> = V extends Checker<infer Result> ? Result : never;
+export type CheckerReturnType<V> = V extends Checker<infer Result>
+  ? Result
+  : never;
 
 /**
  * This file is a manual translation of the flow types, which are the source of truth, so we should not introduce new terminology or behavior in this file.
@@ -145,9 +147,7 @@ export function coercion<T>(
  * checker to assert if a mixed value is an array of
  * values determined by a provided checker
  */
-export function array<V>(
-  valueChecker: Checker<V>,
-): Checker<ReadonlyArray<V>>;
+export function array<V>(valueChecker: Checker<V>): Checker<ReadonlyArray<V>>;
 
 /**
  * checker to assert if a mixed value is a tuple of values
@@ -205,9 +205,12 @@ type CheckersToValues<Checkers extends CheckerObject> = {
   [K in keyof Checkers]: CheckerResult<Checkers[K]>;
 };
 
-type WhereValue<Checkers extends CheckerObject, Condition> = Pick<Checkers, {
-  [Key in keyof Checkers]: Checkers[Key] extends Condition ? Key : never;
-}[keyof Checkers]>;
+type WhereValue<Checkers extends CheckerObject, Condition> = Pick<
+  Checkers,
+  {
+    [Key in keyof Checkers]: Checkers[Key] extends Condition ? Key : never;
+  }[keyof Checkers]
+>;
 
 type RequiredCheckerProperties<Checkers extends CheckerObject> = WhereValue<
   Checkers,
@@ -218,8 +221,9 @@ type OptionalCheckerProperties<Checkers extends CheckerObject> = Partial<
   WhereValue<Checkers, OptionalPropertyChecker<unknown>>
 >;
 
-type ObjectCheckerResult<Checkers extends CheckerObject> =
-  CheckersToValues<RequiredCheckerProperties<Checkers> & OptionalCheckerProperties<Checkers>>;
+type ObjectCheckerResult<Checkers extends CheckerObject> = CheckersToValues<
+  RequiredCheckerProperties<Checkers> & OptionalCheckerProperties<Checkers>
+>;
 
 /**
  * checker to assert if a mixed value is a fixed-property object,
@@ -249,7 +253,7 @@ type ObjectCheckerResult<Checkers extends CheckerObject> =
  * ```
  */
 export function object<Checkers extends CheckerObject>(
-  checkers: Checkers
+  checkers: Checkers,
 ): Checker<Readonly<ObjectCheckerResult<Checkers>>>;
 
 /**
@@ -268,9 +272,7 @@ export function map<K, V>(
 /**
  * identical to `array()` except the resulting value is a writable flow type.
  */
-export function writableArray<V>(
-  valueChecker: Checker<V>,
-): Checker<V[]>;
+export function writableArray<V>(valueChecker: Checker<V>): Checker<V[]>;
 
 /**
  * identical to `dict()` except the resulting value is a writable flow type.
@@ -282,9 +284,7 @@ export function writableDict<V>(
 /**
  * identical to `object()` except the resulting value is a writable flow type.
  */
-export function writableObject<
-  Checkers extends CheckerObject,
->(
+export function writableObject<Checkers extends CheckerObject>(
   checkers: Checkers,
 ): Checker<ObjectCheckerResult<Checkers>>;
 
@@ -318,14 +318,14 @@ export function mixed(): Checker<unknown>;
 /**
  * checker to assert if a mixed value matches a literal value
  */
-export function literal<
-  T extends string | boolean | number | null | undefined,
->(literalValue: T): Checker<T>;
+export function literal<T extends string | boolean | number | null | undefined>(
+  literalValue: T,
+): Checker<T>;
 
 /**
  * boolean value checker
  */
-export function boolean(): Checker<boolean>;
+export function bool(): Checker<boolean>;
 
 /**
  * checker to assert if a mixed value is a number
@@ -410,9 +410,7 @@ export function union<Checkers extends ReadonlyArray<Checker<unknown>>>(
  * );
  * ```
  */
-export function match<T>(
-  ...checkers: ReadonlyArray<Checker<T>>
-): Checker<T>;
+export function match<T>(...checkers: ReadonlyArray<Checker<T>>): Checker<T>;
 
 /**
  * wraps a given checker, making the valid value nullable
@@ -516,10 +514,7 @@ export function voidable<T>(
  * ```
  * Both `{}` and `{num: 123}` will refine to `{num: 123}`
  */
-export function withDefault<T>(
-  checker: Checker<T>,
-  fallback: T,
-): Checker<T>;
+export function withDefault<T>(checker: Checker<T>, fallback: T): Checker<T>;
 
 /**
  * wraps a checker with a logical constraint.


### PR DESCRIPTION
Summary:
Update TypeScript definitions for the `boolean()` -> `bool()` API rename.

Note various incidental prettier updates are included...

Differential Revision: D38844501

