### PR TITLE
test: fix import error that causes test failure

### DIFF
--- a/packages/shared/util/__tests__/Recoil_RecoilEnv-test.js
+++ b/packages/shared/util/__tests__/Recoil_RecoilEnv-test.js
@@ -11,7 +11,9 @@
 
 'use strict';
 
-import {IS_INTERNAL} from 'Recoil_TestingUtils';
+const {
+  IS_INTERNAL,
+} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 
 const testOssOnly = IS_INTERNAL ? test.skip : test;
 


### PR DESCRIPTION
When I run `yarn test`, I got a test case failure from #2078 that says

```
You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    Recoil/packages/shared/util/__tests__/Recoil_RecoilEnv-test.js:13
    import { IS_INTERNAL } from 'Recoil_TestingUtils';
```
This PR is a fix for that