### PR TITLE
fix: atom initialized by promise updates downstream selectors

### DIFF
--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -241,7 +241,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         const state = store.getState().nextTree ?? store.getState().currentTree;
 
         if (state.atomValues.get(key)?.contents === wrappedPromise) {
-          markRecoilValueModified(store, node)
+          markRecoilValueModified(store, node);
           setRecoilValue(store, node, value);
         }
 
@@ -250,7 +250,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       .catch(error => {
         const state = store.getState().nextTree ?? store.getState().currentTree;
         if (state.atomValues.get(key)?.contents === wrappedPromise) {
-          markRecoilValueModified(store, node)
+          markRecoilValueModified(store, node);
           setRecoilValueLoadable(store, node, loadableWithError(error));
         }
         throw error;

--- a/packages/recoil/recoil_values/Recoil_atom.js
+++ b/packages/recoil/recoil_values/Recoil_atom.js
@@ -241,6 +241,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
         const state = store.getState().nextTree ?? store.getState().currentTree;
 
         if (state.atomValues.get(key)?.contents === wrappedPromise) {
+          markRecoilValueModified(store, node)
           setRecoilValue(store, node, value);
         }
 
@@ -249,6 +250,7 @@ function baseAtom<T>(options: BaseAtomOptions<T>): RecoilState<T> {
       .catch(error => {
         const state = store.getState().nextTree ?? store.getState().currentTree;
         if (state.atomValues.get(key)?.contents === wrappedPromise) {
+          markRecoilValueModified(store, node)
           setRecoilValueLoadable(store, node, loadableWithError(error));
         }
         throw error;

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -733,51 +733,6 @@ describe('Dependencies', () => {
     expect(selectorRunCount).toBe(2);
     expect(selectorRunCompleteCount).toBe(0);
   });
-
-  testRecoil('selector waits for async atoms to be set first', async () => {
-    const asyncEffect =
-      result =>
-      ({setSelf}) => {
-        setSelf(
-          new Promise(resolve => {
-            setTimeout(() => {
-              resolve(result);
-            }, 0);
-          }),
-        );
-      };
-
-    const atomA = atom({
-      key: 'selector waits for async atoms to be set first/atomA',
-      default: 'a-default',
-      effects: [asyncEffect('a-async')],
-    });
-    const atomB = atom({
-      key: 'selector waits for async atoms to be set first/atomB',
-      default: 'b-default',
-      effects: [asyncEffect('b-async')],
-    });
-    // $FlowFixMe[incompatible-call]
-    const selectorA = selector({
-      key: 'selector waits for async atoms to be set first/selectorA',
-      // $FlowFixMe[missing-local-annot]
-      get: ({get}) => get(atomA),
-    });
-    const directSelector = selector({
-      key: 'selector waits for async atoms to be set first/directSelector',
-      // $FlowFixMe[missing-local-annot]
-      get: ({get}) => {
-        const valueA = get(atomA);
-        const valueB = get(atomB);
-        return `${valueA}/${valueB}`;
-      },
-    });
-
-    expect(getValue(directSelector) instanceof Promise).toBe(true);
-
-    act(() => jest.runAllTimers());
-    expect(getValue(directSelector)).toEqual('a-async/b-async');
-  });
 });
 
 describe('Async Selector Set', () => {

--- a/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selector-test.js
@@ -733,6 +733,51 @@ describe('Dependencies', () => {
     expect(selectorRunCount).toBe(2);
     expect(selectorRunCompleteCount).toBe(0);
   });
+
+  testRecoil('selector waits for async atoms to be set first', async () => {
+    const asyncEffect =
+      result =>
+      ({setSelf}) => {
+        setSelf(
+          new Promise(resolve => {
+            setTimeout(() => {
+              resolve(result);
+            }, 0);
+          }),
+        );
+      };
+
+    const atomA = atom({
+      key: 'selector waits for async atoms to be set first/atomA',
+      default: 'a-default',
+      effects: [asyncEffect('a-async')],
+    });
+    const atomB = atom({
+      key: 'selector waits for async atoms to be set first/atomB',
+      default: 'b-default',
+      effects: [asyncEffect('b-async')],
+    });
+    // $FlowFixMe[incompatible-call]
+    const selectorA = selector({
+      key: 'selector waits for async atoms to be set first/selectorA',
+      // $FlowFixMe[missing-local-annot]
+      get: ({get}) => get(atomA),
+    });
+    const directSelector = selector({
+      key: 'selector waits for async atoms to be set first/directSelector',
+      // $FlowFixMe[missing-local-annot]
+      get: ({get}) => {
+        const valueA = get(atomA);
+        const valueB = get(atomB);
+        return `${valueA}/${valueB}`;
+      },
+    });
+
+    expect(getValue(directSelector) instanceof Promise).toBe(true);
+
+    act(() => jest.runAllTimers());
+    expect(getValue(directSelector)).toEqual('a-async/b-async');
+  });
 });
 
 describe('Async Selector Set', () => {


### PR DESCRIPTION
There was a problem with not waiting for an atom initialized by promise when used in a selector with another selector. I described details in the related issue. I also created a repro on [codesandbox](https://codesandbox.io/s/recoil-issue-with-promise-effect-l6ddpd?file=/src/App.js).

The PR adds code suggested by @drarmstr in this [comment](https://github.com/facebookexperimental/Recoil/issues/2151#issuecomment-1491111260).

I tested this and it helps with the issue. I created a unit test but it doesn't work correctly. See my [comment here](https://github.com/facebookexperimental/Recoil/issues/2151#issuecomment-1502668034)

Related to https://github.com/facebookexperimental/Recoil/issues/2151