### PR TITLE
Fix typo in example for graphQLSelectorFamily

### DIFF
--- a/docs/docs/recoil-relay/api/graphQLSelectorFamily.md
+++ b/docs/docs/recoil-relay/api/graphQLSelectorFamily.md
@@ -10,7 +10,7 @@ sidebar_label: graphQLSelectorFamily()
 function graphQLSelectorFamily<
   TVariables: Variables,
   TData: $ReadOnly<{[string]: mixed}>,
-  P: Parmaeter = TVariables,
+  P: Parameter = TVariables,
   T = TData,
   TRawResponse = void,
   TMutationVariables: Variables = {},


### PR DESCRIPTION
In the example code for [graphQLSelectorFamily](https://recoiljs.org/docs/recoil-relay/api/graphQLSelectorFamily)  s/Parmaeter/Parameter/