### PR TITLE
fix: remove depricated `substr`

### DIFF
--- a/packages-ext/recoil-devtools/src/pages/Popup/PopupDependencyGraph.js
+++ b/packages-ext/recoil-devtools/src/pages/Popup/PopupDependencyGraph.js
@@ -131,7 +131,7 @@ function PopupDependencyGraph(): React.Node {
           nodes={{
             data: nodes,
             getNodeKey: n => n,
-            getNodeName: n => (n.length < 25 ? n : `${n.substr(0, 22)}...`),
+            getNodeName: n => (n.length < 25 ? n : `${n.substring(0, 22)}...`),
             getNodeValue: _n => 1,
           }}
           links={{

--- a/packages/recoil-sync/RecoilSync_URL.js
+++ b/packages/recoil-sync/RecoilSync_URL.js
@@ -62,11 +62,11 @@ function parseURL(
       return wrapState(deserialize(`${url.pathname}${url.search}${url.hash}`));
     case 'hash':
       return url.hash
-        ? wrapState(deserialize(decodeURIComponent(url.hash.substr(1))))
+        ? wrapState(deserialize(decodeURIComponent(url.hash.substring(1))))
         : null;
     case 'search':
       return url.search
-        ? wrapState(deserialize(decodeURIComponent(url.search.substr(1))))
+        ? wrapState(deserialize(decodeURIComponent(url.search.substring(1))))
         : null;
     case 'queryParams': {
       const searchParams = new URLSearchParams(url.search);


### PR DESCRIPTION
- I replaced `substr` with `substring` since `substr` is now deprecated https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
