### PR TITLE
Make source file name required argument of ReactDOMLegacy_DEPRECATED.render(...)

### DIFF
--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -128,7 +128,7 @@ function renderLegacyReactRoot<Props>(
   container: HTMLElement,
   contents: ReactAbstractElement<Props>,
 ) {
-  ReactDOM.render(contents, container);
+  ReactDOM.render(contents, container, 'Recoil_TestingUtils.js');
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;


### PR DESCRIPTION
Summary:
Update type definition of ReactDOMLegacy_DEPRECATED.render to include required `sourceFileName` argument.

This diff is also adding these names to places not covered by previous diffs.

 ---
Context:  We (React Team) is working on modernizing  Meta codebase, and replacing legacy and deprecated React APIs with Modern (use createRoot + render vs ReactDOM.render).

This diff adds an argument to the legacy render method with explicit file name. We'll be tracking the usage of these legacy renderers and migrate the most used callsites.

Reviewed By: kassens

Differential Revision: D44271426

