### PR TITLE
Better link to documentation and tutorials in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 Recoil is an experimental state management framework for React.
 
-Please see the website: https://recoiljs.org
+Website: https://recoiljs.org
+
+## Documentation
+
+Documentation: https://recoiljs.org/docs/introduction/core-concepts
+
+
+API Reference: https://recoiljs.org/docs/api-reference/core/RecoilRoot
+
+
+Tutorials: https://recoiljs.org/resources
 
 ## Installation
 


### PR DESCRIPTION
Summary: Better link to Recoil documentation and third-party tutorials in the NPM and GitHub `README.md`.

Reviewed By: wd-fb

Differential Revision: D39778651

