### PR TITLE
fix: temporary implementation fixes for `isFastRefreshEnabled

### DIFF
--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -86,7 +86,7 @@ function reactMode(): {mode: ReactMode, early: boolean, concurrent: boolean} {
 function isFastRefreshEnabled(): boolean {
   // @fb-only: const {isAcceptingUpdate} = require('__debug');
   // @fb-only: return typeof isAcceptingUpdate === 'function' && isAcceptingUpdate();
-  return false; // @oss-only
+  return true; // @oss-only
 }
 
 module.exports = {


### PR DESCRIPTION
A duplicate atom key warning is output during development(ref: #733).
The implementation that determines hot modules is tentative and always returns `false`, so the output is always present during development.
I propose to set it `true` temporarily.