### PR TITLE
[BUGFIX] do not throw on deepFreezeValue with objects with properties that are JS Proxy instances

### DIFF
--- a/packages/shared/util/Recoil_deepFreezeValue.js
+++ b/packages/shared/util/Recoil_deepFreezeValue.js
@@ -83,7 +83,17 @@ function deepFreezeValue(value: mixed) {
     if (Object.prototype.hasOwnProperty.call(value, key)) {
       const prop = value[key];
       // Prevent infinite recurssion for circular references.
-      if (typeof prop === 'object' && prop != null && !Object.isFrozen(prop)) {
+      const objectNotFrozen = typeof prop === 'object' && prop != null && !Object.isFrozen(prop);
+
+      // Don't try to freeze proxy objects
+      // 1. Object.freeze() on a proxy proxy with not frozen target will throw
+      // 2. Freeze of the proxy target can break proxy handler behavior
+      // 3. So with 1 and 2, better to leave proxy frozen state up to consumer
+      const isObjectAProxy = prop !== null 
+        && typeof prop === 'object' 
+        && Object.getPrototypeOf(prop) !== Object.getPrototypeOf({});
+
+      if (objectNotFrozen && !isObjectAProxy) {
         deepFreezeValue(prop);
       }
     }

--- a/packages/shared/util/__tests__/Recoil_deepFreezeValue-test.js
+++ b/packages/shared/util/__tests__/Recoil_deepFreezeValue-test.js
@@ -43,6 +43,14 @@ describe('deepFreezeValue', () => {
     ).not.toThrow();
   });
 
+  test('don\'t freeze Proxy objects', () => {
+    const obj = {test: new Proxy({}, {})};
+    expect(() => deepFreezeValue(obj)).not.toThrow();
+    expect(() => deepFreezeValue(obj.test)).not.toThrow();
+    expect(Object.isFrozen(obj)).toBe(true);
+    expect(Object.isFrozen(obj.test)).toBe(false);
+  });
+
   test('check no error: object with Window property', () => {
     if (typeof window === 'undefined') {
       return;


### PR DESCRIPTION
Together with https://github.com/it-mukaseev we met an issue when trying to use recoil with pyodie.

pyodide is a library for running scripts in a browser, that how it is being loaded:

```
// creating atom
import {atom} from 'recoil';
export const pyodideAtom = atom<any>({
    key: "pyodideAtom",
    default: undefined,
});

// loading
import { loadPyodide, PyodideInterface } from "pyodide";
import { pyodideAtom } from "./appAtoms"

function usePyodide() {
    const [pyodide, setPyodide] = useRecoilState(pyodideAtom);
    useEffect(() => {
        const config = {} // pyodide config
        loadPyodide(config)
           .then((pyodideResult) => {
               // pyodideResult contains a property globals, that is not allowed to be frozen
               // e.g. Object.freeze(pyodideResult.globals) will throw an error
               // so the next line will throw an error, because `deepFreezeValue` will be called
               setPyodide(pyodideResult);
            });
    }, []);
}
```

the `loadPyodide` returns instance of pyodide, and that instance contains a property `globals` which is a JS Proxy, which is can not frozen. 

During debugging we have found that the root issue is `deepFreezeValue` function, that calls `Object.freeze` on the proxy with not frozen target.

Proxy with not frozen target can not be frozen, so one solution is to froze the target, but that can break the `handler` of the `Proxy` behavior, so that is a bad decision. And calling the freeze on proxy with not frozen is not possible, so the only solution is to ignore proxy objects and leave up to the consumers of the package.- 