### PR TITLE
Fix CI tests

### DIFF
--- a/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
+++ b/packages/recoil-sync/__test_utils__/RecoilSync_MockURLSerialization.js
@@ -52,7 +52,13 @@ function TestURLSync({
       if (stateStr == null || stateStr === 'anchor' || stateStr === 'foo=bar') {
         return {};
       }
-      return JSON.parse(stateStr);
+      try {
+        return JSON.parse(stateStr);
+      } catch {
+        // Catch errors for open source CI tests which tend to keep previous tests alive so they are
+        // still subscribed to URL changes from future tests and may get invalid JSON as a result.
+        return {error: 'PARSE ERROR'};
+      }
     },
     [location.part],
   );


### PR DESCRIPTION
Summary:
Fix CI test failure from D38922526 (https://github.com/facebookexperimental/recoil/commit/43c51589e5803ca62772983f199bfeda41d512da)

Only in open source CI will the Jest infra keep previous tests alive so they observe URL changes from future tests.  This may cause them to try to parse invalid JSON if they interpret the URL differently, which led to failures.

Differential Revision: D39119598

