### PR TITLE
[docs/korean] Update RecoilRoot docs more natively

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/core/RecoilRoot.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/core/RecoilRoot.md
@@ -3,22 +3,23 @@ title: <RecoilRoot ...props />
 sidebar_label: <RecoilRoot />
 ---
 
-값들을 갖는 원자 컨텍스트를 제공한다. Recoil의 hooks를 사용하는 모든 구성 요소의 조상이어야 한다. 여러개의 루트가 같이 존재할 수 있다. 원자는 각각의 루트 안에서 구별되는 값들을 가질 것 이다. 만약 그것들이 중첩되어 있다면, 가장 안쪽의 루트는 완벽하게 바깥쪽의 루트들을 가릴 것이다.
+값을 가진 atom 컨텍스트를 제공합니다. Recoil의 hooks을 사용하는 모든 컴포넌트의 상위 단계(ancestor)로 설정해야 합니다.
 
 ---
 
 **속성**:
 
 - `initializeState?`: `(MutableSnapshot => void)`
-  - [`MutableSnapshot`](/docs/api-reference/core/Snapshot#transforming-snapshots)을 사용하여 `<RecoilRoot>`의 원자 상태를 초기화하는 옵션 함수. 이것은 초기 렌더링에 대한 상태를 설정하며 이후 상태 변경이나 비동기적인 초기화를 위한 것이 아니다. 비동기 상태 변경에는 [`useSetRecoilState()`](/docs/api-reference/core/useSetRecoilState) 또는 [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback)과 같은 Hooks를 사용하십시오.
+  - [`MutableSnapshot`](/docs/api-reference/core/Snapshot#transforming-snapshots)을 사용하여 `<RecoilRoot>`의 atom 상태를 초기화하는 optional 함수. 이는 초기 렌더링 시 상태를 설정하는 데에 사용되며, 이후 상태 변경이나 비동기적인 초기화를 위한 용도가 아닙니다. 비동기 상태 변경에는 [`useSetRecoilState()`](/docs/api-reference/core/useSetRecoilState) 또는 [`useRecoilCallback()`](/docs/api-reference/core/useRecoilCallback)과 같은 Hooks를 사용하세요.
+  [Atom Effects](/docs/guides/atom-effects)는 동적 atom을 더 쉽게 초기화하며 초기화 로직을 atom 정의와 함께 배치하는 데 사용할 수 있습니다. Atom Effect 초기화는 `initializeState` 보다 우선적으로 처리됩니다.
 - `override?`: `boolean`
-  - 기본값은 `true`로 설정되어 있으며, 이 속성은 `<RecoilRoot>`가 다른 `<RecoilRoot>`와 중첩(nested)된 경우에만 상관이 있다. 만약 `override`가 `true`라면, 해당 루트는 새로운 Recoil 범위(scope)를 생성할 것이다. 만약 `override`가 `false`라면, 해당 `<RecoilRoot>`는 단지 자식 렌더링 외에 다른 기능을 수행하지 않기 때문에, 이 루트의 자식들은 가장 가까운 조상 RecoilRoot의 Recoil 값에 액세스할 것이다.
+  - 기본값은 `true`입니다. 이는 `<RecoilRoot>`가 다른 `<RecoilRoot>`와 중첩(nested)된 경우에만 사용됩니다. `override`가 `true`일 경우, 해당 루트는 새로운 Recoil 범위(scope)를 생성합니다. `override`가 `false`일 경우, 해당 `<RecoilRoot>`는 자식 요소(children)를 렌더링하는 것 외에 다른 동작을 수행하지 않습니다. 따라서 이 루트의 자식 요소는 가장 가까운 상위 RecoilRoot의 Recoil 값에 접근합니다.
 
 ### 여러 개의 `<RecoilRoot>`를 사용하는 경우
 
-`<RecoilRoot>`는 여러 개가 같이 존재할 수 있고, 각각이 독립적인 atom 상태의 providers/store가 된다. atom은 각 루트에 따라 다른 값을 갖게 되는 것이다. 그리고 이러한 동작은 `override`를 `false`로 지정하지 않는 한, 루트가 다른 루트에 중첩될 때 (내부 루트가 외부 루트를 가릴 경우) 동일하게 발생된다. ("속성" 참조)
+`<RecoilRoot>`는 여러 개가 같이 존재할 수 있고, 각각이 독립적인 atom 상태의 providers/store가 됩니다. atom은 각 루트에 따라 다른 값을 갖게 됩니다. 그리고 이 동작은 `override`를 `false`로 지정하지 않는 한, 루트가 다른 루트 안에 중첩되는 경우(내부 루트가 외부 루트를 가릴 경우) 동일하게 유지됩니다. ("속성" 참조)
 
-selector 캐시같은 캐시들은 루트 사이에 공유될 수 있다. Selector 평가는 캐싱이나 로깅을 제외하고는 멱등적(연산을 여러번 적용해도 결과가 달라지지 않음)이어야 하므로 문제가 되지는 않지만, observable하게 되거나, 루트 전체에 걸쳐 중복 쿼리가 캐시될 수도 있다.
+Selector 캐시와 같은 캐시는 루트 사이에서 공유될 수 있다는 점을 유의하세요. Selector 평가는 캐싱이나 로깅을 제외하고는 멱등적(연산을 여러번 적용해도 결과가 달라지지 않음)이어야 하므로 일반적으로 문제가 되지 않습니다. 그러나 이 동작은 관찰될 수 있으며(observable), 루트 간에 중복된 쿼리가 캐시되는 상황을 초래할 수 있습니다. 캐시는 [`useRecoilRefresher_UNSTABLE()`](/docs/api-reference/core/useRecoilRefresher)를 사용하여 지울 수 있습니다.
 
 ### 예시
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/core/RecoilRoot.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/core/RecoilRoot.md
@@ -14,9 +14,9 @@ sidebar_label: <RecoilRoot />
 - `override?`: `boolean`
   - 기본값은 `true`로 설정되어 있으며, 이 속성은 `<RecoilRoot>`가 다른 `<RecoilRoot>`와 중첩(nested)된 경우에만 상관이 있다. 만약 `override`가 `true`라면, 해당 루트는 새로운 Recoil 범위(scope)를 생성할 것이다. 만약 `override`가 `false`라면, 해당 `<RecoilRoot>`는 단지 자식 렌더링 외에 다른 기능을 수행하지 않기 때문에, 이 루트의 자식들은 가장 가까운 조상 RecoilRoot의 Recoil 값에 액세스할 것이다.
 
-### 여러 `<RecoilRoot>`를 사용하는 경우
+### 여러 개의 `<RecoilRoot>`를 사용하는 경우
 
-`<RecoilRoot>`는 여러개가 같이 존재할 수 있고, 각각이 독립적인 atom 상태의 providers/store가 된다. atom은 각 루트에 따라 다른 값을 갖게 되는 것이다. 그리고 이러한 동작은 `override`를 `false`로 지정하지 않는 한, 루트가 다른 루트에 중첩될 때 (내부 루트가 외부 루트를 가릴 경우) 동일하게 발생된다. ("속성" 참조)
+`<RecoilRoot>`는 여러 개가 같이 존재할 수 있고, 각각이 독립적인 atom 상태의 providers/store가 된다. atom은 각 루트에 따라 다른 값을 갖게 되는 것이다. 그리고 이러한 동작은 `override`를 `false`로 지정하지 않는 한, 루트가 다른 루트에 중첩될 때 (내부 루트가 외부 루트를 가릴 경우) 동일하게 발생된다. ("속성" 참조)
 
 selector 캐시같은 캐시들은 루트 사이에 공유될 수 있다. Selector 평가는 캐싱이나 로깅을 제외하고는 멱등적(연산을 여러번 적용해도 결과가 달라지지 않음)이어야 하므로 문제가 되지는 않지만, observable하게 되거나, 루트 전체에 걸쳐 중복 쿼리가 캐시될 수도 있다.
 


### PR DESCRIPTION
Hi, I'm a developer from Korea.
While reading the RecoilRoot documentation, I noticed some sentences in the Korean translation that, while not incorrect, feel slightly unnatural or too literal. These translations can make it harder for developers to intuitively understand the content.

I believe this could lead to confusion for other Korean developers using Recoil.
To address this, I’ve tried to rephrase some sentences to make them sound more natural and easier to understand.

Below, I’ll explain the specific points why the current translation feels unnatural and how I’ve revised them.
If you find my suggestions helpful, I’d be happy to apply similar corrections to other parts of the documentation as well.

# Explanation of Changes
1. **Plural Forms**
    The use of plural forms differs slightly between Korean and English.
    In Korean, plural markers are typically used only in specific situations where emphasizing the plurality is necessary.

    For example, in English, 'I like apples' clearly shows that 'apples' is plural.
    But in Korean, we usually don’t add a plural marker in this context. Instead, we would just say '나는 사과를 좋아해,' using the singular form of 'apple.' From the context, we naturally understand whether it means one apple or many apples.

    Therefore, translating "values" in "Provides the context in which atoms have values" as "값들" (the plural form of "value" in Korean) feels unnatural. I adjusted such instances to better align with natural Korean usage.

2. Overtranslation
    Some commonly used technical terms, such as "atom" and "component", were translated into Korean as "원자" or "구성요소". 

    While technically correct, these translations can make it harder for Korean developers to understand, as they are less familiar with these Korean equivalents.

    To address this, I replaced these overly translated terms with their original English counterparts, which are more commonly used and widely understood in the Korean developer community.

3. Sentence Endings
    I modified sentence endings to be more polite and suitable for a guide document.

    While some Recoil documentation already uses polite endings, there are still parts where the style feels rigid or overly literal. Ensuring that sentence endings are consistent and appropriate for the tone of the document makes it more comfortable and easier to read.

Additionally, I noticed that some sentences from the original documentation were missing in the Korean version, so I translated and added them.
I also made corrections to the spacing between words.

# Examples of Change
- **original sentence**
    : **값들**을 갖는 **원자** 컨텍스트를 제공**한다**. Recoil의 hooks를 사용하는 모든 **구성 요소의 조상**이어야 **한다**.
- **changed sentence**
    : **값**을 가진 **atom** 컨텍스트를 제공**합니다**. Recoil의 hooks을 사용하는 모든 **컴포넌트의 상위 단계**(ancestor)로 설정해야 **합니다**. 

> Key changes:  
> - "값들" → "값" (Avoid overuse of plural forms in Korean)  
> - "원자" → "atom" (Preserve technical term for better understanding)  
> - Sentence endings adjusted to polite style ("한다" → "합니다")

---

I hope this translation helps Korean developers use Recoil more easily and comfortably.
I'm happy to contribute to improving the documentation for the community, and I’m open to any feedback or suggestions!