### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # config GIT so it can do git push
     - uses: fregante/setup-git-user@v1
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - run: npm i -g yarn
+        cache: yarn
     - run: yarn install --frozen-lockfile
     - run: yarn deploy-nightly

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,12 +21,12 @@ jobs:
         react: ['17.0.2', '18.1.0']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g yarn
+        cache: yarn
     - run: cd packages-ext/recoil-devtools && yarn install --frozen-lockfile
     - run: yarn install --frozen-lockfile
     - name: Install React (Unix/Mac)


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- name: Use Node.js 16.x
  uses: actions/setup-node@v1
  with:
    node-version: 16.x
```

### TO-BE

```yml
- name: Use Node.js 16.x
  uses: actions/setup-node@v3
  with:
    node-version: 16.x
    cache: yarn
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)