### PR TITLE
Add react-dom to peer dependencies

### DIFF
--- a/packages/recoil/package-for-release.json
+++ b/packages/recoil/package-for-release.json
@@ -14,7 +14,8 @@
     "hamt_plus": "1.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.13.1"
+    "react": ">=16.13.1",
+    "react-dom": ">=16.13.0"
   },
   "peerDependenciesMeta": {
     "react-dom": {


### PR DESCRIPTION
react-dom is an optional peer dependency which means it should be listed in peerDependencies.

An example of an issue it can cause is this error when used with Module Federation:

> No required version specified and unable to automatically determine one. Unable to find required version for "react-dom" in description file (/Users/be5806/workspace/wccj/channel-devkit-playground/channels/channel-default/node_modules/recoil/package.json). It need to be in dependencies, devDependencies or peerDependencies.

react-native should also be added but I didn't know what the version requirement is.
