### PR TITLE
Workaround React renderers without useSyncExternalStore() support

### DIFF
--- a/CHANGELOG-recoil.md
+++ b/CHANGELOG-recoil.md
@@ -3,6 +3,8 @@
 ## UPCOMING
 **_Add new changes here as they land_**
 
+- Workaround for React 18 environments with nested renderers that don't support `useSyncExternalStore()` (#2001)
+
 ## 0.7.5 (2022-08-11)
 
 - Fix useRecoilSnapshot() with React's Fast Refresh during development (#1891)

--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -8,6 +8,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 const React = require('react');

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -8,7 +8,9 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
+
 import type {StoreID} from '../../core/Recoil_Keys';
 import type {MutableSnapshot} from 'Recoil_Snapshot';
 import type {Node} from 'react';
@@ -56,7 +58,7 @@ function NestedReactRoot({children}: $TEMPORARY$object<{children: Node}>) {
       <RecoilBridge>{children}</RecoilBridge>,
       ref.current,
     );
-  }, [children]);
+  }, [RecoilBridge, children]);
 
   return <div ref={ref} />;
 }


### PR DESCRIPTION
Summary: Recoil will attemp to detect if `useSyncExternalStore()` is supported before calling it.  However, sometimes the host environment supports it but creates additional React renderers, such as with `react-three-fiber`, which do not.  Since React goes through a proxy dispatcher we can't simply check if `useSyncExternalStore()` is defined.  Thus, this workaround will catch the situation and fallback to using `useState()` and `useEffect()`.

Differential Revision: D39329856

