### PR TITLE
RecoilRoot is also a Suspense boundary

### DIFF
--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -17,6 +17,7 @@ import type {RecoilValue} from './Recoil_RecoilValue';
 import type {MutableSnapshot} from './Recoil_Snapshot';
 import type {Store, StoreRef, StoreState, TreeState} from './Recoil_State';
 
+// @fb-only: const FBLogger = require('FBLogger');
 // @fb-only: const RecoilusagelogEvent = require('RecoilusagelogEvent');
 // @fb-only: const RecoilUsageLogFalcoEvent = require('RecoilUsageLogFalcoEvent');
 // @fb-only: const URI = require('URI');
@@ -42,6 +43,7 @@ const {releaseScheduledRetainablesNow} = require('./Recoil_Retention');
 const {freshSnapshot} = require('./Recoil_Snapshot');
 const React = require('react');
 const {
+  Suspense,
   useCallback,
   useContext,
   useEffect,
@@ -360,6 +362,19 @@ function initialStoreState(
   return storeState;
 }
 
+let warned = false;
+function RecoilSuspenseWarning() {
+  // prettier-ignore
+  if (!warned) {
+    warned = true;
+    console.warn( // @oss-only
+    // @fb-only: FBLogger('recoil', 'root_suspended').warn(
+      'Suspended <RecoilRoot> detected. The children of <RecoilRoot> should be wrapped in a <Suspense> boundary since RecoilRoot is not designed to suspend.',
+    );
+  }
+  return null;
+}
+
 let nextID = 0;
 function RecoilRoot_INTERNAL({
   initializeState_DEPRECATED,
@@ -537,7 +552,11 @@ function RecoilRoot_INTERNAL({
     <AppContext.Provider value={storeRef}>
       <MutableSourceContext.Provider value={mutableSource}>
         <Batcher setNotifyBatcherOfChange={setNotifyBatcherOfChange} />
-        {children}
+        {gkx('recoil_suspense_warning') ? (
+          <Suspense fallback={<RecoilSuspenseWarning />}>{children}</Suspense>
+        ) : (
+          children
+        )}
       </MutableSourceContext.Provider>
     </AppContext.Provider>
   );


### PR DESCRIPTION
Summary:
Wraps the ReactRoot internally in a React Suspense boundary as Recoil uses `useEffect` in ways to do automatic batching that's not compatible with React 18 in case the Root suspends itself.

The reason for this is that with React 18, the `useEffect` callback is only called one the component is actually getting displayed. If the `useEffect `callback itself is what makes the component eventually un-suspend it causes an infinite suspense.

This isn't an ideal solution, but I'm not deep enough into Recoil to be able to propose a better solution.

Reviewed By: mrv1k

Differential Revision: D46405179

