### PR TITLE
Export HasToJSON interface

### DIFF
--- a/typescript/recoil.d.ts
+++ b/typescript/recoil.d.ts
@@ -405,7 +405,7 @@ export const RecoilEnv: RecoilEnv;
 
  // bigint not supported yet
  type Primitive = undefined | null | boolean | number | symbol | string;
- interface HasToJSON { toJSON(): SerializableParam; }
+ export interface HasToJSON { toJSON(): SerializableParam; }
 
  export type SerializableParam =
   | Primitive


### PR DESCRIPTION
When implementing custom serializable parameters, extending the interface helps keep the code clean and consistent.