### PR TITLE
add warning if Recoil URL Sync Transit detects unstable 'handlers' prop

### DIFF
--- a/CHANGELOG-recoil-sync.md
+++ b/CHANGELOG-recoil-sync.md
@@ -4,6 +4,7 @@
 **_Add new changes here as they land_**
 
 - Removing parameter from URL will reset atoms when using location `queryParams` with a `param`.  This is also a slight breaking change when an atom might sync with multiple URL params. (#1900, #1976)
+- Add dev warning if unstable `<RecoilURLSyncTransit>` `handlers` prop is detected.
 
 ## 0.1.1 (2022-08-18)
 

--- a/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLTransit-test.js
@@ -341,3 +341,34 @@ describe('URL Transit Parse', () => {
       '/?withFallback=%5B%22%7E%23%27%22%2C%22SET%22%5D',
     ));
 });
+
+describe('URL Transit - handlers prop', () => {
+  let expectationViolation;
+  beforeEach(() => {
+    expectationViolation = jest.fn();
+    jest.mock('Recoil_expectationViolation', expectationViolation);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('detect unstable handlers', async () => {
+    const container = document.createElement('div');
+    function renderWithTransitHandlers(handlers: []) {
+      renderElements(
+        <RecoilURLSyncTransit location={{part: 'hash'}} handlers={handlers}>
+          <ReadsAtom atom={atomNull} />
+        </RecoilURLSyncTransit>,
+        container,
+      );
+    }
+    const handlersA = [];
+    const handlersB = [];
+    renderWithTransitHandlers(handlersA);
+    renderWithTransitHandlers(handlersA);
+    expect(expectationViolation).toBeCalledTimes(0);
+
+    renderWithTransitHandlers(handlersB);
+    expect(expectationViolation).toBeCalledTimes(1);
+  });
+});

--- a/packages/shared/util/Recoil_expectationViolation.js
+++ b/packages/shared/util/Recoil_expectationViolation.js
@@ -8,6 +8,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 // @fb-only: const expectationViolation = require('expectationViolation');

--- a/packages/shared/util/Recoil_usePrevious.js
+++ b/packages/shared/util/Recoil_usePrevious.js
@@ -8,6 +8,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 const {useEffect, useRef} = require('react');


### PR DESCRIPTION
Differential Revision: D39710280

