### PR TITLE
small change in type of graphQLSelector

### DIFF
--- a/packages/recoil-relay/RecoilRelay_graphQLSelector.js
+++ b/packages/recoil-relay/RecoilRelay_graphQLSelector.js
@@ -63,7 +63,8 @@ function graphQLSelector<
   query:
     | Query<TVariables, TData, TRawResponse>
     | GraphQLSubscription<TVariables, TData, TRawResponse>,
-  variables: TVariables | (({get: GetRecoilValue}) => TVariables | null),
+  // The order of union members below is important to prevent errors at the call-site
+  variables: (({get: GetRecoilValue}) => TVariables | null) | TVariables,
   mapResponse: (TData, {get: GetRecoilValue, variables: TVariables}) => T,
   // The default value to use if variables returns null
   default?: T,


### PR DESCRIPTION
Summary:
Small tweak in the type definition of `graphQLSelector` (RecoilRelay_graphQLSelector.js) to avoid Flow errors in the new LTI mode.

Context: https://fb.workplace.com/groups/flow/posts/24417786084510010/?comment_id=24439307842357834&reply_comment_id=24440084235613528

Reviewed By: kartmanny

Differential Revision: D44190433