### PR TITLE
[SSR] Resolve promise on server side rendering as endBatch is only called on useEffect

### DIFF
--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -46,6 +46,7 @@ const expectationViolation = require('recoil-shared/util/Recoil_expectationViola
 const gkx = require('recoil-shared/util/Recoil_gkx');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 const useComponentName = require('recoil-shared/util/Recoil_useComponentName');
+const {isSSR} = require('recoil-shared/util/Recoil_Environment');
 
 function handleLoadable<T>(
   loadable: Loadable<T>,
@@ -60,6 +61,12 @@ function handleLoadable<T>(
   } else if (loadable.state === 'loading') {
     const promise = new Promise(resolve => {
       storeRef.current.getState().suspendedComponentResolvers.add(resolve);
+      if (isSSR) {
+        loadable.contents.then(d => {
+          resolve(d);
+          return d;
+        });
+      }
     });
 
     // $FlowExpectedError Flow(prop-missing) for integrating with tools that inspect thrown promises @fb-only

--- a/packages/recoil/hooks/Recoil_Hooks.js
+++ b/packages/recoil/hooks/Recoil_Hooks.js
@@ -64,6 +64,7 @@ function handleLoadable<T>(
       if (isSSR) {
         loadable.contents.then(d => {
           resolve(d);
+          storeRef.current.getState().suspendedComponentResolvers.delete(resolve);
           return d;
         });
       }


### PR DESCRIPTION
Reference Issue: [https://github.com/facebookexperimental/Recoil/issues/1960](https://github.com/facebookexperimental/Recoil/issues/1960)

The function sendEndOfBatchNotifications is only executed on useEffect as below:
```
useEffect(() => {
    // enqueueExecution runs this function immediately; it is only used to
    // manipulate the order of useEffects during tests, since React seems to
    // call useEffect in an unpredictable order sometimes.
    Queue.enqueueExecution('Batcher', () => {
      endBatch(storeRef.current);
    });
  });
```

This caused the SSR usage of async selector to get stuck in infinite loading. 

With this PR, we make sure that when the original promise is resolved, we resolve the `handleLoadable` promise as well. Thus making it compatible with SSR rendering