### PR TITLE
Avoid unhandled promise rejection in callbacks

### DIFF
--- a/packages/recoil/hooks/Recoil_useRecoilCallback.js
+++ b/packages/recoil/hooks/Recoil_useRecoilCallback.js
@@ -101,7 +101,7 @@ function recoilCallback<Args: $ReadOnlyArray<mixed>, Return, ExtraInterface>(
     'batchUpdates should return immediately',
   );
   if (isPromise(ret)) {
-    ret.finally(() => {
+    ret = ret.finally(() => {
       releaseSnapshot?.();
     });
   } else {


### PR DESCRIPTION
The creation of a finally branch of the promise in `useRecoilCallback` causes unhandled promise rejections, despite the fact that the promise is actually handled downstream. This change returns the finally branch instead of the original promise, so there's no divergence in the handling.

For example, the following selector currently "throws" twice, once caught/logged and once not caught:

```javascript
const testState = selector({
  key: 'testState',
  get: ({ getCallback }) =>
    getCallback(() => async () => {
      throw 'test';
    }),
});

function Component() {
  const test = useRecoilValue(testState);

  useEffect(() => {
    test().then(
      () => console.log('OK'),
      (error) => console.log(error),
    );
  }, [test]);

  // ...
}
```