### PR TITLE
reap test recoil_mutable_source

### DIFF
--- a/packages/recoil/core/Recoil_ReactMode.js
+++ b/packages/recoil/core/Recoil_ReactMode.js
@@ -15,23 +15,6 @@ const React = require('react');
 const gkx = require('recoil-shared/util/Recoil_gkx');
 const recoverableViolation = require('recoil-shared/util/Recoil_recoverableViolation');
 
-export opaque type MutableSource = {};
-
-const createMutableSource: <StoreState, Version>(
-  {current: StoreState},
-  () => Version,
-) => MutableSource =
-  // flowlint-next-line unclear-type:off
-  (React: any).createMutableSource ?? (React: any).unstable_createMutableSource;
-
-const useMutableSource: <StoreState, T>(
-  MutableSource,
-  () => T,
-  (StoreState, () => void) => () => void,
-) => T =
-  // flowlint-next-line unclear-type:off
-  (React: any).useMutableSource ?? (React: any).unstable_useMutableSource;
-
 // https://github.com/reactwg/react-18/discussions/86
 const useSyncExternalStore: <T>(
   subscribe: (() => void) => () => void,
@@ -73,11 +56,7 @@ function currentRendererSupportsUseSyncExternalStore(): boolean {
   return isUseSyncExternalStoreSupported;
 }
 
-type ReactMode =
-  | 'TRANSITION_SUPPORT'
-  | 'SYNC_EXTERNAL_STORE'
-  | 'MUTABLE_SOURCE'
-  | 'LEGACY';
+type ReactMode = 'TRANSITION_SUPPORT' | 'SYNC_EXTERNAL_STORE' | 'LEGACY';
 
 /**
  * mode: The React API and approach to use for syncing state with React
@@ -98,17 +77,6 @@ function reactMode(): {mode: ReactMode, early: boolean, concurrent: boolean} {
     return {mode: 'SYNC_EXTERNAL_STORE', early: true, concurrent: false};
   }
 
-  if (
-    gkx('recoil_mutable_source') &&
-    useMutableSource != null &&
-    typeof window !== 'undefined' &&
-    !window.$disableRecoilValueMutableSource_TEMP_HACK_DO_NOT_USE
-  ) {
-    return gkx('recoil_suppress_rerender_in_callback')
-      ? {mode: 'MUTABLE_SOURCE', early: true, concurrent: true}
-      : {mode: 'MUTABLE_SOURCE', early: false, concurrent: false};
-  }
-
   return gkx('recoil_suppress_rerender_in_callback')
     ? {mode: 'LEGACY', early: true, concurrent: false}
     : {mode: 'LEGACY', early: false, concurrent: false};
@@ -122,8 +90,6 @@ function isFastRefreshEnabled(): boolean {
 }
 
 module.exports = {
-  createMutableSource,
-  useMutableSource,
   useSyncExternalStore,
   currentRendererSupportsUseSyncExternalStore,
   reactMode,

--- a/packages/recoil/core/Recoil_RecoilValueInterface.js
+++ b/packages/recoil/core/Recoil_RecoilValueInterface.js
@@ -320,10 +320,7 @@ function subscribeToRecoilValue<T>(
   // Handle the case that, during the same tick that we are subscribing, an atom
   // has been updated by some effect handler. Otherwise we will miss the update.
   const mode = reactMode();
-  if (
-    mode.early &&
-    (mode.mode === 'LEGACY' || mode.mode === 'MUTABLE_SOURCE')
-  ) {
+  if (mode.early && mode.mode === 'LEGACY') {
     const nextTree = store.getState().nextTree;
     if (nextTree && nextTree.dirtyAtoms.has(key)) {
       callback(nextTree);

--- a/packages/recoil/core/Recoil_State.js
+++ b/packages/recoil/core/Recoil_State.js
@@ -57,9 +57,8 @@ export type TreeState = $ReadOnly<{
 // when atom values change and async requests resolve, and suspendedComponentResolvers
 // is updated when components are suspended.
 export type StoreState = {
-  // The "current" TreeState being either directly read from (legacy) or passed
-  // to useMutableSource (when in use). It is replaced with nextTree when
-  // a transaction is completed or async request finishes:
+  // The "current" TreeState being either directly read from (legacy). It is replaced
+  // with nextTree when a transaction is completed or async request finishes:
   currentTree: TreeState,
 
   // The TreeState that is written to when during the course of a transaction

--- a/packages/recoil/hooks/Recoil_useRecoilBridgeAcrossReactRoots.js
+++ b/packages/recoil/hooks/Recoil_useRecoilBridgeAcrossReactRoots.js
@@ -8,9 +8,9 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
-const {reactMode} = require('../core/Recoil_ReactMode');
 const {RecoilRoot, useStoreRef} = require('../core/Recoil_RecoilRoot');
 const React = require('react');
 const {useMemo} = require('react');
@@ -18,14 +18,6 @@ const {useMemo} = require('react');
 export type RecoilBridge = React.AbstractComponent<{children: React.Node}>;
 
 function useRecoilBridgeAcrossReactRoots(): RecoilBridge {
-  // The test fails when using useMutableSource(), but only if act() is used
-  // for the nested root.  So, this may only be a testing environment issue.
-  if (reactMode().mode === 'MUTABLE_SOURCE') {
-    // eslint-disable-next-line fb-www/no-console
-    console.warn(
-      'Warning: There are known issues using useRecoilBridgeAcrossReactRoots() in recoil_mutable_source rendering mode.  Please consider upgrading to recoil_sync_external_store mode.',
-    );
-  }
   const store = useStoreRef().current;
   return useMemo(() => {
     // eslint-disable-next-line no-shadow

--- a/packages/recoil/hooks/__tests__/Recoil_React-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_React-test.js
@@ -8,20 +8,20 @@
  * @format
  * @oncall recoil
  */
+
 'use strict';
 
 const {
   getRecoilTestFn,
 } = require('recoil-shared/__test_utils__/Recoil_TestingUtils');
 
-let React,
-  useState,
-  flushSync,
-  act,
-  atom,
-  renderElements,
-  useRecoilState,
-  reactMode;
+let React;
+let useState;
+let flushSync;
+let act;
+let atom;
+let renderElements;
+let useRecoilState;
 
 const testRecoil = getRecoilTestFn(() => {
   React = require('react');
@@ -34,18 +34,10 @@ const testRecoil = getRecoilTestFn(() => {
   ({
     renderElements,
   } = require('recoil-shared/__test_utils__/Recoil_TestingUtils'));
-  ({reactMode} = require('../../core/Recoil_ReactMode'));
   ({useRecoilState} = require('../Recoil_Hooks'));
 });
 
-testRecoil('Sync React and Recoil state changes', ({gks}) => {
-  if (
-    reactMode().mode === 'MUTABLE_SOURCE' &&
-    !gks.includes('recoil_suppress_rerender_in_callback')
-  ) {
-    return;
-  }
-
+testRecoil('Sync React and Recoil state changes', () => {
   const myAtom = atom({key: 'sync react recoil', default: 0});
 
   let setReact, setRecoil;
@@ -74,14 +66,7 @@ testRecoil('Sync React and Recoil state changes', ({gks}) => {
   expect(c.textContent).toBe('1 - 1');
 });
 
-testRecoil('React and Recoil state change ordering', ({gks}) => {
-  if (
-    reactMode().mode === 'MUTABLE_SOURCE' &&
-    !gks.includes('recoil_suppress_rerender_in_callback')
-  ) {
-    return;
-  }
-
+testRecoil('React and Recoil state change ordering', () => {
   const myAtom = atom({key: 'sync react recoil', default: 0});
 
   let setReact, setRecoil;

--- a/packages/recoil/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useRecoilBridgeAcrossReactRoots-test.js
@@ -24,7 +24,6 @@ let React,
   renderUnwrappedElements,
   useEffect,
   useRef,
-  reactMode,
   act,
   RecoilRoot,
   useRecoilStoreID,
@@ -37,7 +36,6 @@ const testRecoil = getRecoilTestFn(() => {
   ({useEffect, useRef} = React);
   ({act} = require('ReactTestUtils'));
 
-  ({reactMode} = require('../../core/Recoil_ReactMode'));
   ({
     renderElements,
     renderUnwrappedElements,
@@ -65,14 +63,7 @@ function NestedReactRoot({children}: $TEMPORARY$object<{children: Node}>) {
 
 testRecoil(
   'useRecoilBridgeAcrossReactRoots - create a context bridge',
-  async ({concurrentMode}) => {
-    // Test fails with useRecoilBridgeAcrossReactRoots() and useMutableSource().
-    // It only reproduces if act() is used in renderElements() for the nested
-    // root, so it may just be a testing environment issue.
-    if (concurrentMode && reactMode().mode === 'MUTABLE_SOURCE') {
-      return;
-    }
-
+  async () => {
     const myAtom = atom({
       key: 'useRecoilBridgeAcrossReactRoots - context bridge',
       default: 'DEFAULT',

--- a/packages/recoil/hooks/__tests__/Recoil_useTransition-test.js
+++ b/packages/recoil/hooks/__tests__/Recoil_useTransition-test.js
@@ -269,8 +269,7 @@ testRecoil('useRecoilValue()', async ({concurrentMode}) => {
   // Transition with both React and Recoil state
   act(startBothTransition);
   expect(c.textContent).toBe(
-    concurrentMode &&
-      (reactMode().concurrent || reactMode().mode === 'MUTABLE_SOURCE')
+    concurrentMode && reactMode().concurrent
       ? 'React:1 Recoil:2 [IN TRANSITION] | 1 1 2 RESOLVED'
       : 'React:2 Recoil:3 | LOADING',
   );

--- a/packages/recoil/recoil_values/__tests__/Recoil_selectorHooks-test.js
+++ b/packages/recoil/recoil_values/__tests__/Recoil_selectorHooks-test.js
@@ -1613,8 +1613,7 @@ describe('Async Selectors', () => {
       expect(commit).toHaveBeenCalledTimes(
         BASE_CALLS +
           3 +
-          ((reactMode().mode === 'LEGACY' ||
-            reactMode().mode === 'MUTABLE_SOURCE') &&
+          (reactMode().mode === 'LEGACY' &&
           !gks.includes('recoil_suppress_rerender_in_callback')
             ? 1
             : 0),

--- a/packages/shared/__test_utils__/Recoil_TestingUtils.js
+++ b/packages/shared/__test_utils__/Recoil_TestingUtils.js
@@ -417,14 +417,6 @@ const WWW_GKS_TO_TEST = QUICK_TEST
   : [
       // OSS for React <18:
       ['recoil_hamt_2020', 'recoil_suppress_rerender_in_callback'], // Also enables early rendering
-      // Current internal default:
-      ['recoil_hamt_2020', 'recoil_mutable_source'],
-      // Internal with suppress, early rendering, and useTransition() support:
-      [
-        'recoil_hamt_2020',
-        'recoil_mutable_source',
-        'recoil_suppress_rerender_in_callback', // Also enables early rendering
-      ],
       // OSS for React 18, test internally:
       [
         'recoil_hamt_2020',
@@ -447,14 +439,8 @@ const WWW_GKS_TO_TEST = QUICK_TEST
  * GK combinations to exclude in OSS, presumably because these combinations pass
  * in FB internally but not in OSS. Ideally this array would be empty.
  */
-const OSS_GK_COMBINATION_EXCLUSIONS = [
-  ['recoil_hamt_2020', 'recoil_mutable_source'],
-  [
-    'recoil_hamt_2020',
-    'recoil_mutable_source',
-    'recoil_suppress_rerender_in_callback',
-  ],
-];
+const OSS_GK_COMBINATION_EXCLUSIONS: $ReadOnlyArray<$ReadOnlyArray<string>> =
+  [];
 
 // eslint-disable-next-line no-unused-vars
 const OSS_GKS_TO_TEST = WWW_GKS_TO_TEST.filter(


### PR DESCRIPTION
Summary:
Reaps the GK to use `useMutableSource` in Recoil. While the GK is at 100%, it's never hit as we hit the check for `recoil_sync_external_store` before and that's also 100%.

`useMutableSource` is deprecated in React and this is one of the last callers.

Differential Revision: D47023855

