### PR TITLE
feat: removing the word 'experimental' from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Recoil &middot; [![NPM Version](https://img.shields.io/npm/v/recoil)](https://www.npmjs.com/package/recoil) [![Node.js CI](https://github.com/facebookexperimental/Recoil/workflows/Node.js%20CI/badge.svg)](https://github.com/facebookexperimental/Recoil/actions) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookexperimental/Recoil/blob/main/LICENSE) [![Follow on Twitter](https://img.shields.io/twitter/follow/recoiljs?label=Follow%20Recoil&style=social)](https://twitter.com/recoiljs)
 
-Recoil is an experimental state management framework for React.
+Recoil is a state management framework for React.
 
 Website: https://recoiljs.org
 


### PR DESCRIPTION
Given Recoil is 4 years old now, I think it's safe to say it is no longer experimental.