### PR TITLE
environmental variable to suppress duplicate atom key warning

### DIFF
--- a/packages/recoil/core/Recoil_Node.js
+++ b/packages/recoil/core/Recoil_Node.js
@@ -109,7 +109,7 @@ function recoilValuesForKeys(
 }
 
 function registerNode<T>(node: Node<T>): RecoilValue<T> {
-  if (nodes.has(node.key)) {
+  if (nodes.has(node.key) && !process.env.SUPPRESS_DUPLICATE_ATOM_KEY_WARNING) {
     const message = `Duplicate atom key "${node.key}". This is a FATAL ERROR in
       production. But it is safe to ignore this warning if it occurred because of
       hot module replacement.`;

--- a/packages/recoil/core/Recoil_Node.js
+++ b/packages/recoil/core/Recoil_Node.js
@@ -109,7 +109,11 @@ function recoilValuesForKeys(
 }
 
 function registerNode<T>(node: Node<T>): RecoilValue<T> {
-  if (nodes.has(node.key) && !process.env.SUPPRESS_DUPLICATE_ATOM_KEY_WARNING) {
+  // Gracefully & safely check for intent of environmental variable, which is a string or undefined
+  const suppressWarning =
+    process.env.SUPPRESS_DUPLICATE_ATOM_KEY_WARNING?.trim().toLowerCase() ===
+    'true';
+  if (nodes.has(node.key) && !suppressWarning) {
     const message = `Duplicate atom key "${node.key}". This is a FATAL ERROR in
       production. But it is safe to ignore this warning if it occurred because of
       hot module replacement.`;

--- a/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_atom-test.js
@@ -172,8 +172,8 @@ describe('Creating two atoms with the same key', () => {
   [
     {windowDevValue: true, suppress: undefined, expectedLog: 'console.error'},
     {windowDevValue: false, suppress: undefined, expectedLog: 'console.warn'},
-    {windowDevValue: true, suppress: true, expectedLog: 'nowhere'},
-    {windowDevValue: false, suppress: true, expectedLog: 'nowhere'},
+    {windowDevValue: true, suppress: 'true', expectedLog: 'nowhere'},
+    {windowDevValue: false, suppress: 'TRUE', expectedLog: 'nowhere'},
   ].forEach(({windowDevValue, suppress, expectedLog}) => {
     describe(`when window.__DEV__=${windowDevValue} and ${
       suppress ? 'suppressing' : 'not suppressing'


### PR DESCRIPTION
This PR is an attempt to address https://github.com/facebookexperimental/Recoil/issues/733 by introducing an environmental variable `process.env.SUPPRESS_DUPLICATE_ATOM_KEY_WARNING` that suppresses the duplicate atom key warning.

The first commit just adds tests for the current behavior, i.e. logging to `console.error` / `console.warn`, depending on the value of `window.__DEV__`.  The second commit adds the new behavior and tests for the additional cases where this environmental variable is set.

Feedback and suggestions would be most welcome!

