### PR TITLE
Replace most of the `React.Element<'div'>` and `React.Element<'span'>` with `React.MixedElement` in www

### DIFF
--- a/packages-ext/recoil-devtools/src/pages/Popup/Items/ItemLabel.js
+++ b/packages-ext/recoil-devtools/src/pages/Popup/Items/ItemLabel.js
@@ -7,7 +7,9 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
+
 import type {Node} from '../../../types/DevtoolsTypes';
 
 const {getStyle} = require('../../../utils/getStyle');
@@ -30,13 +32,9 @@ type KeyProps = {
   isRoot?: boolean,
 };
 
-function ItemLabel({
-  name,
-  node,
-  isRoot = false,
-}: KeyProps): React$Element<'span'> {
+function ItemLabel({name, node, isRoot = false}: KeyProps): React$MixedElement {
   return (
-    <span style={getStyle(styles, {label: true, isRoot: isRoot})}>
+    <span style={getStyle(styles, {label: true, isRoot})}>
       <NodeName name={name} node={node} />:
     </span>
   );

--- a/packages-ext/recoil-devtools/src/pages/Popup/Items/NodeName.js
+++ b/packages-ext/recoil-devtools/src/pages/Popup/Items/NodeName.js
@@ -7,6 +7,7 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 import type {Node} from '../../../types/DevtoolsTypes';
@@ -35,10 +36,7 @@ type KeyProps = {
   node: ?Node,
 };
 
-export default function NodeName({
-  name,
-  node,
-}: KeyProps): React$Element<'span'> {
+export default function NodeName({name, node}: KeyProps): React$MixedElement {
   return (
     <span style={styles.label}>
       {node?.type === 'selector' && (


### PR DESCRIPTION
Summary:
This diff cleans up the final batch of leftover `React.Element<'div'>` and `React.Element<'span'>`. These specific types usually serves no purpose for both style and runtime.

Since the number of remaining uses of these types are small, I finally discovered the potential reason of their widespread uses. Some widely used template (the initial stub filled in by VSCode) uses these types:

https://www.internalfb.com/code/www/scripts/comet/components/Component.react.js.template?lines=24

Therefore, I also fixed these templates to use `React.MixedElement` instead.

Differential Revision: D45782223

