### PR TITLE
docs: replace JSON.serialize() with JSON.stringify() in atom-effects guide

### DIFF
--- a/docs/docs/guides/atom-effects.md
+++ b/docs/docs/guides/atom-effects.md
@@ -139,7 +139,7 @@ const history: Array<{
 const historyEffect = name => ({setSelf, onSet}) => {
   onSet((newValue, oldValue) => {
     history.push({
-      label: `${name}: ${JSON.serialize(oldValue)} -> ${JSON.serialize(newValue)}`,
+      label: `${name}: ${JSON.stringify(oldValue)} -> ${JSON.stringify(newValue)}`,
       undo: () => {
         setSelf(oldValue);
       },

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/guides/atom-effects.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/guides/atom-effects.md
@@ -133,7 +133,7 @@ const history: Array<{
 const historyEffect = name => ({setSelf, onSet}) => {
   onSet((newValue, oldValue) => {
     history.push({
-      label: `${name}: ${JSON.serialize(oldValue)} -> ${JSON.serialize(newValue)}`,
+      label: `${name}: ${JSON.stringify(oldValue)} -> ${JSON.stringify(newValue)}`,
       undo: () => {
         setSelf(oldValue);
       },

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/atom-effects.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/atom-effects.md
@@ -134,7 +134,7 @@ const history: Array<{
 const historyEffect = name => ({setSelf, onSet}) => {
   onSet((newValue, oldValue) => {
     history.push({
-      label: `${name}: ${JSON.serialize(oldValue)} -> ${JSON.serialize(newValue)}`,
+      label: `${name}: ${JSON.stringify(oldValue)} -> ${JSON.stringify(newValue)}`,
       undo: () => {
         setSelf(oldValue);
       },

--- a/docs/i18n/zh-hans/docusaurus-plugin-content-docs/current/guides/atom-effects.md
+++ b/docs/i18n/zh-hans/docusaurus-plugin-content-docs/current/guides/atom-effects.md
@@ -133,7 +133,7 @@ const history: Array<{
 const historyEffect = name => ({setSelf, onSet}) => {
   onSet((newValue, oldValue) => {
     history.push({
-      label: `${name}: ${JSON.serialize(oldValue)} -> ${JSON.serialize(newValue)}`,
+      label: `${name}: ${JSON.stringify(oldValue)} -> ${JSON.stringify(newValue)}`,
       undo: () => {
         setSelf(oldValue);
       },


### PR DESCRIPTION
While studying with Recoil Docs, I found an error related to the JSON format.
Since JavaScript does not have a JSON.serialize() method, I suggest modifying it with JSON.stringify().