### PR TITLE
remove unnecessary try/catch from RecoilRoot

### DIFF
--- a/packages/recoil/core/Recoil_RecoilRoot.js
+++ b/packages/recoil/core/Recoil_RecoilRoot.js
@@ -386,17 +386,10 @@ function RecoilRoot_INTERNAL({
   // prettier-ignore
   // @fb-only: useEffect(() => {
     // @fb-only: if (gkx('recoil_usage_logging')) {
-      // @fb-only: try {
-        // @fb-only: RecoilUsageLogFalcoEvent.log(() => ({
-          // @fb-only: type: RecoilusagelogEvent.RECOIL_ROOT_MOUNTED,
-          // @fb-only: path: URI.getRequestURI().getPath(),
-        // @fb-only: }));
-      // @fb-only: } catch {
-        // @fb-only: recoverableViolation(
-          // @fb-only: 'Error when logging Recoil Usage event',
-          // @fb-only: 'recoil',
-        // @fb-only: );
-      // @fb-only: }
+      // @fb-only: RecoilUsageLogFalcoEvent.log(() => ({
+        // @fb-only: type: RecoilusagelogEvent.RECOIL_ROOT_MOUNTED,
+        // @fb-only: path: URI.getRequestURI().getPath(),
+      // @fb-only: }));
     // @fb-only: }
   // @fb-only: }, []);
 


### PR DESCRIPTION
Summary: Unclear why this was added with D23056388. Seems like it was "just in case" this API is bad? Logs don't turn up any errors though.

Reviewed By: mrv1k

Differential Revision: D46444484

