### PR TITLE
fix: atomRegistry deletion overlaps in the cleanup stage

### DIFF
--- a/packages/recoil-sync/RecoilSync_URL.js
+++ b/packages/recoil-sync/RecoilSync_URL.js
@@ -39,7 +39,10 @@ type AtomRegistration = {
   itemKeys: Set<ItemKey>,
 };
 
-const registries: Map<StoreKey, Map<NodeKey, AtomRegistration>> = new Map();
+const registries: Map<
+  StoreKey,
+  Map<{nodeKey: NodeKey}, AtomRegistration>,
+> = new Map();
 
 const itemStateChecker = writableDict(mixed());
 const refineState = assertion(itemStateChecker);
@@ -285,7 +288,8 @@ function urlSyncEffect<T>({
     if (atomRegistry == null) {
       throw err('Error with atom registration');
     }
-    atomRegistry.set(effectArgs.node.key, {
+    const key = {nodeKey: effectArgs.node.key};
+    atomRegistry.set(key, {
       history,
       itemKeys: new Set([options.itemKey ?? effectArgs.node.key]),
     });
@@ -295,7 +299,7 @@ function urlSyncEffect<T>({
 
     // Cleanup atom option registration
     return () => {
-      atomRegistry.delete(effectArgs.node.key);
+      atomRegistry.delete(key);
       cleanup?.();
     };
   };


### PR DESCRIPTION
I found an issue particularly noticeable in strict mode: initializing two effects followed by a cleanup operation erroneously removes cached data for both effects. 
This issue becomes particularly apparent in environments combining strict mode with Next.js. To illustrate, consider the following sequence of events (real sequence on my project):
```
set key:  testState       1
delete key:  testState    0
set key:  testState       1
set key:  testState       2
delete key:  testState    0 // Issue: should be 1 because only one deletion occurred
```
The root cause of this issue is the reuse of the same key for multiple 'set' operations, leading to incorrect 'delete' behavior. A single cleanup call affects all instances with the same key rather than the specific instance intended.

To resolve this, we need to use a distinct key for each 'set' operation, and the corresponding 'delete' operation targets this specific key. This approach ensures accurate tracking and removal of individual effects.

Additionally, this fix also fixes [this](https://github.com/facebookexperimental/Recoil/issues/1994) issue. The reason for that problem was the deletion of the "second key" that had been deleted with the previous cleaning.