### PR TITLE
Enable async atom initialization via the updater form of setSelf() in Atom Effects

### DIFF
--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -128,7 +128,7 @@ function renderLegacyReactRoot<Props>(
   container: HTMLElement,
   contents: ReactAbstractElement<Props>,
 ) {
-  ReactDOM.render(contents, container, 'Recoil_TestingUtils.js');
+  ReactDOM.render(contents, container);
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -128,7 +128,8 @@ function renderLegacyReactRoot<Props>(
   container: HTMLElement,
   contents: ReactAbstractElement<Props>,
 ) {
-  ReactDOM.render(contents, container);
+  ReactDOM.render(contents, container); // @oss-only
+  // @fb-only: ReactDOM.render(contents, container, 'Recoil_TestingUtils.js');
 }
 
 // @fb-only: const createRoot = ReactDOMComet.createRoot;

--- a/typescript/recoil-test.ts
+++ b/typescript/recoil-test.ts
@@ -9,26 +9,42 @@
  * @oncall recoil
  */
 
- import {
+import {
   atom,
   atomFamily,
-  constSelector, DefaultValue,
-  errorSelector, isRecoilValue,
-  noWait, readOnlySelector, RecoilBridge, RecoilRoot,
-  RecoilValue, RecoilState, RecoilValueReadOnly,
+  constSelector,
+  DefaultValue,
+  errorSelector,
+  isRecoilValue,
+  noWait,
+  readOnlySelector,
+  RecoilBridge,
+  RecoilRoot,
+  RecoilValue,
+  RecoilState,
+  RecoilValueReadOnly,
   selector,
   selectorFamily,
   Snapshot,
   snapshot_UNSTABLE,
-  useGetRecoilValueInfo_UNSTABLE, useGotoRecoilSnapshot,
-  useRecoilBridgeAcrossReactRoots_UNSTABLE, useRecoilCallback,
-  useRecoilSnapshot, useRecoilState,
+  useGetRecoilValueInfo_UNSTABLE,
+  useGotoRecoilSnapshot,
+  useRecoilBridgeAcrossReactRoots_UNSTABLE,
+  useRecoilCallback,
+  useRecoilSnapshot,
+  useRecoilState,
   useRecoilStateLoadable,
-  useRecoilTransactionObserver_UNSTABLE, useRecoilValue,
+  useRecoilTransactionObserver_UNSTABLE,
+  useRecoilValue,
   useRecoilValueLoadable,
-  useResetRecoilState, useSetRecoilState,
-  waitForAll, waitForAllSettled, waitForAny, waitForNone,
-  Loadable, RecoilLoadable,
+  useResetRecoilState,
+  useSetRecoilState,
+  waitForAll,
+  waitForAllSettled,
+  waitForAny,
+  waitForNone,
+  Loadable,
+  RecoilLoadable,
   useRecoilTransaction_UNSTABLE,
   useRecoilRefresher_UNSTABLE,
   useRecoilStoreID,
@@ -97,20 +113,20 @@ selector({
 
 const readOnlySelectorSel = selector({
   key: 'ReadOnlySelector',
-  get: ({ get }) => {
-      get(myAtom) + 10;
-      get(mySelector1);
-      get(5); // $ExpectError
-      return 5;
+  get: ({get}) => {
+    get(myAtom) + 10;
+    get(mySelector1);
+    get(5); // $ExpectError
+    return 5;
   },
 });
 
 const writeableSelector = selector({
   key: 'WriteableSelector',
-  get: ({ get }) => {
+  get: ({get}) => {
     return get(mySelector1) + 10;
   },
-  set: ({ get, set, reset }) => {
+  set: ({get, set, reset}) => {
     get(myAtom);
     set(myAtom, 5);
     set(myAtom, 'hello'); // $ExpectError
@@ -124,26 +140,30 @@ const writeableSelector = selector({
 
 const callbackSelector = selector({
   key: 'CallbackSelector',
-  get: ({ getCallback }) => {
-    return getCallback(({snapshot, set, reset, refresh, transact_UNSTABLE}) => () => {
-      set(myAtom, 5);
-      reset(myAtom);
-      refresh(myAtom);
+  get: ({getCallback}) => {
+    return getCallback(
+      ({snapshot, set, reset, refresh, transact_UNSTABLE}) =>
+        () => {
+          set(myAtom, 5);
+          reset(myAtom);
+          refresh(myAtom);
 
-      transact_UNSTABLE(({get, set, reset}) => {
-        get(myAtom); // $ExpectType number
-        set(myAtom, 5);
-        reset(myAtom);
-      });
+          transact_UNSTABLE(({get, set, reset}) => {
+            get(myAtom); // $ExpectType number
+            set(myAtom, 5);
+            reset(myAtom);
+          });
 
-      const ret = snapshot.getPromise(mySelector1); // $ExpectType Promise<number>
-      return ret;
-    });
-  }
+          const ret = snapshot.getPromise(mySelector1); // $ExpectType Promise<number>
+          return ret;
+        },
+    );
+  },
 });
 useRecoilValue(callbackSelector); // $ExpectType () => Promise<number>
 
-const selectorError1 = selector({ // $ExpectError
+// $ExpectError
+const selectorError1 = selector({
   key: 'SelectorError1',
   // Missing get()
 });
@@ -164,8 +184,9 @@ selectorError3;
 
 // RecoilRoot
 RecoilRoot({children: React.createElement('div')}); // $ExpectType ReactElement<any, any> | null
-RecoilRoot({ // $ExpectType ReactElement<any, any> | null
-  initializeState: ({ set, reset }) => {
+// $ExpectType ReactElement<any, any> | null
+RecoilRoot({
+  initializeState: ({set, reset}) => {
     set(myAtom, 5);
     reset(myAtom);
 
@@ -176,11 +197,13 @@ RecoilRoot({ // $ExpectType ReactElement<any, any> | null
   },
   children: React.createElement('div'),
 });
-RecoilRoot({ // $ExpectType ReactElement<any, any> | null
+// $ExpectType ReactElement<any, any> | null
+RecoilRoot({
   override: true,
   children: React.createElement('div'),
 });
-RecoilRoot({ // $ExpectType ReactElement<any, any> | null
+// $ExpectType ReactElement<any, any> | null
+RecoilRoot({
   override: false,
   children: React.createElement('div'),
 });
@@ -301,85 +324,91 @@ useRecoilState_TRANSITION_SUPPORT_UNSTABLE(writeableSelector); // $ExpectType [n
 useRecoilState_TRANSITION_SUPPORT_UNSTABLE(readOnlySelectorSel); // $ExpectError
 useRecoilState_TRANSITION_SUPPORT_UNSTABLE({}); // $ExpectError
 
-useRecoilCallback(({ snapshot, set, reset, refresh, gotoSnapshot, transact_UNSTABLE }) => async () => {
-  snapshot; // $ExpectType Snapshot
-  snapshot.getID(); // $ExpectType SnapshotID
-  await snapshot.getPromise(mySelector1); // $ExpectType number
-  const loadable: Loadable<number> = snapshot.getLoadable(mySelector1);
+useRecoilCallback(
+  ({snapshot, set, reset, refresh, gotoSnapshot, transact_UNSTABLE}) =>
+    async () => {
+      snapshot; // $ExpectType Snapshot
+      snapshot.getID(); // $ExpectType SnapshotID
+      await snapshot.getPromise(mySelector1); // $ExpectType number
+      const loadable: Loadable<number> = snapshot.getLoadable(mySelector1);
 
-  gotoSnapshot(snapshot);
+      gotoSnapshot(snapshot);
 
-  gotoSnapshot(3); // $ExpectError
-  gotoSnapshot(myAtom); // $ExpectError
+      gotoSnapshot(3); // $ExpectError
+      gotoSnapshot(myAtom); // $ExpectError
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
-  loadable.contents; // $ExpectType any
-  switch (loadable.state) {
-    case 'hasValue':
-      loadable.contents; // $ExpectType number
-      break;
-    case 'hasError':
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
       loadable.contents; // $ExpectType any
-      break;
-    case 'loading':
-      loadable.contents; // $ExpectType Promise<number>
-      break;
-  }
+      switch (loadable.state) {
+        case 'hasValue':
+          loadable.contents; // $ExpectType number
+          break;
+        case 'hasError':
+          loadable.contents; // $ExpectType any
+          break;
+        case 'loading':
+          loadable.contents; // $ExpectType Promise<number>
+          break;
+      }
 
-  set(myAtom, 5);
-  set(myAtom, 'hello'); // $ExpectError
-  reset(myAtom);
-  refresh(myAtom);
+      set(myAtom, 5);
+      set(myAtom, 'hello'); // $ExpectError
+      reset(myAtom);
+      refresh(myAtom);
 
-  const release = snapshot.retain(); // $ExpectType () => void
-  release(); // $ExpectType void
-  snapshot.isRetained(); // $ExpectType boolean
+      const release = snapshot.retain(); // $ExpectType () => void
+      release(); // $ExpectType void
+      snapshot.isRetained(); // $ExpectType boolean
 
-  transact_UNSTABLE(({get, set, reset}) => {
-    const x: number = get(myAtom); // eslint-disable-line @typescript-eslint/no-unused-vars
-    set(myAtom, 1);
-    set(myAtom, x => x + 1);
-    reset(myAtom);
-  });
-});
+      transact_UNSTABLE(({get, set, reset}) => {
+        const x: number = get(myAtom); // eslint-disable-line @typescript-eslint/no-unused-vars
+        set(myAtom, 1);
+        set(myAtom, x => x + 1);
+        reset(myAtom);
+      });
+    },
+);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, reset}) => (p: number) => {
-  const x: number = get(myAtom); // eslint-disable-line @typescript-eslint/no-unused-vars
-  set(myAtom, 1);
-  set(myAtom, x => x + 1);
-  reset(myAtom);
-});
+const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(
+  ({get, set, reset}) =>
+    (p: number) => {
+      const x: number = get(myAtom); // eslint-disable-line @typescript-eslint/no-unused-vars
+      set(myAtom, 1);
+      set(myAtom, x => x + 1);
+      reset(myAtom);
+    },
+);
 
 /**
  * useRecoilTransactionObserver_UNSTABLE()
  */
 {
-  useRecoilTransactionObserver_UNSTABLE(
-    ({snapshot, previousSnapshot}) => {
-      snapshot.getLoadable(myAtom); // $ExpectType Loadable<number>
-      snapshot.getPromise(mySelector1); // $ExpectType Promise<number>
-      snapshot.getPromise(mySelector2); // $ExpectType Promise<string>
+  useRecoilTransactionObserver_UNSTABLE(({snapshot, previousSnapshot}) => {
+    snapshot.getLoadable(myAtom); // $ExpectType Loadable<number>
+    snapshot.getPromise(mySelector1); // $ExpectType Promise<number>
+    snapshot.getPromise(mySelector2); // $ExpectType Promise<string>
 
-      previousSnapshot.getLoadable(myAtom); // $ExpectType Loadable<number>
-      previousSnapshot.getPromise(mySelector1); // $ExpectType Promise<number>
-      previousSnapshot.getPromise(mySelector2); // $ExpectType Promise<string>
+    previousSnapshot.getLoadable(myAtom); // $ExpectType Loadable<number>
+    previousSnapshot.getPromise(mySelector1); // $ExpectType Promise<number>
+    previousSnapshot.getPromise(mySelector2); // $ExpectType Promise<string>
 
-      for (const node of Array.from(snapshot.getNodes_UNSTABLE({isModified: true}))) {
-          const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
-      }
-    },
-  );
+    for (const node of Array.from(
+      snapshot.getNodes_UNSTABLE({isModified: true}),
+    )) {
+      const loadable = snapshot.getLoadable(node); // $ExpectType Loadable<unknown>
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const state: 'hasValue' | 'hasError' | 'loading' = loadable.state;
+    }
+  });
 }
 
 /**
  * useGotoRecoilSnapshot()
  */
 {
-  const snapshot: Snapshot = ({} as any);
+  const snapshot: Snapshot = {} as any;
 
   const gotoSnap = useGotoRecoilSnapshot();
 
@@ -412,7 +441,8 @@ const transact: (p: number) => void = useRecoilTransaction_UNSTABLE(({get, set, 
  * useRecoilBridgeAcrossReactRoots()
  */
 {
-  const RecoilBridgeComponent: typeof RecoilBridge = useRecoilBridgeAcrossReactRoots_UNSTABLE();
+  const RecoilBridgeComponent: typeof RecoilBridge =
+    useRecoilBridgeAcrossReactRoots_UNSTABLE();
   RecoilBridgeComponent({children: React.createElement('div')});
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   RecoilBridgeComponent({
@@ -459,11 +489,13 @@ isRecoilValue(mySelector1);
     atomFamily<number, number>({key: 'MyAtomFamilyWithoutDefault'});
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const myAsyncAtomFamily: (number: number) => RecoilState<number> =
-    atomFamily<number, number>({
-      key: 'MyAsyncAtomFamily',
-      default: (param: number) => Promise.resolve(param),
-    });
+  const myAsyncAtomFamily: (number: number) => RecoilState<number> = atomFamily<
+    number,
+    number
+  >({
+    key: 'MyAsyncAtomFamily',
+    default: (param: number) => Promise.resolve(param),
+  });
 }
 
 /**
@@ -472,11 +504,13 @@ isRecoilValue(mySelector1);
 {
   const mySelectorFam = selectorFamily({
     key: 'myAtomFam1',
-    get: (param: number) => ({ get }) => {
-      get(mySelector1); // $ExpectType number
+    get:
+      (param: number) =>
+      ({get}) => {
+        get(mySelector1); // $ExpectType number
 
-      return param;
-    },
+        return param;
+      },
   });
 
   const atm = mySelectorFam(2); // $ExpectType RecoilValueReadOnly<number>
@@ -488,10 +522,12 @@ isRecoilValue(mySelector1);
 
   const mySelectorFamWritable = selectorFamily({
     key: 'myAtomFam1',
-    get: (param: number) => ({ get }) => {
-      get(mySelector1); // $ExpectType number
-      return param;
-    },
+    get:
+      (param: number) =>
+      ({get}) => {
+        get(mySelector1); // $ExpectType number
+        return param;
+      },
     set: (param: number) => () => {
       param; // $ExpectType number
     },
@@ -512,27 +548,36 @@ isRecoilValue(mySelector1);
   }
   const myJsonSerializableSelectorFam = selectorFamily({
     key: 'mySelectorFam1',
-    get: (param: {date: Date, class: MySerializableClass}) => () =>
-      (param.date.toString() + JSON.stringify(param.class.toJSON())),
+    get: (param: {date: Date; class: MySerializableClass}) => () =>
+      param.date.toString() + JSON.stringify(param.class.toJSON()),
   });
-  myJsonSerializableSelectorFam({ date: new Date(), class: new MySerializableClass() });
+  myJsonSerializableSelectorFam({
+    date: new Date(),
+    class: new MySerializableClass(),
+  });
 
   const callbackSelectorFamily = selectorFamily({
     key: 'CallbackSelector',
-    get: (param: number) => ({ getCallback }) => {
-      return getCallback(({snapshot}) => async (num: number) => {
-        num; // $ExpectType number
-        const ret = await snapshot.getPromise(mySelectorFamWritable(param + num)); // $ExpectType number
-        return ret;
-      });
-    }
+    get:
+      (param: number) =>
+      ({getCallback}) => {
+        return getCallback(({snapshot}) => async (num: number) => {
+          num; // $ExpectType number
+          // $ExpectType number
+          const ret = await snapshot.getPromise(
+            mySelectorFamWritable(param + num),
+          );
+          return ret;
+        });
+      },
   });
   useRecoilValue(callbackSelectorFamily('hi')); // $ExpectError
   const cb = useRecoilValue(callbackSelectorFamily(1)); // $ExpectType (num: number) => Promise<number>
   cb('hi'); // $ExpectError
   cb(2); // $ExpectType
 
-  const selectorFamilyError1 = selectorFamily({ // $ExpectError
+  // $ExpectError
+  const selectorFamilyError1 = selectorFamily({
     key: 'SelectorFamilyError1',
     // Missing get()
   });
@@ -547,7 +592,11 @@ isRecoilValue(mySelector1);
 
   const selectorFamilyError3 = selectorFamily({
     key: 'SelectorFamilyError3',
-    get: () => ({badCallback}) => null, // $ExpectError
+    get:
+      () =>
+      // $ExpectError
+      ({badCallback}) =>
+        null,
   });
   selectorFamilyError3;
 }
@@ -559,7 +608,7 @@ isRecoilValue(mySelector1);
   const mySel = constSelector(1);
   const mySel2 = constSelector('hello');
   const mySel3 = constSelector([1, 2]);
-  const mySel4 = constSelector({ a: 1, b: '2' });
+  const mySel4 = constSelector({a: 1, b: '2'});
 
   useRecoilValue(mySel); // $ExpectType 1
   useRecoilValue(mySel2); // $ExpectType "hello"
@@ -612,7 +661,7 @@ isRecoilValue(mySelector1);
   const strSel: RecoilValueReadOnly<string> = {} as any;
 
   const mySel = waitForNone([numSel, strSel]);
-  const mySel2 = waitForNone({ a: numSel, b: strSel });
+  const mySel2 = waitForNone({a: numSel, b: strSel});
 
   useRecoilValue(mySel)[0]; // $ExpectType Loadable<number>
   useRecoilValue(mySel)[1]; // $ExpectType Loadable<string>
@@ -629,7 +678,7 @@ isRecoilValue(mySelector1);
   const strSel: RecoilValueReadOnly<string> = {} as any;
 
   const mySel = waitForAny([numSel, strSel]);
-  const mySel2 = waitForAny({ a: numSel, b: strSel });
+  const mySel2 = waitForAny({a: numSel, b: strSel});
 
   useRecoilValue(mySel)[0]; // $ExpectType Loadable<number>
   useRecoilValue(mySel)[1]; // $ExpectType Loadable<string>
@@ -646,7 +695,7 @@ isRecoilValue(mySelector1);
   const strSel: RecoilValueReadOnly<string> = {} as any;
 
   const mySel = waitForAll([numSel, strSel]);
-  const mySel2 = waitForAll({ a: numSel, b: strSel });
+  const mySel2 = waitForAll({a: numSel, b: strSel});
 
   useRecoilValue(mySel)[0]; // $ExpectType number
   useRecoilValue(mySel)[1]; // $ExpectType string
@@ -663,7 +712,7 @@ isRecoilValue(mySelector1);
   const strSel: RecoilValueReadOnly<string> = {} as any;
 
   const mySel = waitForAllSettled([numSel, strSel]);
-  const mySel2 = waitForAllSettled({ a: numSel, b: strSel });
+  const mySel2 = waitForAllSettled({a: numSel, b: strSel});
 
   useRecoilValue(mySel)[0]; // $ExpectType Loadable<number>
   useRecoilValue(mySel)[1]; // $ExpectType Loadable<string>
@@ -676,17 +725,41 @@ isRecoilValue(mySelector1);
  * effects on atom()
  */
 {
-  atom({
+  atom<number>({
     key: 'thisismyrandomkey',
     default: 0,
     effects: [
-      ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+      ({
+        node,
+        storeID,
+        trigger,
+        setSelf,
+        onSet,
+        resetSelf,
+        getPromise,
+        getLoadable,
+        getInfo_UNSTABLE,
+      }) => {
         node; // $ExpectType RecoilState<number>
         storeID; // $ExpectType StoreID
         trigger; // $ExpectType "set" | "get"
 
+        setSelf(new DefaultValue());
         setSelf(1);
         setSelf('a'); // $ExpectError
+        setSelf(Promise.resolve(new DefaultValue()));
+        setSelf(Promise.resolve(1));
+        setSelf(Promise.resolve('a')); // $ExpectError
+        setSelf(() => new DefaultValue());
+        setSelf(() => 1);
+        setSelf(() => 'a'); // $ExpectError
+        setSelf(() => Promise.resolve(new DefaultValue()));
+        setSelf(() => Promise.resolve(1));
+        setSelf(() => Promise.resolve('a')); // $ExpectError
+        setSelf(old => {
+          old; // $ExpectType number | DefaultValue
+          return old;
+        });
 
         onSet((val, oldVal, isReset) => {
           val; // $ExpectType number
@@ -719,16 +792,40 @@ isRecoilValue(mySelector1);
   atomFamily({
     key: 'myrandomatomfamilykey',
     default: (param: number) => param,
-    effects: (param) => [
-      ({node, storeID, trigger, setSelf, onSet, resetSelf, getPromise, getLoadable, getInfo_UNSTABLE}) => {
+    effects: param => [
+      ({
+        node,
+        storeID,
+        trigger,
+        setSelf,
+        onSet,
+        resetSelf,
+        getPromise,
+        getLoadable,
+        getInfo_UNSTABLE,
+      }) => {
         param; // $ExpectType number
 
         node; // $ExpectType RecoilState<number>
         storeID; // $ExpectType StoreID
         trigger; // $ExpectType "set" | "get"
 
+        setSelf(new DefaultValue());
         setSelf(1);
         setSelf('a'); // $ExpectError
+        setSelf(Promise.resolve(new DefaultValue()));
+        setSelf(Promise.resolve(1));
+        setSelf(Promise.resolve('a')); // $ExpectError
+        setSelf(() => new DefaultValue());
+        setSelf(() => 1);
+        setSelf(() => 'a'); // $ExpectError
+        setSelf(() => Promise.resolve(new DefaultValue()));
+        setSelf(() => Promise.resolve(1));
+        setSelf(() => Promise.resolve('a')); // $ExpectError
+        setSelf(old => {
+          old; // $ExpectType number | DefaultValue
+          return old;
+        });
 
         onSet(val => {
           val; // $ExpectType number
@@ -756,19 +853,17 @@ isRecoilValue(mySelector1);
  * snapshot_UNSTABLE()
  */
 {
-  snapshot_UNSTABLE(
-    mutableSnapshot => mutableSnapshot.set(myAtom, 1)
-  )
-  .getLoadable(mySelector1)
-  .valueOrThrow();
+  snapshot_UNSTABLE(mutableSnapshot => mutableSnapshot.set(myAtom, 1))
+    .getLoadable(mySelector1)
+    .valueOrThrow();
 }
 
 {
   snapshot_UNSTABLE(
-    mutableSnapshot => mutableSnapshot.set(myAtom, '1') // $ExpectError
+    mutableSnapshot => mutableSnapshot.set(myAtom, '1'), // $ExpectError
   )
-  .getLoadable(mySelector1)
-  .valueOrThrow();
+    .getLoadable(mySelector1)
+    .valueOrThrow();
 }
 
 /**
@@ -780,13 +875,13 @@ isRecoilValue(mySelector1);
     get: () => {},
     cachePolicy_UNSTABLE: {
       eviction: 'keep-all',
-    }
+    },
   });
 
   selector({
     key: 'ReadOnlySelectorSel_cachePolicy3',
     get: () => {},
-    cachePolicy_UNSTABLE: { eviction: 'lru' }, // $ExpectError
+    cachePolicy_UNSTABLE: {eviction: 'lru'}, // $ExpectError
   });
 
   selector({
@@ -795,7 +890,7 @@ isRecoilValue(mySelector1);
     cachePolicy_UNSTABLE: {
       eviction: 'lru',
       maxSize: 10,
-    }
+    },
   });
 
   selector({
@@ -803,7 +898,7 @@ isRecoilValue(mySelector1);
     get: () => {},
     cachePolicy_UNSTABLE: {
       eviction: 'most-recent',
-    }
+    },
   });
 
   selectorFamily({
@@ -811,13 +906,13 @@ isRecoilValue(mySelector1);
     get: () => () => {},
     cachePolicy_UNSTABLE: {
       eviction: 'keep-all',
-    }
+    },
   });
 
   selectorFamily({
     key: 'ReadOnlySelectorFSel_cachePolicy3',
     get: () => () => {},
-    cachePolicy_UNSTABLE: { eviction: 'lru' }, // $ExpectError
+    cachePolicy_UNSTABLE: {eviction: 'lru'}, // $ExpectError
   });
 
   selectorFamily({
@@ -826,7 +921,7 @@ isRecoilValue(mySelector1);
     cachePolicy_UNSTABLE: {
       eviction: 'lru',
       maxSize: 10,
-    }
+    },
   });
 
   selectorFamily({
@@ -834,7 +929,7 @@ isRecoilValue(mySelector1);
     get: () => () => {},
     cachePolicy_UNSTABLE: {
       eviction: 'most-recent',
-    }
+    },
   });
 }
 
@@ -843,7 +938,7 @@ isRecoilValue(mySelector1);
 /**
  * Loadable Factory Tests
  */
- {
+{
   RecoilLoadable.of('x'); // $ExpectType Loadable<string>
   RecoilLoadable.of(Promise.resolve('x')); // $ExpectType Loadable<string>
   RecoilLoadable.of(RecoilLoadable.of('x')); // $ExpectType Loadable<string>

--- a/typescript/recoil.d.ts
+++ b/typescript/recoil.d.ts
@@ -13,27 +13,29 @@
  * This file is a manual translation of the flow types, which are the source of truth, so we should not introduce new terminology or behavior in this file.
  */
 
- export { };
+export {};
 
- import * as React from 'react';
+import * as React from 'react';
 
- // state.d.ts
- type NodeKey = string;
+// state.d.ts
+type NodeKey = string;
 
- // node.d.ts
- export class DefaultValue {
+// node.d.ts
+export class DefaultValue {
   private __tag: 'DefaultValue';
- }
+}
 
- // recoilRoot.d.ts
- export type RecoilRootProps = {
-  initializeState?: (mutableSnapshot: MutableSnapshot) => void,
-  override?: true,
-  children: React.ReactNode,
- } | {
-  override: false,
-  children: React.ReactNode,
- };
+// recoilRoot.d.ts
+export type RecoilRootProps =
+  | {
+      initializeState?: (mutableSnapshot: MutableSnapshot) => void;
+      override?: true;
+      children: React.ReactNode;
+    }
+  | {
+      override: false;
+      children: React.ReactNode;
+    };
 
 // recoilEnv.d.ts
 export interface RecoilEnv {
@@ -43,23 +45,23 @@ export interface RecoilEnv {
 
 export const RecoilEnv: RecoilEnv;
 
- /**
-  * Root component for managing Recoil state.  Most Recoil hooks should be
-  * called from a component nested in a <RecoilRoot>
-  */
- export const RecoilRoot: React.FC<RecoilRootProps>;
+/**
+ * Root component for managing Recoil state.  Most Recoil hooks should be
+ * called from a component nested in a <RecoilRoot>
+ */
+export const RecoilRoot: React.FC<RecoilRootProps>;
 
- // Snapshot.d.ts
- declare const SnapshotID_OPAQUE: unique symbol;
- export interface SnapshotID {
+// Snapshot.d.ts
+declare const SnapshotID_OPAQUE: unique symbol;
+export interface SnapshotID {
   readonly [SnapshotID_OPAQUE]: true;
- }
+}
 
- interface ComponentInfo {
+interface ComponentInfo {
   name: string;
- }
+}
 
- interface RecoilStateInfo<T> {
+interface RecoilStateInfo<T> {
   loadable?: Loadable<T>;
   isActive: boolean;
   isSet: boolean;
@@ -67,142 +69,161 @@ export const RecoilEnv: RecoilEnv;
   type: 'atom' | 'selector';
   deps: Iterable<RecoilValue<T>>;
   subscribers: {
-    nodes: Iterable<RecoilValue<T>>,
-    components: Iterable<ComponentInfo>,
+    nodes: Iterable<RecoilValue<T>>;
+    components: Iterable<ComponentInfo>;
   };
- }
+}
 
- export class Snapshot {
+export class Snapshot {
   getID(): SnapshotID;
   getLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
   getPromise<T>(recoilValue: RecoilValue<T>): Promise<T>;
-  getNodes_UNSTABLE(opts?: { isModified?: boolean, isInitialized?: boolean }): Iterable<RecoilValue<unknown>>;
+  getNodes_UNSTABLE(opts?: {
+    isModified?: boolean;
+    isInitialized?: boolean;
+  }): Iterable<RecoilValue<unknown>>;
   getInfo_UNSTABLE<T>(recoilValue: RecoilValue<T>): RecoilStateInfo<T>;
   map(cb: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
-  asyncMap(cb: (mutableSnapshot: MutableSnapshot) => Promise<void>): Promise<Snapshot>;
+  asyncMap(
+    cb: (mutableSnapshot: MutableSnapshot) => Promise<void>,
+  ): Promise<Snapshot>;
   retain(): () => void;
   isRetained(): boolean;
- }
+}
 
- export class MutableSnapshot extends Snapshot {
+export class MutableSnapshot extends Snapshot {
   set: SetRecoilState;
   reset: ResetRecoilState;
- }
+}
 
- declare const WrappedValue_OPAQUE: unique symbol;
- export interface WrappedValue<T> {
-   readonly [WrappedValue_OPAQUE]: true;
- }
+declare const WrappedValue_OPAQUE: unique symbol;
+export interface WrappedValue<T> {
+  readonly [WrappedValue_OPAQUE]: true;
+}
 
- // Effect is called the first time a node is used with a <RecoilRoot>
- export type AtomEffect<T> = (param: {
-  node: RecoilState<T>,
-  storeID: StoreID,
-  parentStoreID_UNSTABLE?: StoreID,
-  trigger: 'set' | 'get',
+// Effect is called the first time a node is used with a <RecoilRoot>
+export type AtomEffect<T> = (param: {
+  node: RecoilState<T>;
+  storeID: StoreID;
+  parentStoreID_UNSTABLE?: StoreID;
+  trigger: 'set' | 'get';
 
   // Call synchronously to initialize value or async to change it later
-  setSelf: (param:
-    | T
-    | DefaultValue
-    | Promise<T | DefaultValue>
-    | WrappedValue<T>
-    | ((param: T | DefaultValue) => T | DefaultValue | WrappedValue<T>),
-  ) => void,
-  resetSelf: () => void,
+  setSelf: (
+    param:
+      | T
+      | DefaultValue
+      | Promise<T | DefaultValue>
+      | WrappedValue<T>
+      | ((
+          param: T | DefaultValue,
+        ) => T | DefaultValue | Promise<T | DefaultValue> | WrappedValue<T>),
+  ) => void;
+  resetSelf: () => void;
 
   // Subscribe callbacks to events.
   // Atom effect observers are called before global transaction observers
   onSet: (
     param: (newValue: T, oldValue: T | DefaultValue, isReset: boolean) => void,
-  ) => void,
+  ) => void;
 
   // Accessors to read other atoms/selectors
-  getPromise: <S>(recoilValue: RecoilValue<S>) => Promise<S>,
-  getLoadable: <S>(recoilValue: RecoilValue<S>) => Loadable<S>,
-  getInfo_UNSTABLE: <S>(recoilValue: RecoilValue<S>) => RecoilStateInfo<S>,
- }) => void | (() => void);
+  getPromise: <S>(recoilValue: RecoilValue<S>) => Promise<S>;
+  getLoadable: <S>(recoilValue: RecoilValue<S>) => Loadable<S>;
+  getInfo_UNSTABLE: <S>(recoilValue: RecoilValue<S>) => RecoilStateInfo<S>;
+}) => void | (() => void);
 
- // atom.d.ts
- interface AtomOptionsWithoutDefault<T> {
-   key: NodeKey;
-   effects?: ReadonlyArray<AtomEffect<T>>;
-   effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
-   dangerouslyAllowMutability?: boolean;
- }
- interface AtomOptionsWithDefault<T> extends AtomOptionsWithoutDefault<T> {
-   default: RecoilValue<T> | Promise<T> | Loadable<T> | WrappedValue<T> | T;
- }
- export type AtomOptions<T> = AtomOptionsWithoutDefault<T> | AtomOptionsWithDefault<T>;
+// atom.d.ts
+interface AtomOptionsWithoutDefault<T> {
+  key: NodeKey;
+  effects?: ReadonlyArray<AtomEffect<T>>;
+  effects_UNSTABLE?: ReadonlyArray<AtomEffect<T>>;
+  dangerouslyAllowMutability?: boolean;
+}
+interface AtomOptionsWithDefault<T> extends AtomOptionsWithoutDefault<T> {
+  default: RecoilValue<T> | Promise<T> | Loadable<T> | WrappedValue<T> | T;
+}
+export type AtomOptions<T> =
+  | AtomOptionsWithoutDefault<T>
+  | AtomOptionsWithDefault<T>;
 
- /**
-  * Creates an atom, which represents a piece of writeable state
-  */
- export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
- export namespace atom {
+/**
+ * Creates an atom, which represents a piece of writeable state
+ */
+export function atom<T>(options: AtomOptions<T>): RecoilState<T>;
+export namespace atom {
   function value<T>(value: T): WrappedValue<T>;
- }
+}
 
- export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
- export type SetterOrUpdater<T> = (valOrUpdater: ((currVal: T) => T) | T) => void;
- export type Resetter = () => void;
- export interface TransactionInterface_UNSTABLE {
+export type GetRecoilValue = <T>(recoilVal: RecoilValue<T>) => T;
+export type SetterOrUpdater<T> = (
+  valOrUpdater: ((currVal: T) => T) | T,
+) => void;
+export type Resetter = () => void;
+export interface TransactionInterface_UNSTABLE {
   get<T>(a: RecoilValue<T>): T;
   set<T>(s: RecoilState<T>, u: ((currVal: T) => T) | T): void;
   reset(s: RecoilState<any>): void;
- }
- export interface CallbackInterface {
-  set: <T>(recoilVal: RecoilState<T>, valOrUpdater: ((currVal: T) => T) | T) => void;
+}
+export interface CallbackInterface {
+  set: <T>(
+    recoilVal: RecoilState<T>,
+    valOrUpdater: ((currVal: T) => T) | T,
+  ) => void;
   reset: (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
   refresh: (recoilValue: RecoilValue<any>) => void;
   snapshot: Snapshot;
   gotoSnapshot: (snapshot: Snapshot) => void;
   transact_UNSTABLE: (cb: (i: TransactionInterface_UNSTABLE) => void) => void;
- }
+}
 
- // selector.d.ts
- export interface SelectorCallbackInterface extends CallbackInterface {
-   node: RecoilState<unknown>; // TODO This isn't properly typed
- }
- export type GetCallback = <Args extends ReadonlyArray<unknown>, Return>(
+// selector.d.ts
+export interface SelectorCallbackInterface extends CallbackInterface {
+  node: RecoilState<unknown>; // TODO This isn't properly typed
+}
+export type GetCallback = <Args extends ReadonlyArray<unknown>, Return>(
   fn: (interface: SelectorCallbackInterface) => (...args: Args) => Return,
- ) => (...args: Args) => Return;
+) => (...args: Args) => Return;
 
- export type SetRecoilState = <T>(
-    recoilVal: RecoilState<T>,
-    newVal: T | DefaultValue | ((prevValue: T) => T | DefaultValue),
- ) => void;
+export type SetRecoilState = <T>(
+  recoilVal: RecoilState<T>,
+  newVal: T | DefaultValue | ((prevValue: T) => T | DefaultValue),
+) => void;
 
- export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+export type ResetRecoilState = (recoilVal: RecoilState<any>) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
 
- // export type EqualityPolicy = 'reference' | 'value'; TODO: removing while we discuss long term API
+// export type EqualityPolicy = 'reference' | 'value'; TODO: removing while we discuss long term API
 
- export type EvictionPolicy = 'lru' | 'keep-all' | 'most-recent';
+export type EvictionPolicy = 'lru' | 'keep-all' | 'most-recent';
 
- // TODO: removing while we discuss long term API
- // export type CachePolicy =
- //   | {eviction: 'lru', maxSize: number, equality?: EqualityPolicy}
- //   | {eviction: 'none', equality?: EqualityPolicy}
- //   | {eviction?: undefined, equality: EqualityPolicy};
+// TODO: removing while we discuss long term API
+// export type CachePolicy =
+//   | {eviction: 'lru', maxSize: number, equality?: EqualityPolicy}
+//   | {eviction: 'none', equality?: EqualityPolicy}
+//   | {eviction?: undefined, equality: EqualityPolicy};
 
- // TODO: removing while we discuss long term API
- // export interface CachePolicyWithoutEviction {
- //   equality: EqualityPolicy;
- // }
+// TODO: removing while we discuss long term API
+// export interface CachePolicyWithoutEviction {
+//   equality: EqualityPolicy;
+// }
 
- export type CachePolicyWithoutEquality = {eviction: 'lru', maxSize: number} | {eviction: 'keep-all'} | {eviction: 'most-recent'};
+export type CachePolicyWithoutEquality =
+  | {eviction: 'lru'; maxSize: number}
+  | {eviction: 'keep-all'}
+  | {eviction: 'most-recent'};
 
- export interface ReadOnlySelectorOptions<T> {
-    key: string;
-    get: (opts: {
-      get: GetRecoilValue,
-      getCallback: GetCallback,
-    }) => Promise<T> | RecoilValue<T> | Loadable<T> | WrappedValue<T> | T;
-    dangerouslyAllowMutability?: boolean;
-    cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
- }
+export interface ReadOnlySelectorOptions<T> {
+  key: string;
+  get: (opts: {
+    get: GetRecoilValue;
+    getCallback: GetCallback;
+  }) => Promise<T> | RecoilValue<T> | Loadable<T> | WrappedValue<T> | T;
+  dangerouslyAllowMutability?: boolean;
+  cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
+}
 
- export interface ReadWriteSelectorOptions<T> extends ReadOnlySelectorOptions<T> {
+export interface ReadWriteSelectorOptions<T>
+  extends ReadOnlySelectorOptions<T> {
   set: (
     opts: {
       set: SetRecoilState;
@@ -211,132 +232,153 @@ export const RecoilEnv: RecoilEnv;
     },
     newValue: T | DefaultValue,
   ) => void;
- }
+}
 
- /**
-  * Creates a selector which represents derived state.
-  */
- export function selector<T>(options: ReadWriteSelectorOptions<T>): RecoilState<T>;
- export function selector<T>(options: ReadOnlySelectorOptions<T>): RecoilValueReadOnly<T>;
- export namespace selector {
+/**
+ * Creates a selector which represents derived state.
+ */
+export function selector<T>(
+  options: ReadWriteSelectorOptions<T>,
+): RecoilState<T>;
+export function selector<T>(
+  options: ReadOnlySelectorOptions<T>,
+): RecoilValueReadOnly<T>;
+export namespace selector {
   function value<T>(value: T): WrappedValue<T>;
- }
+}
 
- // hooks.d.ts
+// hooks.d.ts
 
- /**
-  * Returns the value of an atom or selector (readonly or writeable) and
-  * subscribes the components to future updates of that state.
-  */
- export function useRecoilValue<T>(recoilValue: RecoilValue<T>): T;
+/**
+ * Returns the value of an atom or selector (readonly or writeable) and
+ * subscribes the components to future updates of that state.
+ */
+export function useRecoilValue<T>(recoilValue: RecoilValue<T>): T;
 
- /**
-  * Returns a Loadable representing the status of the given Recoil state
-  * and subscribes the component to future updates of that state. Useful
-  * for working with async selectors.
-  */
- export function useRecoilValueLoadable<T>(recoilValue: RecoilValue<T>): Loadable<T>;
+/**
+ * Returns a Loadable representing the status of the given Recoil state
+ * and subscribes the component to future updates of that state. Useful
+ * for working with async selectors.
+ */
+export function useRecoilValueLoadable<T>(
+  recoilValue: RecoilValue<T>,
+): Loadable<T>;
 
- /**
-  * Returns a tuple where the first element is the value of the recoil state
-  * and the second is a setter to update that state. Subscribes component
-  * to updates of the given state.
-  */
- export function useRecoilState<T>(recoilState: RecoilState<T>): [T, SetterOrUpdater<T>];
+/**
+ * Returns a tuple where the first element is the value of the recoil state
+ * and the second is a setter to update that state. Subscribes component
+ * to updates of the given state.
+ */
+export function useRecoilState<T>(
+  recoilState: RecoilState<T>,
+): [T, SetterOrUpdater<T>];
 
- /**
-  * Returns a tuple where the first element is a Loadable and the second
-  * element is a setter function to update the given state. Subscribes
-  * component to updates of the given state.
-  */
- export function useRecoilStateLoadable<T>(recoilState: RecoilState<T>): [Loadable<T>, SetterOrUpdater<T>];
+/**
+ * Returns a tuple where the first element is a Loadable and the second
+ * element is a setter function to update the given state. Subscribes
+ * component to updates of the given state.
+ */
+export function useRecoilStateLoadable<T>(
+  recoilState: RecoilState<T>,
+): [Loadable<T>, SetterOrUpdater<T>];
 
- /**
-  * Returns a setter function for updating Recoil state. Does not subscribe
-  * the component to the given state.
-  */
+/**
+ * Returns a setter function for updating Recoil state. Does not subscribe
+ * the component to the given state.
+ */
 
- export function useSetRecoilState<T>(recoilState: RecoilState<T>): SetterOrUpdater<T>;
+export function useSetRecoilState<T>(
+  recoilState: RecoilState<T>,
+): SetterOrUpdater<T>;
 
- /**
-  * Returns a function that will reset the given state to its default value.
-  */
- export function useResetRecoilState(recoilState: RecoilState<any>): Resetter; // eslint-disable-line @typescript-eslint/no-explicit-any
+/**
+ * Returns a function that will reset the given state to its default value.
+ */
+export function useResetRecoilState(recoilState: RecoilState<any>): Resetter; // eslint-disable-line @typescript-eslint/no-explicit-any
 
- /**
-  * Returns current info about an atom
-  */
- export function useGetRecoilValueInfo_UNSTABLE(): <T>(recoilValue: RecoilValue<T>) => RecoilStateInfo<T>;
+/**
+ * Returns current info about an atom
+ */
+export function useGetRecoilValueInfo_UNSTABLE(): <T>(
+  recoilValue: RecoilValue<T>,
+) => RecoilStateInfo<T>;
 
 /**
  * Experimental version of hooks for useTransition() support
  */
- export function useRecoilValue_TRANSITION_SUPPORT_UNSTABLE<T>(recoilValue: RecoilValue<T>): T;
- export function useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE<T>(recoilValue: RecoilValue<T>): Loadable<T>;
- export function useRecoilState_TRANSITION_SUPPORT_UNSTABLE<T>(recoilState: RecoilState<T>): [T, SetterOrUpdater<T>];
+export function useRecoilValue_TRANSITION_SUPPORT_UNSTABLE<T>(
+  recoilValue: RecoilValue<T>,
+): T;
+export function useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE<T>(
+  recoilValue: RecoilValue<T>,
+): Loadable<T>;
+export function useRecoilState_TRANSITION_SUPPORT_UNSTABLE<T>(
+  recoilState: RecoilState<T>,
+): [T, SetterOrUpdater<T>];
 
- /**
-  * Returns a function that will run the callback that was passed when
-  * calling this hook. Useful for accessing Recoil state in response to
-  * events.
-  */
- export function useRecoilCallback<Args extends ReadonlyArray<unknown>, Return>(
+/**
+ * Returns a function that will run the callback that was passed when
+ * calling this hook. Useful for accessing Recoil state in response to
+ * events.
+ */
+export function useRecoilCallback<Args extends ReadonlyArray<unknown>, Return>(
   fn: (interface: CallbackInterface) => (...args: Args) => Return,
   deps?: ReadonlyArray<unknown>,
- ): (...args: Args) => Return;
+): (...args: Args) => Return;
 
- /**
-  * Returns a function that executes an atomic transaction for updating Recoil state.
-  */
- export function useRecoilTransaction_UNSTABLE<Args extends ReadonlyArray<unknown>>(
+/**
+ * Returns a function that executes an atomic transaction for updating Recoil state.
+ */
+export function useRecoilTransaction_UNSTABLE<
+  Args extends ReadonlyArray<unknown>,
+>(
   fn: (interface: TransactionInterface_UNSTABLE) => (...args: Args) => void,
   deps?: ReadonlyArray<unknown>,
- ): (...args: Args) => void;
+): (...args: Args) => void;
 
- export function useRecoilTransactionObserver_UNSTABLE(
-  callback: (opts: {
-    snapshot: Snapshot,
-    previousSnapshot: Snapshot,
-  }) => void,
- ): void;
+export function useRecoilTransactionObserver_UNSTABLE(
+  callback: (opts: {snapshot: Snapshot; previousSnapshot: Snapshot}) => void,
+): void;
 
- /**
-  * Updates Recoil state to match the provided snapshot.
-  */
- export function useGotoRecoilSnapshot(): (snapshot: Snapshot) => void;
+/**
+ * Updates Recoil state to match the provided snapshot.
+ */
+export function useGotoRecoilSnapshot(): (snapshot: Snapshot) => void;
 
- /**
-  * Returns a snapshot of the current Recoil state and subscribes the component
-  * to re-render when any state is updated.
-  */
- export function useRecoilSnapshot(): Snapshot;
+/**
+ * Returns a snapshot of the current Recoil state and subscribes the component
+ * to re-render when any state is updated.
+ */
+export function useRecoilSnapshot(): Snapshot;
 
- // useRecoilRefresher.d.ts
- /**
-  * Clears the cache for a selector causing it to be reevaluated.
-  */
- export function useRecoilRefresher_UNSTABLE(recoilValue: RecoilValue<any>): () => void;
+// useRecoilRefresher.d.ts
+/**
+ * Clears the cache for a selector causing it to be reevaluated.
+ */
+export function useRecoilRefresher_UNSTABLE(
+  recoilValue: RecoilValue<any>,
+): () => void;
 
- // useRecoilBridgeAcrossReactRoots.d.ts
- export const RecoilBridge: React.FC<{children: React.ReactNode}>;
- /**
-  * Returns a component that acts like a <RecoilRoot> but shares the same store
-  * as the current <RecoilRoot>.
-  */
- export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
+// useRecoilBridgeAcrossReactRoots.d.ts
+export const RecoilBridge: React.FC<{children: React.ReactNode}>;
+/**
+ * Returns a component that acts like a <RecoilRoot> but shares the same store
+ * as the current <RecoilRoot>.
+ */
+export function useRecoilBridgeAcrossReactRoots_UNSTABLE(): typeof RecoilBridge;
 
- // useRecoilStoreID
- declare const StoreID_OPAQUE: unique symbol;
- export interface StoreID {
+// useRecoilStoreID
+declare const StoreID_OPAQUE: unique symbol;
+export interface StoreID {
   readonly [StoreID_OPAQUE]: true;
- }
- /**
-  * Returns an ID for the currently active state store of the host <RecoilRoot>
-  */
- export function useRecoilStoreID(): StoreID;
+}
+/**
+ * Returns an ID for the currently active state store of the host <RecoilRoot>
+ */
+export function useRecoilStoreID(): StoreID;
 
- // loadable.d.ts
- interface BaseLoadable<T> {
+// loadable.d.ts
+interface BaseLoadable<T> {
   getValue: () => T;
   toPromise: () => Promise<T>;
   valueOrThrow: () => T;
@@ -344,71 +386,73 @@ export const RecoilEnv: RecoilEnv;
   promiseOrThrow: () => Promise<T>;
   is: (other: Loadable<any>) => boolean;
   map: <S>(map: (from: T) => Loadable<S> | Promise<S> | S) => Loadable<S>;
- }
+}
 
- interface ValueLoadable<T> extends BaseLoadable<T> {
+interface ValueLoadable<T> extends BaseLoadable<T> {
   state: 'hasValue';
   contents: T;
   valueMaybe: () => T;
   errorMaybe: () => undefined;
   promiseMaybe: () => undefined;
- }
+}
 
- interface LoadingLoadable<T> extends BaseLoadable<T> {
+interface LoadingLoadable<T> extends BaseLoadable<T> {
   state: 'loading';
   contents: Promise<T>;
   valueMaybe: () => undefined;
   errorMaybe: () => undefined;
   promiseMaybe: () => Promise<T>;
- }
+}
 
- interface ErrorLoadable<T> extends BaseLoadable<T> {
+interface ErrorLoadable<T> extends BaseLoadable<T> {
   state: 'hasError';
   contents: any;
   valueMaybe: () => undefined;
   errorMaybe: () => any;
   promiseMaybe: () => undefined;
- }
+}
 
- export type Loadable<T> =
+export type Loadable<T> =
   | ValueLoadable<T>
   | LoadingLoadable<T>
   | ErrorLoadable<T>;
 
- // recoilValue.d.ts
- declare class AbstractRecoilValue<T> {
+// recoilValue.d.ts
+declare class AbstractRecoilValue<T> {
   __tag: [T];
   __cTag: (t: T) => void; // for contravariance
 
   key: NodeKey;
   constructor(newKey: NodeKey);
   toJSON(): {key: string};
- }
+}
 
- declare class AbstractRecoilValueReadonly<T> {
+declare class AbstractRecoilValueReadonly<T> {
   __tag: [T];
 
   key: NodeKey;
   constructor(newKey: NodeKey);
   toJSON(): {key: string};
- }
+}
 
- export class RecoilState<T> extends AbstractRecoilValue<T> {}
- export class RecoilValueReadOnly<T> extends AbstractRecoilValueReadonly<T> {}
- export type RecoilValue<T> = RecoilValueReadOnly<T> | RecoilState<T>;
+export class RecoilState<T> extends AbstractRecoilValue<T> {}
+export class RecoilValueReadOnly<T> extends AbstractRecoilValueReadonly<T> {}
+export type RecoilValue<T> = RecoilValueReadOnly<T> | RecoilState<T>;
 
- /**
-  * Returns true if the parameter is a Recoil atom or selector.
-  */
- export function isRecoilValue(val: unknown): val is RecoilValue<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+/**
+ * Returns true if the parameter is a Recoil atom or selector.
+ */
+export function isRecoilValue(val: unknown): val is RecoilValue<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
- /** Utilities */
+/** Utilities */
 
- // bigint not supported yet
- type Primitive = undefined | null | boolean | number | symbol | string;
- interface HasToJSON { toJSON(): SerializableParam; }
+// bigint not supported yet
+type Primitive = undefined | null | boolean | number | symbol | string;
+interface HasToJSON {
+  toJSON(): SerializableParam;
+}
 
- export type SerializableParam =
+export type SerializableParam =
   | Primitive
   | HasToJSON
   | ReadonlyArray<SerializableParam>
@@ -419,76 +463,92 @@ export const RecoilEnv: RecoilEnv;
 interface AtomFamilyOptionsWithoutDefault<T, P extends SerializableParam> {
   key: NodeKey;
   dangerouslyAllowMutability?: boolean;
-  effects?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
-  effects_UNSTABLE?: | ReadonlyArray<AtomEffect<T>> | ((param: P) => ReadonlyArray<AtomEffect<T>>);
+  effects?:
+    | ReadonlyArray<AtomEffect<T>>
+    | ((param: P) => ReadonlyArray<AtomEffect<T>>);
+  effects_UNSTABLE?:
+    | ReadonlyArray<AtomEffect<T>>
+    | ((param: P) => ReadonlyArray<AtomEffect<T>>);
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
-  }
-  interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam> extends AtomFamilyOptionsWithoutDefault<T, P> {
+}
+interface AtomFamilyOptionsWithDefault<T, P extends SerializableParam>
+  extends AtomFamilyOptionsWithoutDefault<T, P> {
   default:
     | RecoilValue<T>
     | Promise<T>
     | Loadable<T>
     | WrappedValue<T>
     | T
-    | ((param: P) => T | RecoilValue<T> | Promise<T> | Loadable<T> | WrappedValue<T>);
-  }
-  export type AtomFamilyOptions<T, P extends SerializableParam> =
-    | AtomFamilyOptionsWithDefault<T, P>
-    | AtomFamilyOptionsWithoutDefault<T, P>;
+    | ((
+        param: P,
+      ) => T | RecoilValue<T> | Promise<T> | Loadable<T> | WrappedValue<T>);
+}
+export type AtomFamilyOptions<T, P extends SerializableParam> =
+  | AtomFamilyOptionsWithDefault<T, P>
+  | AtomFamilyOptionsWithoutDefault<T, P>;
 
- /**
-  * Returns a function which returns a memoized atom for each unique parameter value.
-  */
- export function atomFamily<T, P extends SerializableParam>(
+/**
+ * Returns a function which returns a memoized atom for each unique parameter value.
+ */
+export function atomFamily<T, P extends SerializableParam>(
   options: AtomFamilyOptions<T, P>,
- ): (param: P) => RecoilState<T>;
+): (param: P) => RecoilState<T>;
 
- export interface ReadOnlySelectorFamilyOptions<T, P extends SerializableParam> {
+export interface ReadOnlySelectorFamilyOptions<T, P extends SerializableParam> {
   key: string;
-  get: (param: P) => (opts: {
-    get: GetRecoilValue,
-    getCallback: GetCallback,
+  get: (
+    param: P,
+  ) => (opts: {
+    get: GetRecoilValue;
+    getCallback: GetCallback;
   }) => Promise<T> | RecoilValue<T> | Loadable<T> | WrappedValue<T> | T;
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
   cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
   dangerouslyAllowMutability?: boolean;
- }
+}
 
- export interface ReadWriteSelectorFamilyOptions<T, P extends SerializableParam> {
+export interface ReadWriteSelectorFamilyOptions<
+  T,
+  P extends SerializableParam,
+> {
   key: string;
-  get: (param: P) => (opts: {
-    get: GetRecoilValue,
-    getCallback: GetCallback,
+  get: (
+    param: P,
+  ) => (opts: {
+    get: GetRecoilValue;
+    getCallback: GetCallback;
   }) => Promise<T> | Loadable<T> | WrappedValue<T> | RecoilValue<T> | T;
   set: (
-      param: P,
+    param: P,
   ) => (
-      opts: { set: SetRecoilState; get: GetRecoilValue; reset: ResetRecoilState },
-      newValue: T | DefaultValue,
+    opts: {set: SetRecoilState; get: GetRecoilValue; reset: ResetRecoilState},
+    newValue: T | DefaultValue,
   ) => void;
   // cachePolicyForParams_UNSTABLE?: CachePolicyWithoutEviction; TODO: removing while we discuss long term API
   cachePolicy_UNSTABLE?: CachePolicyWithoutEquality; // TODO: using the more restrictive CachePolicyWithoutEquality while we discuss long term API
   dangerouslyAllowMutability?: boolean;
- }
+}
 
 /**
  * Returns a function which returns a memoized atom for each unique parameter value.
  */
 export function selectorFamily<T, P extends SerializableParam>(
-options: ReadWriteSelectorFamilyOptions<T, P>,
+  options: ReadWriteSelectorFamilyOptions<T, P>,
 ): (param: P) => RecoilState<T>;
 
 /**
  * Returns a function which returns a memoized atom for each unique parameter value.
  */
 export function selectorFamily<T, P extends SerializableParam>(
-options: ReadOnlySelectorFamilyOptions<T, P>,
+  options: ReadOnlySelectorFamilyOptions<T, P>,
 ): (param: P) => RecoilValueReadOnly<T>;
 
 /**
  * Returns a selector that always has a constant value.
  */
-export function constSelector<T extends SerializableParam>(constant: T): RecoilValueReadOnly<T>;
+export function constSelector<T extends SerializableParam>(
+  constant: T,
+): RecoilValueReadOnly<T>;
 
 /**
  * Returns a selector which is always in the provided error state.
@@ -498,96 +558,126 @@ export function errorSelector(message: string): RecoilValueReadOnly<never>;
 /**
  * Casts a selector to be a read-only selector
  */
-export function readOnlySelector<T>(atom: RecoilValue<T>): RecoilValueReadOnly<T>;
+export function readOnlySelector<T>(
+  atom: RecoilValue<T>,
+): RecoilValueReadOnly<T>;
 
 /**
  * Returns a selector that has the value of the provided atom or selector as a Loadable.
  * This means you can use noWait() to avoid entering an error or suspense state in
  * order to manually handle those cases.
  */
-export function noWait<T>(state: RecoilValue<T>): RecoilValueReadOnly<Loadable<T>>;
+export function noWait<T>(
+  state: RecoilValue<T>,
+): RecoilValueReadOnly<Loadable<T>>;
 
- /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
- export type UnwrapRecoilValue<T> = T extends RecoilValue<infer R> ? R : never;
+export type UnwrapRecoilValue<T> = T extends RecoilValue<infer R> ? R : never;
 
- export type UnwrapRecoilValues<T extends Array<RecoilValue<any>> | { [key: string]: RecoilValue<any> }> = {
+export type UnwrapRecoilValues<
+  T extends Array<RecoilValue<any>> | {[key: string]: RecoilValue<any>},
+> = {
   [P in keyof T]: UnwrapRecoilValue<T[P]>;
- };
- export type UnwrapRecoilValueLoadables<T extends Array<RecoilValue<any>> | { [key: string]: RecoilValue<any> }> = {
+};
+export type UnwrapRecoilValueLoadables<
+  T extends Array<RecoilValue<any>> | {[key: string]: RecoilValue<any>},
+> = {
   [P in keyof T]: Loadable<UnwrapRecoilValue<T[P]>>;
- };
+};
 
- export function waitForNone<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForNone<
+  RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>],
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForNone<RecoilValues extends { [key: string]: RecoilValue<any> }>(
+export function waitForNone<
+  RecoilValues extends {[key: string]: RecoilValue<any>},
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAny<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForAny<
+  RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>],
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAny<RecoilValues extends { [key: string]: RecoilValue<any> }>(
-    param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
-
- export function waitForAll<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForAny<
+  RecoilValues extends {[key: string]: RecoilValue<any>},
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAll<RecoilValues extends { [key: string]: RecoilValue<any> }>(
+export function waitForAll<
+  RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>],
+>(param: RecoilValues): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+
+export function waitForAll<
+  RecoilValues extends {[key: string]: RecoilValue<any>},
+>(param: RecoilValues): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+
+export function waitForAllSettled<
+  RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>],
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValues<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAllSettled<RecoilValues extends Array<RecoilValue<any>> | [RecoilValue<any>]>(
+export function waitForAllSettled<
+  RecoilValues extends {[key: string]: RecoilValue<any>},
+>(
   param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
 
- export function waitForAllSettled<RecoilValues extends { [key: string]: RecoilValue<any> }>(
-  param: RecoilValues,
- ): RecoilValueReadOnly<UnwrapRecoilValueLoadables<RecoilValues>>;
+export type UnwrapLoadable<T> = T extends Loadable<infer R>
+  ? R
+  : T extends Promise<infer P>
+  ? P
+  : T;
+export type UnwrapLoadables<T extends any[] | {[key: string]: any}> = {
+  [P in keyof T]: UnwrapLoadable<T[P]>;
+};
 
-  export type UnwrapLoadable<T> = T extends Loadable<infer R> ? R : T extends Promise<infer P> ? P : T;
-  export type UnwrapLoadables<T extends any[] | { [key: string]: any }> = {
-    [P in keyof T]: UnwrapLoadable<T[P]>;
-  };
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export namespace RecoilLoadable {
+  /**
+   * Factory to make a Loadable object.  If a Promise is provided the Loadable will
+   * be in a 'loading' state until the Promise is either resolved or rejected.
+   */
+  function of<T>(x: T | Promise<T> | Loadable<T>): Loadable<T>;
+  /**
+   * Factory to make a Loadable object in an error state.
+   */
+  function error(x: any): ErrorLoadable<any>;
+  /**
+   * Factory to make a loading Loadable which never resolves.
+   */
+  function loading(): LoadingLoadable<any>;
+  /**
+   * Factory to make a Loadable which is resolved when all of the Loadables provided
+   * to it are resolved or any one has an error.  The value is an array of the values
+   * of all of the provided Loadables.  This is comparable to Promise.all() for Loadables.
+   * Similar to Promise.all(), inputs may be Loadables, Promises, or literal values.
+   */
+  function all<Inputs extends any[] | [Loadable<any>]>(
+    inputs: Inputs,
+  ): Loadable<UnwrapLoadables<Inputs>>;
+  function all<Inputs extends {[key: string]: any}>(
+    inputs: Inputs,
+  ): Loadable<UnwrapLoadables<Inputs>>;
+  /**
+   * Returns true if the provided parameter is a Loadable type.
+   */
+  function isLoadable(x: any): x is Loadable<any>;
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  export namespace RecoilLoadable {
-    /**
-     * Factory to make a Loadable object.  If a Promise is provided the Loadable will
-     * be in a 'loading' state until the Promise is either resolved or rejected.
-     */
-    function of<T>(x: T | Promise<T> | Loadable<T>): Loadable<T>;
-    /**
-     * Factory to make a Loadable object in an error state.
-     */
-    function error(x: any): ErrorLoadable<any>;
-    /**
-     * Factory to make a loading Loadable which never resolves.
-     */
-    function loading(): LoadingLoadable<any>;
-    /**
-     * Factory to make a Loadable which is resolved when all of the Loadables provided
-     * to it are resolved or any one has an error.  The value is an array of the values
-     * of all of the provided Loadables.  This is comparable to Promise.all() for Loadables.
-     * Similar to Promise.all(), inputs may be Loadables, Promises, or literal values.
-     */
-    function all<Inputs extends any[] | [Loadable<any>]>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
-    function all<Inputs extends {[key: string]: any}>(inputs: Inputs): Loadable<UnwrapLoadables<Inputs>>;
-    /**
-     * Returns true if the provided parameter is a Loadable type.
-     */
-    function isLoadable(x: any): x is Loadable<any>;
-   }
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
- /* eslint-enable @typescript-eslint/no-explicit-any */
-
- /**
-  * Factory to produce a Recoil snapshot object with all atoms in the default state.
-  */
- export function snapshot_UNSTABLE(initializeState?: (mutableSnapshot: MutableSnapshot) => void): Snapshot;
+/**
+ * Factory to produce a Recoil snapshot object with all atoms in the default state.
+ */
+export function snapshot_UNSTABLE(
+  initializeState?: (mutableSnapshot: MutableSnapshot) => void,
+): Snapshot;


### PR DESCRIPTION
The `setSelf()` in atom effects enabled users to set to a `Promise<T>` in order to initialize atoms to an asynchronous value.  `setSelf()` also has an updater form where the user can pass in a function which provides the current value and allows them to return a new value based on that.  This PR just allows the user to initialize atoms with a `Promise<T>` when using the updater form of `setSelf()`.