### PR TITLE
[Migration] Fix open source tests - remove extra parameter from ReactDOM.render()

### DIFF
--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -128,7 +128,7 @@ function renderLegacyReactRoot<Props>(
   container: HTMLElement,
   contents: ReactAbstractElement<Props>,
 ) {
-  ReactDOM.render(contents, container, 'Recoil_TestingUtils.js');
+  ReactDOM.render(contents, container);
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -128,7 +128,8 @@ function renderLegacyReactRoot<Props>(
   container: HTMLElement,
   contents: ReactAbstractElement<Props>,
 ) {
-  ReactDOM.render(contents, container);
+  ReactDOM.render(contents, container); // @oss-only
+  // @fb-only: ReactDOM.render(contents, container, 'Recoil_TestingUtils.js');
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;


### PR DESCRIPTION
It appears that this commit https://github.com/facebookexperimental/Recoil/commit/b94eb51c2049d155984869b992e9ea8cf85d4101 (related to diff D44271426) broke the open-source tests by adding a string parameter to `ReactDOM.render()` from `ReactDOMLegacy_DEPRECATED`, while open source uses `react-dom`.  

I patched this using the `// @oss-only` and `// @fb-only` tags.  Though, if the source of truth migration is fully complete then that should no longer be necessary?