### PR TITLE
Suppress linter for legacy modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-preset-fbjs": "^3.3.0",
     "dtslint": "^4.2.0",
     "eslint": "^8.2.0",
-    "eslint-plugin-fb-www": "^1.10.0",
+    "eslint-plugin-fb-www": "^1.11.0",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -114,6 +114,7 @@ export type RecoilInterface = {
 function useRecoilInterface_DEPRECATED(): RecoilInterface {
   const componentName = useComponentName();
   const storeRef = useStoreRef();
+  // eslint-disable-next-line fb-www/react-no-unused-state-hook
   const [, forceUpdate] = useState([]);
 
   const recoilValuesUsed = useRef<$ReadOnlySet<NodeKey>>(new Set());
@@ -501,6 +502,7 @@ function useRecoilValueLoadable_LEGACY<T>(
   recoilValue: RecoilValue<T>,
 ): Loadable<T> {
   const storeRef = useStoreRef();
+  // eslint-disable-next-line fb-www/react-no-unused-state-hook
   const [, forceUpdate] = useState([]);
   const componentName = useComponentName();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2578,10 +2578,10 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-fb-www@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.10.0.tgz#705dad1e12d4ae19c7b2ce5ae6ee88641d8dbbbe"
-  integrity sha512-9vBnFCNUXGBlD8DWGVw5TJ8vvHxyEN7QXs2OADW2Vq3mHkntKdiC8QhzGUCPtsCE9hdhxO0tu5mUkvhnjzICgg==
+eslint-plugin-fb-www@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.11.0.tgz#303565a7e701a7dc0f13bbd471c6f476f3236bea"
+  integrity sha512-/6gZpGKBUZJlcD5rg2X6nC8P7eHUu1g7rvowpuQ6YqidxrIdg+ZNGsdRRzGSzc5FawDPlZhJVQvbqyarrnGamw==
 
 eslint-plugin-flowtype@^8.0.3:
   version "8.0.3"


### PR DESCRIPTION
Summary:
Suppress linter warnings for legacy rendering modes.

Also update https://github.com/aaronabramov/eslint-plugin-fb-www

Differential Revision: D39512879

