### PR TITLE
Corrected the wrong message while copying failed for README.md file

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -73,8 +73,8 @@ async function buildAll() {
   console.log('Building all packages...\n');
   await Promise.all(
     Object.entries(PACKAGES).map(([target, config]) =>
-      buildPackage(target, config)
-    )
+      buildPackage(target, config),
+    ),
   );
 }
 
@@ -85,11 +85,11 @@ async function buildPackage(target, config) {
       buildRollup(
         `recoil (${buildType})`,
         createInputOption(buildType, target, config.inputFile),
-        packageTypes.map((type) =>
-          createOutputOption(type, target, config.umdName)
-        )
-      )
-    )
+        packageTypes.map(type =>
+          createOutputOption(type, target, config.umdName),
+        ),
+      ),
+    ),
   );
 
   console.log('Copying files...');
@@ -104,7 +104,9 @@ async function buildPackage(target, config) {
     `${projectRootDir}/README${target === 'recoil' ? '' : '-' + target}.md`,
     `${BUILD_TARGET}/${target}/README.md`,
     fs.constants.COPYFILE_FICLONE,
-    createErrorHandler(`Failed to copy README-${target}.md`),
+    createErrorHandler(
+      `Failed to copy README${target === 'recoil' ? '' : '-' + target}.md`,
+    ),
   );
   fs.copyFile(
     `${projectRootDir}/CHANGELOG-${target}.md`,
@@ -150,7 +152,7 @@ async function buildRollup(name, inputOptions, outputOptionsList) {
     const bundle = await rollup(inputOptions);
 
     await Promise.all(
-      outputOptionsList.map((outputOptions) => bundle.write(outputOptions))
+      outputOptionsList.map(outputOptions => bundle.write(outputOptions)),
     );
   } catch (error) {
     createErrorHandler(`Build for package ${name} failed!`)(error);


### PR DESCRIPTION
Here, if the build script failed to copy the **README.md** file then it is showing **Failed to copy README-recoil.md**. But there is no file named as README-recoil.md into project's root directory, the message should be **Failed to copy README.md**. Rest of the changes into this file done by prettier.