### PR TITLE
use testRecoil in RecoilSync_URLCompound

### DIFF
--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -8,36 +8,44 @@
 
 'use strict';
 
-const React = require('react');
-const {DefaultValue, atom, atomFamily} = require('Recoil');
+const {
+  getRecoilTestFn,
+} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 const {assertion, dict, nullable, number, string} = require('refine');
 
-const {
-  encodeURL,
-  expectURL,
-  gotoURL,
-} = require('../__test_utils__/RecoilSync_MockURLSerialization');
-const {
+let React,
+  DefaultValue,
+  atom,
+  atomFamily,
   act,
   componentThatReadsAndWritesAtom,
   renderElements,
-} = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
-const {
-  setConcurrentMode,
-} = require('recoil-shared/__test_utils__/Recoil_ReactRenderModes');
+  encodeURL,
+  expectURL,
+  gotoURL,
+  syncEffect,
+  RecoilURLSyncJSON;
 
-const {syncEffect} = require('../RecoilSync');
-const {RecoilURLSyncJSON} = require('../RecoilSync_URLJSON');
+const testRecoil = getRecoilTestFn(() => {
+  React = require('react');
+  ({DefaultValue, atom, atomFamily} = require('Recoil'));
 
-beforeEach(() => {
-  setConcurrentMode(true);
+  ({act} = require('ReactTestUtils'));
+  ({
+    componentThatReadsAndWritesAtom,
+    renderElements,
+  } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
+  ({
+    encodeURL,
+    expectURL,
+    gotoURL,
+  } = require('../__test_utils__/RecoilSync_MockURLSerialization'));
+
+  ({syncEffect} = require('../RecoilSync'));
+  ({RecoilURLSyncJSON} = require('../RecoilSync_URLJSON'));
 });
 
-afterEach(() => {
-  setConcurrentMode(false);
-});
-
-test('Upgrade item ID', async () => {
+testRecoil('Upgrade item ID', async () => {
   const loc = {part: 'queryParams'};
 
   const myAtom = atom({
@@ -75,7 +83,7 @@ test('Upgrade item ID', async () => {
   expectURL([[loc, {}]]);
 });
 
-test('Many items to one atom', async () => {
+testRecoil('Many items to one atom', async () => {
   const loc = {part: 'queryParams'};
 
   const manyToOneSyncEffct = () =>
@@ -133,7 +141,7 @@ test('Many items to one atom', async () => {
   expectURL([[loc, {}]]);
 });
 
-test('One item to multiple atoms', async () => {
+testRecoil('One item to multiple atoms', async () => {
   const loc = {part: 'queryParams'};
   const input = assertion(dict(nullable(number())));
 
@@ -208,7 +216,7 @@ test('One item to multiple atoms', async () => {
   ]);
 });
 
-test('One item to atom family', async () => {
+testRecoil('One item to atom family', async () => {
   const loc = {part: 'queryParams'};
   const input = assertion(dict(nullable(number())));
 

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -10,6 +10,7 @@
 
 const {act} = require('ReactTestUtils');
 const {DefaultValue, atom, atomFamily} = require('Recoil');
+const {setConcurrentMode} = require('Recoil_ReactRenderModes');
 
 const {
   encodeURL,
@@ -24,6 +25,14 @@ const {
   renderElements,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 const {assertion, dict, nullable, number, string} = require('refine');
+
+beforeEach(() => {
+  setConcurrentMode(true);
+});
+
+afterEach(() => {
+  setConcurrentMode(false);
+});
 
 test('Upgrade item ID', async () => {
   const loc = {part: 'queryParams'};

--- a/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
+++ b/packages/recoil-sync/__tests__/RecoilSync_URLCompound-test.js
@@ -8,23 +8,26 @@
 
 'use strict';
 
-const {act} = require('ReactTestUtils');
+const React = require('react');
 const {DefaultValue, atom, atomFamily} = require('Recoil');
-const {setConcurrentMode} = require('Recoil_ReactRenderModes');
+const {assertion, dict, nullable, number, string} = require('refine');
 
 const {
   encodeURL,
   expectURL,
   gotoURL,
 } = require('../__test_utils__/RecoilSync_MockURLSerialization');
-const {syncEffect} = require('../RecoilSync');
-const {RecoilURLSyncJSON} = require('../RecoilSync_URLJSON');
-const React = require('react');
 const {
+  act,
   componentThatReadsAndWritesAtom,
   renderElements,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
-const {assertion, dict, nullable, number, string} = require('refine');
+const {
+  setConcurrentMode,
+} = require('recoil-shared/__test_utils__/Recoil_ReactRenderModes');
+
+const {syncEffect} = require('../RecoilSync');
+const {RecoilURLSyncJSON} = require('../RecoilSync_URLJSON');
 
 beforeEach(() => {
   setConcurrentMode(true);


### PR DESCRIPTION
Instead of using `setConcurrentMode` directly, use `testRecoil` to make sure it runs with correct versions of React