### PR TITLE
Fix a typo in GraphQL Query with Parameters documentation

### DIFF
--- a/docs/docs/recoil-relay/graphql-queries.md
+++ b/docs/docs/recoil-relay/graphql-queries.md
@@ -46,7 +46,7 @@ const pictureForUserState = selector({
 
 ## GraphQL Query with Parameters
 
-[**`graphQLSelectorFamily()`**](/docs/recoil-relay/api/graphQLSelectorFamily) allows you to use parameters in addition to other Recoil state for computing query variables.  Parameters can be determined basd on a component's props, React state, used in another Recoil selector, etc.
+[**`graphQLSelectorFamily()`**](/docs/recoil-relay/api/graphQLSelectorFamily) allows you to use parameters in addition to other Recoil state for computing query variables.  Parameters can be determined based on a component's props, React state, used in another Recoil selector, etc.
 
 ```jsx
 const userQuery = graphQLSelectorFamily({


### PR DESCRIPTION
In the [GraphQL Query with Parameters](https://recoiljs.org/docs/recoil-relay/graphql-queries#graphql-query-with-parameters) section s/basd/based/