### PR TITLE
feat: introduce `<RecoilURLSyncQueryString>`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,3 @@ package-lock.json
 
 # Generated files for recoil-relay unit tests
 packages/recoil-relay/__tests__/mock-graphql/__generated__
-
-# VS Code
-/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ package-lock.json
 
 # Generated files for recoil-relay unit tests
 packages/recoil-relay/__tests__/mock-graphql/__generated__
+
+# VS Code
+/.vscode

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "hamt_plus": "1.0.2",
+    "query-string": "^7.1.1",
     "transit-js": "^0.8.874"
   },
   "peerDependencies": {

--- a/packages/recoil-sync/RecoilSync_URL.js
+++ b/packages/recoil-sync/RecoilSync_URL.js
@@ -55,6 +55,7 @@ function parseURL(
   href: string,
   loc: LocationOption,
   deserialize: string => mixed,
+  isQueryString: boolean,
 ): ?ItemSnapshot {
   const url = new URL(href);
   switch (loc.part) {
@@ -71,6 +72,9 @@ function parseURL(
     case 'queryParams': {
       const searchParams = new URLSearchParams(url.search);
       const {param} = loc;
+      if (isQueryString) {
+        return wrapState(deserialize(url.search));
+      }
       if (param != null) {
         const stateStr = searchParams.get(param);
         return stateStr != null ? wrapState(deserialize(stateStr)) : new Map();
@@ -94,21 +98,33 @@ function encodeURL(
   loc: LocationOption,
   items: ItemSnapshot,
   serialize: mixed => string,
+  isQueryString: boolean,
 ): string {
   const url = new URL(href);
   switch (loc.part) {
     case 'href':
       return serialize(unwrapState(items));
     case 'hash':
-      url.hash = encodeURIComponent(serialize(unwrapState(items)));
+      if (isQueryString) {
+        url.hash = encodeURIComponent(serialize(items));
+      } else {
+        url.hash = encodeURIComponent(serialize(unwrapState(items)));
+      }
       break;
     case 'search':
-      url.search = encodeURIComponent(serialize(unwrapState(items)));
+      if (isQueryString) {
+        url.search = encodeURIComponent(serialize(items));
+      } else {
+        url.search = encodeURIComponent(serialize(unwrapState(items)));
+      }
       break;
     case 'queryParams': {
       const {param} = loc;
       const searchParams = new URLSearchParams(url.search);
-      if (param != null) {
+      if (isQueryString) {
+        url.search = serialize(items);
+        break;
+      } else if (param != null) {
         searchParams.set(param, serialize(unwrapState(items)));
       } else {
         for (const [itemKey, value] of items.entries()) {
@@ -144,6 +160,7 @@ export type RecoilURLSyncOptions = {
   children: React.Node,
   storeKey?: StoreKey,
   location: LocationOption,
+  isQueryString: boolean,
   serialize: mixed => string,
   deserialize: string => mixed,
   browserInterface?: BrowserInterface,
@@ -162,6 +179,7 @@ const DEFAULT_BROWSER_INTERFACE = {
 function RecoilURLSync({
   storeKey,
   location: loc,
+  isQueryString = false,
   serialize,
   deserialize,
   browserInterface,
@@ -182,7 +200,12 @@ function RecoilURLSync({
     [loc.part, loc.queryParam], // eslint-disable-line fb-www/react-hooks-deps
   );
   const updateCachedState: () => void = useCallback(() => {
-    cachedState.current = parseURL(getURL(), memoizedLoc, deserialize);
+    cachedState.current = parseURL(
+      getURL(),
+      memoizedLoc,
+      deserialize,
+      isQueryString,
+    );
   }, [getURL, memoizedLoc, deserialize]);
   const cachedState = useRef<?ItemSnapshot>(null);
   // Avoid executing updateCachedState() on each render
@@ -223,13 +246,17 @@ function RecoilURLSync({
             replaceItems.set(key, value);
           }
         }
-        replaceURL(encodeURL(getURL(), loc, replaceItems, serialize));
+        replaceURL(
+          encodeURL(getURL(), loc, replaceItems, serialize, isQueryString),
+        );
 
         // Next, push the URL with any atoms that caused a new URL history entry
-        pushURL(encodeURL(getURL(), loc, allItems, serialize));
+        pushURL(encodeURL(getURL(), loc, allItems, serialize, isQueryString));
       } else {
         // Just replace the URL with the new state
-        replaceURL(encodeURL(getURL(), loc, allItems, serialize));
+        replaceURL(
+          encodeURL(getURL(), loc, allItems, serialize, isQueryString),
+        );
       }
       cachedState.current = allItems;
     },

--- a/packages/recoil-sync/RecoilSync_URLQueryString.js
+++ b/packages/recoil-sync/RecoilSync_URLQueryString.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall recoil
+ */
+
+'use strict';
+
+import type {RecoilURLSyncOptions} from './RecoilSync_URL';
+import type {ItemSnapshot} from './RecoilSync';
+
+const {RecoilURLSync} = require('./RecoilSync_URL');
+const React = require('react');
+const {useCallback} = require('react');
+const err = require('recoil-shared/util/Recoil_err');
+const nullthrows = require('recoil-shared/util/Recoil_nullthrows');
+const queryString = require('query-string');
+
+export type QueryStringOptions = {
+  //https://github.com/sindresorhus/query-string
+
+  // for .parse()
+  arrayFormat:
+    | 'none'
+    | 'bracket'
+    | 'index'
+    | 'comma'
+    | 'separator'
+    | 'bracket-separator'
+    | 'colon-list-separator',
+  sort: boolean,
+
+  // for stringify()
+  skipEmptyString: boolean,
+  skipNull: boolean,
+};
+
+export type RecoilURLSyncQueryStringOptions = $Rest<
+  RecoilURLSyncOptions,
+  {
+    serialize: mixed => string,
+    deserialize: string => mixed,
+    isQueryString: boolean,
+    queryStringOptions: QueryStringOptions,
+  },
+>;
+
+function RecoilURLSyncQueryString(
+  options: RecoilURLSyncQueryStringOptions,
+): React.Node {
+  if (options.location.part === 'href') {
+    throw err('"href" location is not supported for query-string encoding');
+  }
+  if (options.location.param) {
+    throw err('"param" location is not supported for query-string encoding');
+  }
+  const serialize = useCallback((x: ItemSnapshot) => {
+    if (x === undefined) {
+      return '';
+    }
+    return nullthrows(
+      queryString.stringify(Object.fromEntries(x), {
+        skipEmptyString: options.queryStringOptions.skipEmptyString,
+        skipNull: options.queryStringOptions.skipNull,
+      }),
+      'Unable to serialize state with query-string',
+    );
+  }, []);
+  const deserialize = useCallback((x: string) => {
+    return queryString.parse(x, {
+      arrayFormat: options.queryStringOptions.arrayFormat,
+      parseBooleans: true,
+      parseNumbers: true,
+      sort: options.queryStringOptions.sort,
+    });
+  }, []);
+
+  return (
+    <RecoilURLSync
+      {...{
+        ...options,
+        serialize,
+        deserialize,
+        isQueryString: true,
+      }}
+    />
+  );
+}
+
+module.exports = {RecoilURLSyncQueryString};

--- a/packages/recoil-sync/__tests__/RecoilSync_URLQueryString-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLQueryString-test.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall recoil
+ */
+
+'use strict';
+
+import type {LocationOption} from '../RecoilSync_URL';
+
+const {atom} = require('Recoil');
+
+const {syncEffect} = require('../RecoilSync');
+const {RecoilURLSyncQueryString} = require('../RecoilSync_URLQueryString');
+const React = require('react');
+const {
+  ReadsAtom,
+  flushPromisesAndTimers,
+  renderElements,
+} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
+const {
+  array,
+  bool,
+  jsonDate,
+  literal,
+  number,
+  object,
+  string,
+  tuple,
+} = require('refine');
+
+const atomUndefined = atom({
+  key: 'void',
+  default: undefined,
+  effects: [syncEffect({refine: literal(undefined), syncDefault: true})],
+});
+const atomNull = atom({
+  key: 'null',
+  default: null,
+  effects: [syncEffect({refine: literal(null), syncDefault: true})],
+});
+const atomBoolean = atom({
+  key: 'boolean',
+  default: true,
+  effects: [syncEffect({refine: bool(), syncDefault: true})],
+});
+const atomNumber = atom({
+  key: 'number',
+  default: 123,
+  effects: [syncEffect({refine: number(), syncDefault: true})],
+});
+const atomString = atom({
+  key: 'string',
+  default: 'STRING',
+  effects: [syncEffect({refine: string(), syncDefault: true})],
+});
+const atomArray = atom({
+  key: 'array',
+  default: [1, 'a'],
+  effects: [syncEffect({refine: tuple(number(), string()), syncDefault: true})],
+});
+const atomDate = atom({
+  key: 'date',
+  default: new Date('7:00 GMT October 26, 1985'),
+  effects: [syncEffect({refine: jsonDate(), syncDefault: true})],
+});
+
+async function testQueryString(
+  loc: LocationOption,
+  contents: string,
+  beforeURL: string,
+  afterURL: string,
+) {
+  history.replaceState(null, '', beforeURL);
+
+  const container = renderElements(
+    <RecoilURLSyncQueryString
+      location={loc}
+      queryStringOptions={{
+        arrayFormat: 'none',
+        parseBooleans: true,
+        sort: true,
+        skipEmptyString: false,
+        skipNull: false,
+      }}>
+      <ReadsAtom atom={atomUndefined} />
+      <ReadsAtom atom={atomNull} />
+      <ReadsAtom atom={atomBoolean} />
+      <ReadsAtom atom={atomNumber} />
+      <ReadsAtom atom={atomString} />
+      <ReadsAtom atom={atomArray} />
+      <ReadsAtom atom={atomDate} />
+    </RecoilURLSyncQueryString>,
+  );
+
+  expect(container.textContent).toBe(contents);
+  await flushPromisesAndTimers();
+  expect(window.location.href).toBe(window.location.origin + afterURL);
+}
+
+describe('URL Query-String Encode', () => {
+  test('Anchor', async () =>
+    testQueryString(
+      {part: 'queryParams'},
+      'nulltrue123"STRING"[1,"a"]"1985-10-26T07:00:00.000Z"',
+      '/path/page.html?foo=bar',
+      '/path/page.html?array=1&array=a&boolean=true&date=Sat%20Oct%2026%201985%2000%3A00%3A00%20GMT-0700%20%28Pacific%20Daylight%20Time%29&null&number=123&string=STRING',
+    ));
+  test('Search', async () =>
+    testQueryString(
+      {part: 'search'},
+      'nulltrue123"STRING"[1,"a"]"1985-10-26T07:00:00.000Z"',
+      '/path/page.html#anchor',
+      '/path/page.html?array%3D1%26array%3Da%26boolean%3Dtrue%26date%3DSat%2520Oct%252026%25201985%252000%253A00%253A00%2520GMT-0700%2520%2528Pacific%2520Daylight%2520Time%2529%26null%26number%3D123%26string%3DSTRING#anchor',
+    ));
+  test('Query Params', async () =>
+    testQueryString(
+      {part: 'queryParams'},
+      'nulltrue123"STRING"[1,"a"]"1985-10-26T07:00:00.000Z"',
+      '/path/page.html#anchor',
+      '/path/page.html?array=1&array=a&boolean=true&date=Sat%20Oct%2026%201985%2000%3A00%3A00%20GMT-0700%20%28Pacific%20Daylight%20Time%29&null&number=123&string=STRING#anchor',
+    ));
+});
+
+describe('URL Query-String Parse', () => {
+  test('Anchor', async () =>
+    testQueryString(
+      {part: 'hash'},
+      'nullfalse456"SET"[2,"b"]"1955-11-05T07:00:00.000Z"',
+      '/#array=2&array=b&boolean=false&date=1955-11-05T07%3A00%3A00.000Z&null&number=456&string=SET',
+      '/#array%3D2%26array%3Db%26boolean%3Dfalse%26date%3DFri%2520Nov%252004%25201955%252023%253A00%253A00%2520GMT-0800%2520%2528Pacific%2520Daylight%2520Time%2529%26null%26number%3D456%26string%3DSET',
+    ));
+  test('Search', async () =>
+    testQueryString(
+      {part: 'search'},
+      'nullfalse456"SET"[2,"b"]"1955-11-05T07:00:00.000Z"',
+      '/?array=2&array=b&boolean=false&date=1955-11-05T07%3A00%3A00.000Z&null&number=456&string=SET',
+      '/?array%3D2%26array%3Db%26boolean%3Dfalse%26date%3DFri%2520Nov%252004%25201955%252023%253A00%253A00%2520GMT-0800%2520%2528Pacific%2520Daylight%2520Time%2529%26null%26number%3D456%26string%3DSET',
+    ));
+  test('Query Params', async () =>
+    testQueryString(
+      {part: 'queryParams'},
+      'nullfalse456"SET"[2,"b"]"1955-11-05T07:00:00.000Z"',
+      '/?array=2&array=b&boolean=false&date=1955-11-05T07%3A00%3A00.000Z&null&number=456&string=SET',
+      '/?array=2&array=b&boolean=false&date=Fri%20Nov%2004%201955%2023%3A00%3A00%20GMT-0800%20%28Pacific%20Daylight%20Time%29&null&number=456&string=SET',
+    ));
+});

--- a/packages/recoil-sync/package-for-release.json
+++ b/packages/recoil-sync/package-for-release.json
@@ -10,6 +10,7 @@
   "repository": "https://github.com/facebookexperimental/Recoil.git",
   "license": "MIT",
   "dependencies": {
+    "query-string": "^7.1.1",
     "transit-js": "^0.8.874",
     "@recoiljs/refine": "^0.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2954,6 +2954,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
+
 find-babel-config@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
@@ -5085,6 +5090,16 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
+query-string@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 react-dom@>=16.13.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
@@ -5619,6 +5634,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -5661,6 +5681,11 @@ static-extend@^0.1.1:
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-argv@0.3.1:
   version "0.3.1"


### PR DESCRIPTION
## Motivation

https://github.com/facebookexperimental/Recoil/discussions/2081#discussioncomment-4022664

> Is it possible to remove "" from query params when refine type is string? Currently it's like ?query="value", it would be nice to have ?query=value. That would be ideal to handle query params like [query-string](https://www.npmjs.com/package/query-string)
>> The quoting or other encoding is not part of the core <RecoilSync> or even the URL syncing but is rather part of the encoding layer on top such as <RecoilURLSyncJSON> `. The quotes are added as part of the JSON encoding of strings. I think it makes sense to add an additional encoding type for standard simple URL params, such as unquoted strings and vector entries. Please feel free to submit a PR for this!



## TODO
- [ ] Setup query-string configs
- [ ] Write test for them
- [x]  Throw error when param option is used in RecoilURLSyncQueryString
- [ ] Add types for Typescript
- Write doc
  - [ ]  No object support cuz query-string doesnt support it
  - [ ]  Mention no `param` option

Hello @drarmstr, I implemented the feature I asked before. I'm not sure if I implemented it in the right way, so I didn't write docs or full test cases because I'd like to hear your opinion first. 

First, I made a new component called `<RecoilURLSyncQueryString>` (temporary name). It is almost similar to `<RecoilURLSyncJSON>`, but it is serialized/deserialized by [query-string](https://www.npmjs.com/package/query-string) (I explored other libs and thought about not using libs at all, but `query-string` looked good.  If you know good  idea, I'm open). However, `query-string` has few restrictions. 

- Not recommended to use `object` in query parameters https://github.com/sindresorhus/query-string#nesting
  - So, I've decided not to support `object`
- `param` option is not applicable
