### PR TITLE
fix: remove useless css property

### DIFF
--- a/packages-ext/recoil-devtools/src/pages/Popup/Tabs.js
+++ b/packages-ext/recoil-devtools/src/pages/Popup/Tabs.js
@@ -22,7 +22,6 @@ const styles = {
     height: 36,
     cursor: 'pointer',
     fontSize: '16px',
-    display: 'flex',
     alignItems: 'center',
     boxSizing: 'border-box',
     outline: 'none',


### PR DESCRIPTION
There is useless duplicated `display: 'flex',` property